### PR TITLE
[reliability] Guard: Prevent silent NaN propagation when calculating average load

### DIFF
--- a/androidApp/src/main/res/drawable/ic_launcher_logo_background.xml
+++ b/androidApp/src/main/res/drawable/ic_launcher_logo_background.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) Grzegorz Kaczmarski (TajemnikTV) 2026. All rights reserved.
   -->
-
-<<!--
-  ~ Copyright (c) Grzegorz Kaczmarski (TajemnikTV) 2026. All rights reserved.
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -518,7 +518,12 @@ fun calculateAreaHealthSnapshot(
     val disappearingAreaIds =
         computed.filter { it.isDisappearing }.mapTo(mutableSetOf()) { it.areaId }
 
-    val avgLoad = computed.map { it.stressLoad }.average()
+    val avgLoad =
+        if (computed.isNotEmpty()) {
+            computed.map { it.stressLoad }.average()
+        } else {
+            0.0
+        }
     val variance =
         if (computed.size > 1) {
             computed.map { (it.stressLoad - avgLoad) * (it.stressLoad - avgLoad) }.average()


### PR DESCRIPTION
- **What failure mode was addressed:** Calculating `.average()` on an empty Kotlin array returns `Double.NaN`, which can silently propagate to subsequent calculations (like load variance) when not guarded.
- **What changed:** Added an `if (computed.isNotEmpty())` guard check around the `avgLoad` calculation in `MainSnapshotCalculators.kt`. Also fixed an accidental malformed XML comment `<<!--` in `ic_launcher_logo_background.xml` that caused local test failures for `:androidApp:parseDebugLocalResources`.
- **Why the fix is low-risk:** This change isolates the fix strictly to a targeted average calculation and sets a safe `0.0` default.
- **How it was validated:** Verified logic by running the compilation `./gradlew :composeApp:compileKotlinJvm` and `./gradlew test` (after fixing the broken XML resource comment).

---
*PR created automatically by Jules for task [304409590526776496](https://jules.google.com/task/304409590526776496) started by @tajemniktv*