### PR TITLE
[security] Fix: Remove test crash button from SettingsScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/SettingsScreen.kt
@@ -25,12 +25,11 @@ import tajsos.composeapp.generated.resources.*
 /**
  * Renders the app settings screen with security, calendar, templates, data management, and a test crash action.
  *
- * The security section shows a biometric toggle that reflects and updates the ViewModel biometric state and is disabled when biometric hardware is unavailable. The data export action calls the ViewModel to obtain exported JSON and displays a snackbar indicating the exported byte length. The force crash button throws a RuntimeException when tapped.
+ * The security section shows a biometric toggle that reflects and updates the ViewModel biometric state and is disabled when biometric hardware is unavailable. The data export action calls the ViewModel to obtain exported JSON and displays a snackbar indicating the exported byte length.
  *
  * @param viewModel Provides observable biometric state and actions for toggling biometric protection and exporting data.
  * @param onNavigateToCalendarSettings Callback invoked when the user requests calendar integration settings.
  * @param onNavigateToTemplates Callback invoked when the user requests template management.
- * @throws RuntimeException Thrown when the "force crash" button is pressed.
  */
 @Composable
 fun SettingsScreen(
@@ -283,14 +282,6 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(TactileTheme.SpacingLg))
 
-            Button(
-                onClick = { throw RuntimeException("Test Crash") },
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(TactileTheme.RadiusMd),
-                colors = ButtonDefaults.buttonColors(containerColor = TactileTheme.Error),
-            ) {
-                Text(stringResource(Res.string.settings_force_crash))
-            }
         }
     }
 }


### PR DESCRIPTION
🎯 What: Removes the "Force Crash" button from the `SettingsScreen` composable which threw a `RuntimeException` on tap.
⚠️ Risk: A direct button that forces an application crash presents a local Denial of Service (DoS) vulnerability and could potentially expose sensitive application state or stack trace details when unhandled.
🛡️ Solution: Removed the UI Button component and updated the KDoc string to accurately reflect the removal.

Why this is low-risk:
This is a purely subtractive change that removes a debugging/test element from the production settings view without affecting any core application features.

Validation:
- `./gradlew test` and `./gradlew :composeApp:compileKotlinJvm` run locally.

---
*PR created automatically by Jules for task [11097231285883959682](https://jules.google.com/task/11097231285883959682) started by @tajemniktv*