### PR TITLE
[perf] Improve: Cache derived state in DashboardScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
@@ -134,8 +134,8 @@ private fun DashboardUnifiedContent(
     val allModes by viewModel.allModes.collectAsState()
     val enabledPacks by viewModel.enabledPacks.collectAsState()
 
-    val pinnedNodes = allNodes.filter { it.pin != null }
-    val completedTodayCount = pinnedNodes.count { it.node.status == "done" }
+    val pinnedNodes = remember(allNodes) { allNodes.filter { it.pin != null } }
+    val completedTodayCount = remember(pinnedNodes) { pinnedNodes.count { it.node.status == "done" } }
     val totalTodayCount = pinnedNodes.size
     val dailyProgress =
         if (totalTodayCount > 0) completedTodayCount.toFloat() / totalTodayCount else 0f


### PR DESCRIPTION
What unnecessary work was reduced:
- `allNodes.filter` and `pinnedNodes.count` executed unconditionally on every recomposition. They are O(N) operations over collections and allocate new lists.

Why this path matters:
- DashboardScreen is the core hub of the app, and is constantly recomposing due to rapidly ticking updates (system clock, active tracking logic). Unnecessary GC allocations here drain battery.

Why the change is safe:
- `remember` is standard Compose behavior to skip computation on recompositions unless the input keys (`allNodes`, `pinnedNodes`) change.

How it was validated:
- Ran `jvmTest` and `compileKotlinJvm` successfully.
- Code reviewed to ensure cheap O(1) ops (like `.size`) weren't redundantly cached.

Expected impact:
- Reduced CPU and memory churn on the dashboard when `allNodes` remains constant but unrelated states trigger recomposition.

---
*PR created automatically by Jules for task [9853275690994580926](https://jules.google.com/task/9853275690994580926) started by @tajemniktv*