### PR TITLE
[security] Fix: Remove test crash button from production Settings UI

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -142,7 +142,6 @@
     <string name="settings_data_management">ZARZĄDZANIE DANYMI</string>
     <string name="settings_export_data">EKSPORTUJ DANE LOKALNE</string>
     <string name="settings_export_success">Dane wyeksportowane (%1$d znaków)</string>
-    <string name="settings_force_crash">WYMUŚ TESTOWĄ AWARIĘ</string>
 
     <!-- Inbox -->
     <string name="inbox_quick_capture">Szybkie Przechwytywanie</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -227,7 +227,6 @@
     <string name="settings_data_management">DATA MANAGEMENT</string>
     <string name="settings_export_data">EXPORT LOCAL DATA</string>
     <string name="settings_export_success">Data exported (%1$d chars)</string>
-    <string name="settings_force_crash">FORCE TEST CRASH</string>
 
     <!-- Inbox -->
     <string name="inbox_quick_capture">Quick Capture</string>

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/SettingsScreen.kt
@@ -54,19 +54,17 @@ import tajsos.composeapp.generated.resources.settings_configure_calendars
 import tajsos.composeapp.generated.resources.settings_data_management
 import tajsos.composeapp.generated.resources.settings_export_data
 import tajsos.composeapp.generated.resources.settings_export_success
-import tajsos.composeapp.generated.resources.settings_force_crash
 import tajsos.composeapp.generated.resources.settings_manage_templates
 import tajsos.composeapp.generated.resources.settings_security
 
 /**
- * Renders the app settings screen with security, calendar, templates, data management, and a test crash action.
+ * Renders the app settings screen with security, calendar, templates, and data management.
  *
- * The security section shows a biometric toggle that reflects and updates the ViewModel biometric state and is disabled when biometric hardware is unavailable. The data export action calls the ViewModel to obtain exported JSON and displays a snackbar indicating the exported byte length. The force crash button throws a RuntimeException when tapped.
+ * The security section shows a biometric toggle that reflects and updates the ViewModel biometric state and is disabled when biometric hardware is unavailable. The data export action calls the ViewModel to obtain exported JSON and displays a snackbar indicating the exported byte length.
  *
  * @param viewModel Provides observable biometric state and actions for toggling biometric protection and exporting data.
  * @param onNavigateToCalendarSettings Callback invoked when the user requests calendar integration settings.
  * @param onNavigateToTemplates Callback invoked when the user requests template management.
- * @throws RuntimeException Thrown when the "force crash" button is pressed.
  */
 @Composable
 fun SettingsScreen(
@@ -331,17 +329,6 @@ fun SettingsScreen(
                     ),
             ) {
                 Text("Import JSON")
-            }
-
-            Spacer(Modifier.height(TactileTheme.SpacingLg))
-
-            Button(
-                onClick = { throw RuntimeException("Test Crash") },
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(TactileTheme.RadiusMd),
-                colors = ButtonDefaults.buttonColors(containerColor = TactileTheme.Error),
-            ) {
-                Text(stringResource(Res.string.settings_force_crash))
             }
         }
     }


### PR DESCRIPTION
- **What risk was reduced:** Removed a Denial-of-Service (DoS) and nuisance vector by deleting a "Force Test Crash" button intentionally left in the production settings screen.
- **What changed:** Removed the button and spacing in `SettingsScreen.kt`, the accompanying string references in `values/strings.xml` and `values-pl/strings.xml`, and updated the KDoc.
- **Why the change is low-risk:** This removes isolated test code. It does not touch core business logic, architecture, or modify existing functionality.
- **How it was validated:** Compiled the ComposeApp JVM application successfully (`./gradlew :composeApp:compileKotlinJvm`), ran local test suite, and passed internal automated code review.

---
*PR created automatically by Jules for task [8686893587520444751](https://jules.google.com/task/8686893587520444751) started by @tajemniktv*