### PR TITLE
[test] test: Enhance edge test coverage for DomainLensQueries

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
@@ -95,4 +95,35 @@ class DomainLensQueriesEdgeTest {
         val result = DomainLensQueries.financeKnowledgeItems(listOf(oldNote, newNote, medNote))
         assertEquals(listOf(2L, 3L, 1L), result.map { it.node.id })
     }
+
+    @Test
+    fun financeDeadlineItems_includes_any_type_with_date_and_signal() {
+        val financeTaskWithDate = createNode(1, "Tax task", dueAt = 100L, type = "task")
+        val financeNoteWithDate = createNode(2, "Budget reference", dueAt = 200L, type = "note")
+        val nonFinanceWithDate = createNode(3, "Generic idea", dueAt = 300L, type = "note")
+        val financeNoDate = createNode(4, "Insurance file", type = "record")
+
+        val allNodes = listOf(financeTaskWithDate, financeNoteWithDate, nonFinanceWithDate, financeNoDate)
+        val result = DomainLensQueries.financeDeadlineItems(allNodes)
+
+        // Only items 1 and 2 have both a finance signal AND a due date
+        assertEquals(2, result.size)
+        assertEquals(listOf(1L, 2L), result.map { it.node.id })
+    }
+
+    @Test
+    fun financeKnowledgeItems_includes_reference_notes_with_signal_only() {
+        // "reference" alone is not enough, must have signal
+        val refNoteWithSignal = createNode(1, "Tax form 1040", type = "note", noteType = "reference")
+        val refNoteNoSignal = createNode(2, "CSS guide", type = "note", noteType = "reference")
+        val regNoteWithSignal = createNode(3, "My budget rules", type = "note")
+
+        val allNodes = listOf(refNoteWithSignal, refNoteNoSignal, regNoteWithSignal)
+        val result = DomainLensQueries.financeKnowledgeItems(allNodes)
+
+        // 1 matches because reference + title signal
+        // 3 matches because note (knowledge item) + title signal
+        assertEquals(2, result.size)
+        assertEquals(listOf(1L, 3L).sorted(), result.map { it.node.id }.sorted())
+    }
 }


### PR DESCRIPTION
- **What behavior is now protected**: The specific edge cases where an item has a due date but isn't necessarily a task (and needs a domain signal), and reference notes that require explicit title signals to be included in knowledge item lenses.
- **Why this area needed stronger coverage**: `DomainLensQueries` is heavily relied upon to implicitly sort nodes by hardcoded rules. The `financeDeadlineItems` logic did not have any dedicated tests verifying that items lacking finance signals are correctly filtered out despite having a deadline, and knowledge items have complex matching criteria based on `noteType` requiring signal validation.
- **Whether production code changed**: No production code was changed; this PR is isolated entirely to the test suite.
- **How it was validated**: Validation was performed by running the specific edge test suite `./gradlew :shared:jvmTest --tests "com.tajemniktv.tajsos.domain.lens.DomainLensQueriesEdgeTest"` and compiling the Kotlin code for `composeApp` via `./gradlew :composeApp:compileKotlinJvm`.

---
*PR created automatically by Jules for task [2716717330444521148](https://jules.google.com/task/2716717330444521148) started by @tajemniktv*