### PR TITLE
[reliability] Guard: Remove unsafe null casts in Compose UI components

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
@@ -179,12 +179,13 @@ fun NodeCard(
                             color = TactileTheme.Error.copy(alpha = 0.5f),
                         )
                     }
-                    if (node.energyLevel != null) {
+                    val energyLevel = node.energyLevel
+                    if (energyLevel != null) {
                         Spacer(Modifier.width(8.dp))
                         NodeBadge(
-                            text = "⚡".repeat(node.energyLevel!!),
+                            text = "⚡".repeat(energyLevel),
                             color =
-                                when (node.energyLevel)
+                                when (energyLevel)
                                 {
                                     1 -> TactileTheme.Success
                                     2 -> TactileTheme.Primary
@@ -193,16 +194,17 @@ fun NodeCard(
                                 },
                         )
                     }
-                    if (node.friction != null) {
+                    val friction = node.friction
+                    if (friction != null) {
                         Spacer(Modifier.width(8.dp))
                         val frictionLabel =
-                            when (node.friction)
+                            when (friction)
                             {
                                 "easy" -> stringResource(Res.string.dash_overwhelmed)
                                 "annoying" -> "ANNOYING"
                                 "mentally_heavy" -> "HEAVY"
                                 "unclear" -> "UNCLEAR"
-                                else -> node.friction!!
+                                else -> friction
                             }
                         NodeBadge(text = frictionLabel.uppercase(), color = TactileTheme.Primary)
                     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
@@ -85,12 +85,13 @@ fun TaskRow(
                     color = if (isDone) TactileTheme.Muted else TactileTheme.Text,
                 )
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    if (node.energyLevel != null)
+                    val energyLevel = node.energyLevel
+                    if (energyLevel != null)
                     {
                         Text(
-                            text = "⚡".repeat(node.energyLevel!!),
+                            text = "⚡".repeat(energyLevel),
                             style = MaterialTheme.typography.labelSmall,
-                            color = when (node.energyLevel)
+                            color = when (energyLevel)
                             {
                                 1    -> TactileTheme.Success
                                 2    -> TactileTheme.Primary
@@ -100,15 +101,16 @@ fun TaskRow(
                         )
                         Spacer(Modifier.width(8.dp))
                     }
-                    if (node.friction != null)
+                    val friction = node.friction
+                    if (friction != null)
                     {
-                        val frictionLabel = when (node.friction)
+                        val frictionLabel = when (friction)
                         {
                             "easy"           -> stringResource(Res.string.dash_overwhelmed)
                             "annoying"       -> stringResource(Res.string.dash_annoying)
                             "mentally_heavy" -> stringResource(Res.string.dash_heavy)
                             "unclear"        -> stringResource(Res.string.dash_unclear)
-                            else             -> node.friction!!
+                            else             -> friction
                         }
                         Text(
                             text = frictionLabel.uppercase(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/NoteDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/NoteDetailScreen.kt
@@ -459,7 +459,8 @@ fun NoteDetailScreen(
                             }
                         }
 
-                        if (node.nextSmallestStep != null) {
+                        val nextStep = node.nextSmallestStep
+                        if (nextStep != null) {
                             Surface(
                                 modifier = Modifier.fillMaxWidth(),
                                 color = TactileTheme.Accent.copy(alpha = 0.1f),
@@ -475,7 +476,7 @@ fun NoteDetailScreen(
                                         fontWeight = FontWeight.Bold,
                                     )
                                     BasicTextField(
-                                        value = node.nextSmallestStep!!,
+                                        value = nextStep,
                                         onValueChange = {
                                             viewModel.updateNode(
                                                 node.copy(
@@ -552,8 +553,9 @@ fun NoteDetailScreen(
                                             color = TactileTheme.Muted,
                                             fontSize = 8.sp,
                                         )
+                                        val rating = node.rating
                                         Text(
-                                            if (node.rating != null) "⭐".repeat(node.rating!!) else "UNRATED",
+                                            if (rating != null) "⭐".repeat(rating) else "UNRATED",
                                             style = MaterialTheme.typography.bodyMedium,
                                             fontWeight = FontWeight.Bold,
                                         )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/ReviewScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/ReviewScreen.kt
@@ -139,10 +139,11 @@ fun ReviewScreen(
                 .fillMaxSize()
                 .background(TactileTheme.Background),
     ) {
-        if (reviewType != null) {
-            val steps = if (reviewType == "daily") dailySteps else weeklySteps
+        val type = reviewType
+        if (type != null) {
+            val steps = if (type == "daily") dailySteps else weeklySteps
             ReviewFlow(
-                type = reviewType!!,
+                type = type,
                 steps = steps,
                 currentStep = currentStep,
                 viewModel = viewModel,
@@ -150,7 +151,7 @@ fun ReviewScreen(
                 insights = insights,
                 onNext = { if (currentStep < steps.size - 1) currentStep++ },
                 onComplete = { content, mood, energy ->
-                    viewModel.completeReview(reviewType!!, content, mood, energy)
+                    viewModel.completeReview(type, content, mood, energy)
                     onBack()
                 },
             )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/TrackScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/TrackScreen.kt
@@ -356,9 +356,10 @@ fun TrackHistoryItem(entry: TrackEntryEntity) {
                 StatusChip("ENG", entry.energyScore)
                 StatusChip("COG", entry.focusScore)
                 StatusChip("SYS", entry.anxietyScore)
-                if (entry.sleepScore != null) {
+                val sleep = entry.sleepScore
+                if (sleep != null) {
                     Text(
-                        stringResource(Res.string.track_history_sleep, entry.sleepScore!!),
+                        stringResource(Res.string.track_history_sleep, sleep),
                         style = MaterialTheme.typography.labelSmall,
                         color = TactileTheme.Text,
                     )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsDashboardBlocks.kt
@@ -202,14 +202,15 @@ internal fun InsightsMainBlock(
             }
         }
 
-        if (insights.captureTimePattern != null) {
+        val captureTimePattern = insights.captureTimePattern
+        if (captureTimePattern != null) {
             item {
                 InsightPatternCard(
                     title = stringResource(Res.string.insights_creative_peak_title),
                     message =
                         stringResource(
                             Res.string.insights_creative_peak_msg,
-                            insights.captureTimePattern!!,
+                            captureTimePattern,
                         ),
                     icon = Icons.Default.Lightbulb,
                     color = TactileTheme.Success,


### PR DESCRIPTION
What failure mode was addressed: Unsafe casts (!!) on nullable properties during Compose recomposition, which risk runtime NullPointerExceptions if state changes concurrently or data is missing.
What changed: Extracted nullable state properties into local variables before checking for nullability and accessing their values across various UI screens and components (TaskRow, NodeCards, ReviewScreen, NoteDetailScreen, InsightsDashboardBlocks, TrackScreen).
Why the fix is low-risk: The changes only affect local variable assignment and null-checking logic within the UI layer, without altering any business logic or application architecture.
How it was validated: Validated by successfully running the JVM test suite and compiling the Compose application using ./gradlew test and ./gradlew :composeApp:compileKotlinJvm.

---
*PR created automatically by Jules for task [10744156029696288099](https://jules.google.com/task/10744156029696288099) started by @tajemniktv*