### PR TITLE
[ux] Polish: Disable save button in CaptureSheet when input is empty

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
@@ -549,6 +549,7 @@ fun CaptureSheet(
                         }
                     }
                 },
+                enabled = text.isNotBlank(),
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(TactileTheme.RadiusMd),
             ) {


### PR DESCRIPTION
- What user-facing friction was improved: The primary save button in the `CaptureSheet` appeared active and clickable even when the text input was empty. This led to unresponsive interactions and violated the common UX pattern where a button should only appear active if the required input is satisfied.
- Where the change appears: `CaptureSheet` (bottom sheet dialog used for quick capturing nodes, tasks, notes, etc.).
- Why the change matches existing UX patterns: Other parts of the app (such as the quick capture button in `InboxMainBlock`) correctly disable the submit action when the input field is blank.
- How it was validated: Ran local Kotlin JVM compilation (`./gradlew :composeApp:compileKotlinJvm`) and ran the test suite (`./gradlew test`). Verified that the `enabled = text.isNotBlank()` property works natively with Material 3 Button components for disabled styling.

---
*PR created automatically by Jules for task [1484034980550252083](https://jules.google.com/task/1484034980550252083) started by @tajemniktv*