### PR TITLE
🧪 [test] test: cover invalid date values in IcsCalendarProvider

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProviderTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProviderTest.kt
@@ -207,4 +207,35 @@ class IcsCalendarProviderTest {
             // The parser should skip events with malformed dates instead of throwing StringIndexOutOfBoundsException
             assertEquals(0, events.size)
         }
+
+    @Test
+    fun `test skip invalid date values`(): TestResult =
+        runTest {
+            val ics =
+                """
+                BEGIN:VCALENDAR
+                BEGIN:VEVENT
+                UID:invalid-month
+                SUMMARY:Invalid Month
+                DTSTART;VALUE=DATE:20231301
+                END:VEVENT
+                BEGIN:VEVENT
+                UID:non-numeric
+                SUMMARY:Non Numeric
+                DTSTART;VALUE=DATE:202310XX
+                END:VEVENT
+                BEGIN:VEVENT
+                UID:invalid-iso
+                SUMMARY:Invalid ISO
+                DTSTART:20231024T256060Z
+                END:VEVENT
+                END:VCALENDAR
+                """.trimIndent()
+
+            val provider = createProviderWithIcs(ics)
+            val events = provider.fetchEvents(testProviderEntity, defaultFrom, defaultTo)
+
+            // The parser should catch exceptions during date conversion and skip those events
+            assertEquals(0, events.size)
+        }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing error path tests for invalid dates in `IcsEventBuilder`.
📊 **Coverage:** What scenarios are now tested:
- Invalid month/day in all-day date (e.g., `20231301`).
- Non-numeric characters in all-day date (e.g., `202310XX`).
- Invalid time components in ISO date (e.g., `20231024T256060Z`).
✨ **Result:** Improved test coverage and reliability of the ICS calendar parser by ensuring malformed date values don't cause crashes and are gracefully skipped.

---
*PR created automatically by Jules for task [5252151114681214926](https://jules.google.com/task/5252151114681214926) started by @tajemniktv*