### PR TITLE
[test] test: Add tests for DecisionCommands.setDecisionRevisit

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/DecisionCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/DecisionCommandsTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Grzegorz Kaczmarski (TajemnikTV) 2026. All rights reserved.
+ */
+
+package com.tajemniktv.tajsos.ui.main.actions
+
+import com.tajemniktv.tajsos.data.AppRepository
+import com.tajemniktv.tajsos.data.FakeAttachmentDao
+import com.tajemniktv.tajsos.data.FakeCalendarEventDao
+import com.tajemniktv.tajsos.data.FakeCalendarProviderDao
+import com.tajemniktv.tajsos.data.FakeDecisionDao
+import com.tajemniktv.tajsos.data.FakeEventLogDao
+import com.tajemniktv.tajsos.data.FakeFocusSessionDao
+import com.tajemniktv.tajsos.data.FakeMedicationDao
+import com.tajemniktv.tajsos.data.FakeModeDao
+import com.tajemniktv.tajsos.data.FakeNodeDao
+import com.tajemniktv.tajsos.data.FakeNodeSnapshotDao
+import com.tajemniktv.tajsos.data.FakeProtocolDao
+import com.tajemniktv.tajsos.data.FakeRelationDao
+import com.tajemniktv.tajsos.data.FakeReviewDao
+import com.tajemniktv.tajsos.data.FakeTagDao
+import com.tajemniktv.tajsos.data.FakeTemplateDao
+import com.tajemniktv.tajsos.data.FakeTrackDao
+import com.tajemniktv.tajsos.data.FakeUserDao
+import com.tajemniktv.tajsos.data.NodeEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DecisionCommandsTest {
+    private fun createFakeRepo(): AppRepository {
+        return AppRepository(
+            nodeDao = FakeNodeDao(),
+            focusSessionDao = FakeFocusSessionDao(),
+            trackDao = FakeTrackDao(),
+            relationDao = FakeRelationDao(),
+            tagDao = FakeTagDao(),
+            eventLogDao = FakeEventLogDao(),
+            attachmentDao = FakeAttachmentDao(),
+            templateDao = FakeTemplateDao(),
+            nodeSnapshotDao = FakeNodeSnapshotDao(),
+            reviewDao = FakeReviewDao(),
+            calendarProviderDao = FakeCalendarProviderDao(),
+            calendarEventDao = FakeCalendarEventDao(),
+            modeDao = FakeModeDao(),
+            protocolDao = FakeProtocolDao(),
+            decisionDao = FakeDecisionDao(),
+            userDao = FakeUserDao(),
+            medicationDao = FakeMedicationDao(),
+        )
+    }
+
+    @Test
+    fun setDecisionRevisit_ignoresNonDecisionNodes() {
+        var updatedNode: NodeEntity? = null
+        val commands =
+            DecisionCommands(
+                repository = createFakeRepo(),
+                scope = TestScope(),
+                addRelation = { _, _, _ -> },
+                updateNode = { updatedNode = it },
+            )
+
+        val taskNode = NodeEntity(id = 1L, type = "task", title = "Task")
+        commands.setDecisionRevisit(taskNode, 1000L)
+
+        assertNull(updatedNode, "Expected updateNode not to be called for non-decision nodes")
+    }
+
+    @Test
+    fun setDecisionRevisit_updatesDecisionNodes() {
+        var updatedNode: NodeEntity? = null
+        val commands =
+            DecisionCommands(
+                repository = createFakeRepo(),
+                scope = TestScope(),
+                addRelation = { _, _, _ -> },
+                updateNode = { updatedNode = it },
+            )
+
+        val decisionNode = NodeEntity(id = 1L, type = "decision", title = "Decision")
+        commands.setDecisionRevisit(decisionNode, 1000L)
+
+        assertEquals(1000L, updatedNode?.decisionRevisitAt, "Expected decisionRevisitAt to be updated")
+    }
+}


### PR DESCRIPTION
- **What behavior is now protected:** The hidden logic in `DecisionCommands.setDecisionRevisit` where it silently returns without updating the node if its `type` is not `"decision"` is now explicitly protected. A test ensures `decisionRevisitAt` is updated for "decision" nodes and left completely untouched for all others.
- **Why this area needed stronger coverage:** `DecisionCommands` handles database updates and complex logic around critical decision loops. It is important to guarantee edgecases like `setDecisionRevisit` bailing out on non-decisions do not silently regress, since developers might assume it handles the database updates directly regardless of the object passed.
- **Whether production code changed:** No production code changed. A new isolated unit test suite was added to `shared`.
- **How it was validated:** Verified by running `./gradlew test -PexcludeShared` and `./gradlew :shared:jvmTest --tests "com.tajemniktv.tajsos.ui.main.actions.DecisionCommandsTest"`. All tests pass successfully and no untracked artifacts were left behind.

---
*PR created automatically by Jules for task [11172949352786984545](https://jules.google.com/task/11172949352786984545) started by @tajemniktv*