### PR TITLE
[ux] Polish: Standardize empty states in Templates and Calendar Settings

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/CalendarSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/CalendarSettingsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.tajemniktv.tajsos.ui.MainViewModel
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.theme.TactileTheme
 import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.*
@@ -63,9 +64,7 @@ fun CalendarSettingsScreen(viewModel: MainViewModel)
 
         if (providers.isEmpty())
         {
-            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text(stringResource(Res.string.cal_settings_empty), color = TactileTheme.Muted)
-            }
+            EmptyState(message = stringResource(Res.string.cal_settings_empty))
         } else
         {
             LazyColumn(verticalArrangement = Arrangement.spacedBy(TactileTheme.SpacingSm)) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/TemplatesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/TemplatesScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.tajemniktv.tajsos.ui.MainViewModel
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.components.layout.LocalHeaderActions
 import com.tajemniktv.tajsos.ui.theme.TactileTheme
 import org.jetbrains.compose.resources.stringResource
@@ -61,12 +62,7 @@ fun TemplatesScreen(
         ) {
             if (templates.isEmpty())
             {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(stringResource(Res.string.templates_empty), color = TactileTheme.Muted)
-                }
+                EmptyState(message = stringResource(Res.string.templates_empty))
             } else
             {
                 LazyColumn(


### PR DESCRIPTION
This PR addresses inconsistent and weak empty states in the application by standardizing them.

- **What user-facing friction was improved:** The empty state views in the Templates and Calendar Settings screens were previously just plain text in a box. This felt inconsistent compared to screens like Inbox or Search which use the more polished `EmptyState` component with a pulsing icon.
- **Where the change appears:** `TemplatesScreen` when no templates exist, and `CalendarSettingsScreen` when no calendar providers are configured.
- **Why the change matches existing UX patterns:** It reuses the exact same `com.tajemniktv.tajsos.ui.components.common.EmptyState` composable that is already the established pattern in other list screens within the app.
- **How it was validated:** Ran `./gradlew test` and `./gradlew :composeApp:compileKotlinJvm` to verify everything compiles successfully and no tests were broken by this pure UI presentation change.

---
*PR created automatically by Jules for task [4883998349768699753](https://jules.google.com/task/4883998349768699753) started by @tajemniktv*