### PR TITLE
[security] Fix: disable insecure Android data backup

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher_logo"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_logo_round"


### PR DESCRIPTION
- What risk was reduced: Prevented potential insecure extraction or exposure of sensitive local application data (e.g. databases, shared preferences) via ADB backups or cloud backups on Android devices.
- What changed: Set `android:allowBackup="false"` in `androidApp/src/main/AndroidManifest.xml`.
- Why the change is low-risk: Modifying this manifest attribute is a standard, highly localized Android security best practice that does not alter any core business logic, UI, or runtime functionality.
- How it was validated: Validated that JVM and Kotlin Multiplatform tests run and pass without regression. Confirmed the manifest change using Git diffs.

---
*PR created automatically by Jules for task [8860153037105901409](https://jules.google.com/task/8860153037105901409) started by @tajemniktv*