### PR TITLE
[test] test: Strengthen InsightsData test coverage

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/state/InsightsDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/state/InsightsDataTest.kt
@@ -64,6 +64,15 @@ class InsightsDataTest {
         assertTrue(data.neglectedProjects.isEmpty())
     }
 
+    @Test
+    fun insightsData_defaultAdvancedMetrics_areZeroOrEmpty() {
+        val data = InsightsData()
+        assertEquals(0, data.inboxGrowth)
+        assertEquals(0.0, data.archiveRate)
+        assertTrue(data.completionsByArea.isEmpty())
+        assertTrue(data.completionsByProject.isEmpty())
+    }
+
     // --- Custom value construction ---
 
     @Test
@@ -78,7 +87,11 @@ class InsightsDataTest {
                 avgMood = 4.2,
                 avgEnergy = 3.8,
                 avgFocus = 4.0,
-                neglectedProjects = listOf(project)
+                neglectedProjects = listOf(project),
+                inboxGrowth = 2,
+                archiveRate = 0.5,
+                completionsByArea = mapOf(10L to 3),
+                completionsByProject = mapOf(20L to 2)
             )
 
         assertEquals(10, data.weeklyCaptures)
@@ -90,6 +103,10 @@ class InsightsDataTest {
         assertEquals(4.0, data.avgFocus)
         assertEquals(1, data.neglectedProjects.size)
         assertEquals("Old Project", data.neglectedProjects.first().title)
+        assertEquals(2, data.inboxGrowth)
+        assertEquals(0.5, data.archiveRate)
+        assertEquals(3, data.completionsByArea[10L])
+        assertEquals(2, data.completionsByProject[20L])
     }
 
     // --- Data class equality ---


### PR DESCRIPTION
What behavior is now protected: 
The default state generation and manual instantiation of advanced analytics metrics within the `InsightsData` data class (such as `inboxGrowth`, `archiveRate`, `completionsByArea`, and `completionsByProject`) are now explicitly protected against silent regressions or structural initialization changes.

Why this area needed stronger coverage: 
The `InsightsDataTest.kt` file contained tests only for basic fields (e.g., `weeklyCaptures`, `avgMood`). The newer, more advanced mapping and calculating parameters (like `completionsByArea` mapping IDs to counts) had zero assertions ensuring their default state remained intact (empty maps/zeros), which is a crucial assumption required by the Insights dashboard calculators.

Whether production code changed: 
No production code was altered. The changes are strictly confined to test additions in `shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/state/InsightsDataTest.kt`.

How it was validated: 
Validated locally by successfully executing:
- `./gradlew :shared:jvmTest --tests "com.tajemniktv.tajsos.ui.main.state.InsightsDataTest"`
- `./gradlew :composeApp:compileKotlinJvm`

---
*PR created automatically by Jules for task [6755396442264192820](https://jules.google.com/task/6755396442264192820) started by @tajemniktv*