### PR TITLE
[perf] Improve: add keys to compose LazyRow items in CaptureSheet

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
@@ -359,7 +359,7 @@ fun CaptureSheet(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
                 ) {
-                    items(templates.filter { it.nodeType == selectedType }) { template ->
+                    items(templates.filter { it.nodeType == selectedType }, key = { it.id }) { template ->
                         FilterChip(
                             selected = false,
                             onClick = {
@@ -380,7 +380,7 @@ fun CaptureSheet(
                         color = TajsOSTheme.Primary,
                     )
                     LazyRow(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                        items(areas) { area ->
+                        items(areas, key = { it.id }) { area ->
                             FilterChip(
                                 selected = selectedAreaId == area.id,
                                 onClick = {
@@ -400,7 +400,7 @@ fun CaptureSheet(
                         color = TajsOSTheme.Primary,
                     )
                     LazyRow(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                        items(projects) { project ->
+                        items(projects, key = { it.id }) { project ->
                             FilterChip(
                                 selected = selectedProjectId == project.id,
                                 onClick = {
@@ -578,7 +578,7 @@ fun CaptureSheet(
                     color = TajsOSTheme.Primary,
                 )
                 LazyRow(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                    items(areas) { area ->
+                    items(areas, key = { it.id }) { area ->
                         FilterChip(
                             selected = selectedAreaId == area.id,
                             onClick = {


### PR DESCRIPTION
- What unnecessary work was reduced: Prevented unnecessary item recompositions and view hierarchy diffing inside `LazyRow` loops for areas, projects, and templates by adding an explicit unique `key = { it.id }`.
- Why this path matters: `CaptureSheet` is an interactive modal heavily used to capture tasks and notes. The user interacts with the UI (selecting area/project, editing text), triggering state changes. Without keys, the Jetpack Compose renderer re-creates list items unnecessarily during these interactive cycles. 
- Why the change is safe: Adding the `key` parameter to `items()` is a standard Compose practice. Using `it.id` leverages the unique identifiers of the entity records in the local database.
- How it was validated: Validated via JVM compilation (`./gradlew :composeApp:compileKotlinJvm`) and jvm unit tests (`./gradlew :composeApp:jvmTest`).
- Expected impact: Reduced UI hitching and better CPU profile performance when interacting with and selecting properties within the CaptureSheet modal.

---
*PR created automatically by Jules for task [1268543321214725877](https://jules.google.com/task/1268543321214725877) started by @tajemniktv*