### PR TITLE
[ux] Polish: Use consistent EmptyState component in Calendar and Decisions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.MainViewModel
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.main.state.CalendarEntry
 import com.tajemniktv.tajsos.ui.main.state.EntryType
 import com.tajemniktv.tajsos.ui.theme.TactileTheme
@@ -327,13 +328,7 @@ fun AgendaView(
         }
 
     if (dayEntries.isEmpty()) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(
-                stringResource(Res.string.cal_no_events),
-                color = TactileTheme.Muted,
-                style = MaterialTheme.typography.labelSmall,
-            )
-        }
+        EmptyState(message = stringResource(Res.string.cal_no_events))
     } else {
         LazyColumn(verticalArrangement = Arrangement.spacedBy(TactileTheme.SpacingSm)) {
             items(dayEntries) { entry ->

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/decisions/DecisionsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/decisions/DecisionsDashboardBlocks.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.NodeWithPin
 import com.tajemniktv.tajsos.ui.MainViewModel
 import com.tajemniktv.tajsos.ui.components.cards.DashCard
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.lens.LensUiContract
 import com.tajemniktv.tajsos.ui.theme.TactileTheme
 import org.jetbrains.compose.resources.stringResource
@@ -168,12 +169,7 @@ fun DecisionList(
     onEdit: (Long) -> Unit,
 ) {
     if (nodes.isEmpty()) {
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(
-                stringResource(Res.string.decision_no_decisions_category),
-                color = TactileTheme.Muted,
-            )
-        }
+        EmptyState(message = stringResource(Res.string.decision_no_decisions_category))
     } else {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
- **What user-facing friction was improved:** Previously, empty states on the Calendar Agenda view and the Decisions list view were inconsistent (showing just a text string centered in a box) compared to the rest of the app which utilizes the standard `EmptyState` component.
- **Where the change appears:** `CalendarScreen.kt` and `DecisionsDashboardBlocks.kt`.
- **Why the change matches existing UX patterns:** The `EmptyState` component is a heavily utilized piece of standardized visual feedback throughout the app (used in tasks, notes, insights, etc.). Extending its use aligns these previously overlooked screens with the rest of the application's look and feel without modifying any core flows.
- **How it was validated:** Verified by running the standard `gradlew :composeApp:compileKotlinJvm` and `gradlew test -PexcludeShared` to ensure zero regressions. Code reviewed.

---
*PR created automatically by Jules for task [3489500550937920566](https://jules.google.com/task/3489500550937920566) started by @tajemniktv*