### PR TITLE
[docs] docs: Document decision repository queries

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -785,11 +785,23 @@ class AppRepository(
     suspend fun insertProtocolHistory(history: ProtocolHistoryEntity) = protocolDao.insertProtocolHistory(history)
 
     // Decisions
+
+    /**
+     * Retrieves a reactive stream of decision nodes filtered by their specific decision status.
+     *
+     * @param status The decision status to filter by (e.g., 'decided', 'pending').
+     * @return A Flow emitting a list of matching decision [NodeEntity] objects.
+     */
     fun getDecisionsByStatus(status: String): Flow<List<NodeEntity>> =
         nodeDao.getNodesByType("decision").map { nodes ->
             nodes.filter { it.decisionStatus == status }
         }
 
+    /**
+     * Observes decision nodes that have not yet been triaged or processed from the inbox.
+     *
+     * @return A Flow emitting a list of decision [NodeEntity] objects with an active inbox state.
+     */
     fun getDecisionInbox(): Flow<List<NodeEntity>> =
         nodeDao.getNodesByType("decision").map { nodes ->
             nodes.filter { it.inboxState }


### PR DESCRIPTION
What was unclear before:
The domain-specific parameters and expected node state filters (like `status` string match and `inboxState` behavior) on decision-specific queries inside `AppRepository` lacked inline documentation, forcing developers to cross-reference DAO implementations or viewmodels.

What was documented:
Added KDoc to `getDecisionsByStatus` and `getDecisionInbox` explaining their intent, filtered fields, parameters, and returned Flow shapes.

Why this improves maintainability or onboarding:
Explicitly documenting the decision-specific filtering (e.g., that the inbox query returns nodes awaiting triage) reduces onboarding friction when working on the Decision features and clarifies the distinction between triaged and pending decisions at the repository boundary.

How it was validated against the code:
Verified that the documentation additions accurately match the internal Room DAO filter conditions (`node.decisionStatus == status` and `node.inboxState`). Validated with `./gradlew :composeApp:compileKotlinJvm` and JVM tests to ensure structural integrity was maintained.

---
*PR created automatically by Jules for task [3553622469848113859](https://jules.google.com/task/3553622469848113859) started by @tajemniktv*