### PR TITLE
[test] test: Add edge-case coverage for AppRepository.decideOn

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/AppRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/AppRepositoryTest.kt
@@ -279,6 +279,82 @@ class AppRepositoryTest {
             assertTrue(updatedOption2.isSelected)
         }
 
+    @Test
+    fun testDecideOn_withNullOption_updatesNodeButNoOptionsSelected(): TestResult =
+        runTest {
+            val nodeId =
+                fakeNodeDao.insertNode(
+                    NodeEntity(
+                        type = "decision",
+                        title = "What framework?",
+                        decisionStatus = "pending",
+                    ),
+                )
+
+            val option1Id =
+                repository.insertDecisionOption(
+                    DecisionOptionEntity(decisionNodeId = nodeId, title = "Option A", isSelected = true),
+                )
+            val option2Id =
+                repository.insertDecisionOption(
+                    DecisionOptionEntity(decisionNodeId = nodeId, title = "Option B"),
+                )
+
+            repository.decideOn(nodeId, "Decided not to choose", null)
+
+            val updatedNode = repository.getNodeById(nodeId)
+            assertNotNull(updatedNode)
+            assertEquals("decided", updatedNode.decisionStatus)
+            assertEquals("Decided not to choose", updatedNode.decisionOutcome)
+            assertEquals("done", updatedNode.status)
+
+            val options = repository.getOptionsForDecision(nodeId).first()
+            assertEquals(2, options.size)
+
+            val updatedOption1 = options.find { it.id == option1Id }
+            val updatedOption2 = options.find { it.id == option2Id }
+
+            assertNotNull(updatedOption1)
+            assertNotNull(updatedOption2)
+            assertFalse(updatedOption1.isSelected)
+            assertFalse(updatedOption2.isSelected)
+        }
+
+    @Test
+    fun testDecideOn_deselectsPreviousOption(): TestResult =
+        runTest {
+            val nodeId =
+                fakeNodeDao.insertNode(
+                    NodeEntity(
+                        type = "decision",
+                        title = "What framework?",
+                        decisionStatus = "pending",
+                    ),
+                )
+
+            val option1Id =
+                repository.insertDecisionOption(
+                    DecisionOptionEntity(decisionNodeId = nodeId, title = "Option A", isSelected = true),
+                )
+            val option2Id =
+                repository.insertDecisionOption(
+                    DecisionOptionEntity(decisionNodeId = nodeId, title = "Option B"),
+                )
+
+            repository.decideOn(nodeId, "Changed to B", option2Id)
+
+            val options = repository.getOptionsForDecision(nodeId).first()
+            assertEquals(2, options.size)
+
+            val updatedOption1 = options.find { it.id == option1Id }
+            val updatedOption2 = options.find { it.id == option2Id }
+
+            assertNotNull(updatedOption1)
+            assertNotNull(updatedOption2)
+            assertFalse(updatedOption1.isSelected)
+            assertTrue(updatedOption2.isSelected)
+        }
+
     private suspend fun assertDerivedRelation(
         originalId: Long,
         derivedId: Long,


### PR DESCRIPTION
- **What behavior is now protected**: The `decideOn` method in `AppRepository` clears previously selected options when a new option is chosen, and it handles `null` option IDs without crashing or selecting random options.
- **Why this area needed stronger coverage**: The method contains explicit branching logic to unselect previously chosen options `else if (option.isSelected) { decisionDao.updateDecisionOption(option.copy(isSelected = false)) }` but this logic, along with the `null` safety branch, was completely untested. Adding these tests prevents future regressions if the persistence or mapping logic is refactored.
- **Whether production code changed**: No production code was modified.
- **How it was validated**: Validated locally by running `./gradlew :shared:jvmTest --tests "com.tajemniktv.tajsos.data.AppRepositoryTest"` and `./gradlew :composeApp:compileKotlinJvm`.

---
*PR created automatically by Jules for task [9809309910446824903](https://jules.google.com/task/9809309910446824903) started by @tajemniktv*