### PR TITLE
[test] test: Add missing relevance sorting test for FilterHelper

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperTest.kt
@@ -159,6 +159,45 @@ class FilterHelperTest {
     }
 
     @Test
+    fun testRelevanceSortingOrder() {
+        val exactMatch = createTestNode(1, "search", updatedAt = 100)
+        val startMatch = createTestNode(2, "search query", updatedAt = 100)
+        val containsMatch = createTestNode(3, "my search query", updatedAt = 100)
+        val contentMatch = createTestNode(4, "different", content = "search inside", updatedAt = 100)
+        val tagMatchExact = createTestNode(5, "other", tags = listOf("search"), updatedAt = 100)
+
+        val nodes = listOf(contentMatch, startMatch, containsMatch, exactMatch, tagMatchExact)
+
+        val sortedNodes =
+            FilterHelper.filterAndSortNodes(
+                nodes = nodes,
+                query = "search",
+                type = null,
+                status = null,
+                projectId = null,
+                areaId = null,
+                linkedToId = null,
+                maxMins = null,
+                energy = null,
+                friction = null,
+                locationContext = null,
+                energyContext = null,
+                deviceContext = null,
+                socialContext = null,
+                timeWindowContext = null,
+                timeHorizon = null,
+                relations = emptyList(),
+                sortMode = "relevance",
+            )
+
+        val ids = sortedNodes.map { it.node.id }
+        // exact (195) -> start (95) -> tag exact (35) -> contains (35) -> content (20)
+        // Since tag exact and contains both have score 35, they are then sorted by updatedAt (both 100)
+        // and then by ID descending. Tag exact (ID 5) will be before Contains (ID 3).
+        assertEquals(listOf(1L, 2L, 5L, 3L, 4L), ids)
+    }
+
+    @Test
     fun testSearchSortModeUpdatedOrdersByUpdatedAt() {
         val older = createTestNode(1, "Task One", updatedAt = 100)
         val newer = createTestNode(2, "Task Two", updatedAt = 200)


### PR DESCRIPTION
What behavior is now protected:
The relevance score weighting and the fallback sorting cascade in `FilterHelper.filterAndSortNodes` and `FilterHelper.relevanceScore` are now protected by tests.

Why this area needed stronger coverage:
Relevance sorting is complex, involving heuristic scoring weights (exact title match > starts with > tags > content) and specific fallback sorting mechanics. Regressions in this logic would directly degrade the user search experience, yet it was completely uncovered.

Whether production code changed:
No production code was changed.

How it was validated:
Run `./gradlew :shared:jvmTest` and `./gradlew :composeApp:compileKotlinJvm` to ensure tests run and build without failure.

---
*PR created automatically by Jules for task [13052480811264004551](https://jules.google.com/task/13052480811264004551) started by @tajemniktv*