### PR TITLE
[perf] Improve: Add keys to project and area lists in SearchDashboardBlocks

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -348,7 +348,7 @@ private fun renderSearchFilters(context: SearchDashboardContext) {
                         )
                     }
                 }
-                items(context.areasById.values.toList()) { area ->
+                items(context.areasById.values.toList(), key = { it.id }) { area ->
                     FilterChip(
                         selected = context.searchAreaFilter == area.id,
                         onClick = { viewModel.updateSearchAreaFilter(if (context.searchAreaFilter == area.id) null else area.id) },
@@ -362,7 +362,7 @@ private fun renderSearchFilters(context: SearchDashboardContext) {
                         },
                     )
                 }
-                items(context.projectsById.values.toList()) { project ->
+                items(context.projectsById.values.toList(), key = { it.id }) { project ->
                     FilterChip(
                         selected = context.searchProjectFilter == project.id,
                         onClick = {


### PR DESCRIPTION
### What unnecessary work was reduced
Unnecessary Jetpack Compose list item recompositions. In `SearchDashboardBlocks.kt`, the `items` lists for the project and area `FilterChip`s did not provide unique `key` functions. Jetpack Compose defaults to using item positions when no keys are provided, which can result in full list recompositions when the data order changes or list elements update. By specifying an explicit unique identifier `key = { it.id }`, Compose only updates elements whose specific data changed.

### Why this path matters
This path is part of the `SearchDashboard`, which can have many areas and projects loaded into its filter row. The `context.areasById.values.toList()` and `context.projectsById.values.toList()` computations are executed repeatedly across recompositions, meaning visual jank or performance hits in the filter row could be noticeably smoothed out by uniquely identifying components so Compose does not unnecessarily re-render all of them.

### Why the change is safe
The change introduces an optimization pattern natively supported and highly recommended by the Jetpack Compose framework (`key = { it.id }`). It does not alter public APIs or modify business logic. 

### How it was validated
- Compiled Compose UI with `./gradlew :composeApp:compileKotlinJvm`
- Ran module tests via `./gradlew :composeApp:jvmTest` 

### Expected impact
Improved render speed and reduced UI jank within the Search Dashboard when toggling statuses or dealing with multiple active filters that might prompt wide recompositions.

---
*PR created automatically by Jules for task [9586789602797377196](https://jules.google.com/task/9586789602797377196) started by @tajemniktv*