### PR TITLE
[security] Fix: Disable insecure Android app backup

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher_logo"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_logo_round"


### PR DESCRIPTION
- **What risk was reduced**: Prevented insecure local extraction of potentially sensitive application data via ADB backups or unsafely stored cloud backups by disabling the overly permissive `allowBackup` default.
- **What changed**: Modified `android:allowBackup="true"` to `android:allowBackup="false"` in `androidApp/src/main/AndroidManifest.xml`.
- **Why the change is low-risk**: It is a standard, declarative security hardening configuration change that only restricts data backup capabilities. It does not modify runtime business logic, introduces no new dependencies, and does not alter any core app functionality.
- **How it was validated**: Validated locally by ensuring the Android application compiles successfully with `./gradlew :androidApp:compileDebugKotlin`, and executed module tests using `./gradlew :shared:jvmTest` and `./gradlew :composeApp:jvmTest` to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [4915219771637497527](https://jules.google.com/task/4915219771637497527) started by @tajemniktv*