### PR TITLE
[security] Fix: Remove deliberate test crash from production UI

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -79,7 +79,6 @@ object SettingsDashboardBlocks {
             "settings_health" to ::renderSettingsHealth,
             "settings_feature_packs" to ::renderSettingsFeaturePacks,
             "settings_data" to ::renderSettingsData,
-            "settings_debug" to ::renderSettingsDebug,
             "settings_appearance" to ::renderSettingsAppearance,
             "settings_preferences" to ::renderSettingsPreferences,
         )
@@ -267,23 +266,6 @@ private fun renderSettingsData(context: SettingsDashboardContext) {
                 ),
         ) {
             Text("Import JSON")
-        }
-    }
-}
-
-@Composable
-private fun renderSettingsDebug(context: SettingsDashboardContext) {
-    SettingsSimpleScaffold(
-        title = "DEBUG",
-        description = "Internal diagnostics and crash testing controls.",
-    ) {
-        Button(
-            onClick = context.onForceCrash,
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            colors = ButtonDefaults.buttonColors(containerColor = TajsOSTheme.Error),
-        ) {
-            Text(stringResource(Res.string.settings_force_crash))
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardContracts.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardContracts.kt
@@ -62,7 +62,6 @@ data class SettingsDashboardContext(
     val onSetGlassmorphismEnabled: (Boolean) -> Unit,
     val onSetReduceMotion: (Boolean) -> Unit,
     val onSetSidebarMode: (SidebarMode) -> Unit,
-    val onForceCrash: () -> Unit,
 )
 
 /**

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsScreen.kt
@@ -81,7 +81,6 @@ fun SettingsScreen(
             onSetGlassmorphismEnabled = { viewModel.setGlassmorphismEnabled(it) },
             onSetReduceMotion = { viewModel.setReduceMotion(it) },
             onSetSidebarMode = { viewModel.setSidebarMode(it) },
-            onForceCrash = { throw RuntimeException("Test Crash") },
         )
 
     val plan = remember(screenId) { buildSettingsPlan(screenId) }


### PR DESCRIPTION
- **What risk was reduced**: Removed a deliberate application crash button ("Force Crash") from the user-facing Settings UI, eliminating a potential self-inflicted Denial of Service (DoS) and potential information disclosure via stack traces.
- **What changed**: Removed the `renderSettingsDebug` view that displayed the button, along with the underlying `onForceCrash` state variables in the layout configurations (`SettingsDashboardContracts.kt`, `SettingsDashboardBlocks.kt`, and `SettingsScreen.kt`).
- **Why the change is low-risk**: It removes isolated test code/buttons intentionally meant to crash the app, which does not interact with core business logic.
- **How it was validated**: Validated with `./gradlew :composeApp:jvmTest`, `./gradlew :shared:jvmTest` and `./gradlew :composeApp:compileKotlinJvm` which compile correctly and pass all tests.

---
*PR created automatically by Jules for task [7884928107112618844](https://jules.google.com/task/7884928107112618844) started by @tajemniktv*