### PR TITLE
[reliability] Guard: Add fallback title for empty split note sections

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
@@ -407,7 +407,7 @@ class NodeCommands(
                 if (sections.size > 1) {
                     for (section in sections) {
                         val lines = section.lines()
-                        val title = lines.first().removePrefix("# ").trim()
+                        val title = lines.first().removePrefix("# ").trim().ifBlank { "Untitled Note" }
                         val content = lines.drop(1).joinToString("\n").trim()
 
                         repository.insertNode(


### PR DESCRIPTION
- What failure mode was addressed: If a user ran the "Split Note" command on a note that contained a section header followed by nothing, or a malformed header, the resulting split node would have an empty string as its title. This leads to poor UX and unclickable empty list items in the interface.
- What changed: In `shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt`, appended `.ifBlank { "Untitled Note" }` to the title extraction logic.
- Why the fix is low-risk: It leverages Kotlin's standard library safely without changing any dependencies, modifying the existing regex logic, or changing the database schema. The behavior for correctly structured notes remains entirely identical.
- How it was validated: Validated via `./gradlew :shared:jvmTest` and `./gradlew :composeApp:compileKotlinJvm -PexcludeShared`. The change compiles successfully and no new test regressions were introduced.

---
*PR created automatically by Jules for task [10046447809110725142](https://jules.google.com/task/10046447809110725142) started by @tajemniktv*