### PR TITLE
[security] Fix: Remove deliberate crash button from settings

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -79,7 +79,6 @@ object SettingsDashboardBlocks {
             "settings_health" to ::renderSettingsHealth,
             "settings_feature_packs" to ::renderSettingsFeaturePacks,
             "settings_data" to ::renderSettingsData,
-            "settings_debug" to ::renderSettingsDebug,
             "settings_appearance" to ::renderSettingsAppearance,
             "settings_preferences" to ::renderSettingsPreferences,
         )
@@ -267,23 +266,6 @@ private fun renderSettingsData(context: SettingsDashboardContext) {
                 ),
         ) {
             Text("Import JSON")
-        }
-    }
-}
-
-@Composable
-private fun renderSettingsDebug(context: SettingsDashboardContext) {
-    SettingsSimpleScaffold(
-        title = "DEBUG",
-        description = "Internal diagnostics and crash testing controls.",
-    ) {
-        Button(
-            onClick = context.onForceCrash,
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            colors = ButtonDefaults.buttonColors(containerColor = TajsOSTheme.Error),
-        ) {
-            Text(stringResource(Res.string.settings_force_crash))
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardContracts.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardContracts.kt
@@ -62,7 +62,6 @@ data class SettingsDashboardContext(
     val onSetGlassmorphismEnabled: (Boolean) -> Unit,
     val onSetReduceMotion: (Boolean) -> Unit,
     val onSetSidebarMode: (SidebarMode) -> Unit,
-    val onForceCrash: () -> Unit,
 )
 
 /**

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsScreen.kt
@@ -81,7 +81,6 @@ fun SettingsScreen(
             onSetGlassmorphismEnabled = { viewModel.setGlassmorphismEnabled(it) },
             onSetReduceMotion = { viewModel.setReduceMotion(it) },
             onSetSidebarMode = { viewModel.setSidebarMode(it) },
-            onForceCrash = { throw RuntimeException("Test Crash") },
         )
 
     val plan = remember(screenId) { buildSettingsPlan(screenId) }


### PR DESCRIPTION
- What risk was reduced: Removed a deliberate application crash vector (`RuntimeException("Test Crash")`) exposed via the settings UI, reducing the risk of local Denial of Service (DoS) and potential information disclosure through uncaught crash stack traces.
- What changed: 
  - Removed `renderSettingsDebug` and the "settings_debug" registration from `SettingsDashboardBlocks.kt`.
  - Removed the `onForceCrash` callback property from `SettingsDashboardContracts.kt`.
  - Removed the dummy throwing logic from `SettingsScreen.kt`.
- Why the change is low-risk: It simply deletes isolated diagnostic code and associated UI components without modifying any core logic, state architectures, or external dependencies.
- How it was validated: Validated via JVM compilation targets (`:composeApp:compileKotlinJvm`) and all tests passing in `:shared` and `:composeApp` via `./gradlew test`.

---
*PR created automatically by Jules for task [19362237913674391](https://jules.google.com/task/19362237913674391) started by @tajemniktv*