### PR TITLE
[reliability] Guard: Remove unsafe null assertions in UI and Calculators

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
@@ -348,7 +348,7 @@ fun CaptureSheet(
                         FilterChip(
                             selected = false,
                             onClick = {
-                                if (template.defaultTitle != null) text = template.defaultTitle!!
+                                template.defaultTitle?.let { text = it }
                                 // Apply other template defaults if needed
                             },
                             label = { Text(template.name) },

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -119,13 +119,13 @@ fun calculateInsights(
 
     val completionsByArea =
         recentCompletions
-            .filter { it.node.areaId != null }
-            .groupBy { it.node.areaId!! }
+            .mapNotNull { item -> item.node.areaId?.let { it to item } }
+            .groupBy({ it.first }, { it.second })
             .mapValues { it.value.size }
     val completionsByProject =
         recentCompletions
-            .filter { it.node.projectId != null }
-            .groupBy { it.node.projectId!! }
+            .mapNotNull { item -> item.node.projectId?.let { it to item } }
+            .groupBy({ it.first }, { it.second })
             .mapValues { it.value.size }
 
     val inboxGrowth = recentNodes.count { it.node.inboxState }
@@ -299,8 +299,8 @@ fun calculateInsights(
     // Insight Cards Logic (Roadmap Section 7)
     val mostPostponedAreaId =
         nodes
-            .filter { it.node.areaId != null && it.node.postponeCount > 0 }
-            .groupBy { it.node.areaId!! }
+            .mapNotNull { item -> item.node.areaId?.takeIf { item.node.postponeCount > 0 }?.let { it to item } }
+            .groupBy({ it.first }, { it.second })
             .maxByOrNull { entry -> entry.value.sumOf { it.node.postponeCount } }
             ?.key
 
@@ -670,7 +670,7 @@ fun calculateOpenLoopsSnapshot(
             .sortedByDescending { it.node.node.completedAt ?: 0L }
 
     val byArea = active.groupBy { it.node.node.areaId }
-    val byPerson = active.filter { it.relatedPersonId != null }.groupBy { it.relatedPersonId!! }
+    val byPerson = active.mapNotNull { item -> item.relatedPersonId?.let { it to item } }.groupBy({ it.first }, { it.second })
     val byUrgency =
         linkedMapOf(
             "critical" to active.filter { it.urgency == "critical" },


### PR DESCRIPTION
- **What failure mode was addressed:** Several instances of the non-null assertion operator (`!!`) were present in `MainSnapshotCalculators.kt` and `CaptureSheet.kt`. These are fragile and would throw runtime `NullPointerException`s if data parsed unexpectedly, changed state unexpectedly, or was operated on concurrently without a non-null key.
- **What changed:** Replaced `!!` assertions during `groupBy` operations with safer idiomatic Kotlin constructs (`.mapNotNull` and `?.let`) in `MainSnapshotCalculators.kt`. In `CaptureSheet.kt`, replaced an `if (x != null) { x!! }` assignment with a safe `.let` call.
- **Why the fix is low-risk:** The refactor implements functionally identical operations safely without changing any architectural patterns, adding any dependencies, or fundamentally changing the logic. It only strips away compiler enforcement bypasses. 
- **How it was validated:** Ran the full `:composeApp:compileKotlinJvm` tests and tests under `:shared:jvmTest` (using `./gradlew`). All tasks passed and compiled successfully without exceptions or NPEs during build validation.

---
*PR created automatically by Jules for task [707847473976774242](https://jules.google.com/task/707847473976774242) started by @tajemniktv*