### PR TITLE
[perf] Improve: hoist active projects count in Areas cards

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
@@ -236,19 +236,30 @@ private fun AreasCards(
     metricsById: Map<Long, AreaHealthMetrics>,
     onOpen: (Long) -> Unit,
 ) {
+    val activeProjectsByAreaId = remember(allProjects) {
+        val counts = mutableMapOf<Long, Int>()
+        for (project in allProjects) {
+            val areaId = project.areaId
+            if (areaId != null && project.projectStateOrNull() == ProjectState.ACTIVE) {
+                counts[areaId] = (counts[areaId] ?: 0) + 1
+            }
+        }
+        counts
+    }
+
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val desktop = maxWidth > 900.dp
         if (desktop) {
             LazyVerticalGrid(columns = GridCells.Adaptive(minSize = 300.dp), verticalArrangement = Arrangement.spacedBy(TactileTheme.SpacingSm), horizontalArrangement = Arrangement.spacedBy(TactileTheme.SpacingSm)) {
                 items(count = areas.size, key = { index -> areas[index].id }) { index ->
                     val area = areas[index]
-                    AreaCard(area = area, metrics = metricsById[area.id], activeProjects = allProjects.count { it.areaId == area.id && it.projectStateOrNull() == ProjectState.ACTIVE }, onClick = { onOpen(area.id) })
+                    AreaCard(area = area, metrics = metricsById[area.id], activeProjects = activeProjectsByAreaId[area.id] ?: 0, onClick = { onOpen(area.id) })
                 }
             }
         } else {
             LazyColumn(verticalArrangement = Arrangement.spacedBy(TactileTheme.SpacingSm)) {
                 items(areas, key = { it.id }) { area ->
-                    AreaCard(area = area, metrics = metricsById[area.id], activeProjects = allProjects.count { it.areaId == area.id && it.projectStateOrNull() == ProjectState.ACTIVE }, onClick = { onOpen(area.id) })
+                    AreaCard(area = area, metrics = metricsById[area.id], activeProjects = activeProjectsByAreaId[area.id] ?: 0, onClick = { onOpen(area.id) })
                 }
             }
         }


### PR DESCRIPTION
- **What unnecessary work was reduced:** Precomputed the mapping of `activeProjectsByAreaId` outside of the `LazyVerticalGrid`/`LazyColumn` loops instead of calling `.count { ... }` on the entire `allProjects` list inside each `items` iteration.
- **Why this path matters:** The `AreasDashboardBlocks` renders the user's areas. When there are dozens of areas and hundreds of projects, running `allProjects.count` for every single area on every recomposition/scroll event creates an expensive `O(Areas * Projects)` loop leading to scrolling jank and wasted CPU.
- **Why the change is safe:** The precomputed map relies on `remember(allProjects)` which reacts to the exact same state updates as the previous inline code. The rendering logic inside `AreaCard` simply reads a pre-calculated `Int` defaulting to 0 without altering any underlying data or logic behavior.
- **How it was validated:** Verified by running `./gradlew :composeApp:compileKotlinJvm` and `./gradlew :composeApp:jvmTest`.
- **Expected impact:** Smoother scrolling and fewer CPU cycles spent inside list-rendering paths on the Areas dashboard for users with a large library of active projects.

---
*PR created automatically by Jules for task [4142934540598217578](https://jules.google.com/task/4142934540598217578) started by @tajemniktv*