### PR TITLE
[reliability] Guard: Safely extract area ID in dashboard batch suggestions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardCoreBlockRenderers.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardCoreBlockRenderers.kt
@@ -580,7 +580,7 @@ internal fun renderSuggestionsBlock(context: DashboardBlockContext) {
                 context.dashboardState.batchableTasks.values
                     .first()
             val areaName =
-                context.allAreas.find { it.id == firstBatch.first().node.areaId }?.title
+                context.allAreas.find { it.id == firstBatch.firstOrNull()?.node?.areaId }?.title
                     ?: "GENERAL"
             SuggestionGroup(
                 title = "BATCH SUGGESTION // $areaName",


### PR DESCRIPTION
- What failure mode was addressed: Prevented an unhandled `NoSuchElementException` that could crash the dashboard UI when rendering the batch suggestion block if `firstBatch` (a list of task nodes) is unexpectedly empty.
- What changed: Replaced `firstBatch.first().node.areaId` with `firstBatch.firstOrNull()?.node?.areaId` inside `DashboardCoreBlockRenderers.kt`.
- Why the fix is low-risk: It replaces an unsafe list unwrapping `.first()` with a safe `.firstOrNull()` combined with safe navigation operators (`?.`), avoiding exceptions and safely falling back to `"GENERAL"` for the `areaName` as designed. It doesn't add dependencies or modify business logic.
- How it was validated: Validated via JVM tests (`./gradlew :composeApp:jvmTest`) to ensure UI components compile and logic holds up, alongside codebase verification.

---
*PR created automatically by Jules for task [16482033006060046096](https://jules.google.com/task/16482033006060046096) started by @tajemniktv*