### PR TITLE
[ux] Polish: Add call-to-action buttons to settings empty states

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsBlocks.kt
@@ -7,13 +7,16 @@ package com.tajemniktv.tajsos.ui.screens.calendar
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -23,6 +26,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.CalendarProviderEntity
 import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
@@ -68,7 +72,12 @@ private fun renderCalendarSettingsHeader(context: CalendarSettingsContext) {
 @Composable
 private fun renderCalendarSettingsList(context: CalendarSettingsContext) {
     if (context.providers.isEmpty()) {
-        EmptyState(message = stringResource(Res.string.cal_settings_empty))
+        EmptyState(message = stringResource(Res.string.cal_settings_empty)) {
+            Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
+            Button(onClick = context.onShowAddDialog) {
+                Text(stringResource(Res.string.cal_settings_add))
+            }
+        }
     } else {
         LazyColumn(verticalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
             items(context.providers, key = { it.id }) { provider ->

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesDashboardBlocks.kt
@@ -5,11 +5,14 @@
 package com.tajemniktv.tajsos.ui.screens.templates
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
@@ -22,6 +25,7 @@ import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.archive_delete
+import tajsos.composeapp.generated.resources.templates_add_desc
 import tajsos.composeapp.generated.resources.templates_empty
 import tajsos.composeapp.generated.resources.type_area
 import tajsos.composeapp.generated.resources.type_note
@@ -42,7 +46,12 @@ object TemplatesDashboardBlocks {
 private fun renderTemplatesList(context: TemplatesDashboardContext) {
     val templates = context.templates
     if (templates.isEmpty()) {
-        EmptyState(message = stringResource(Res.string.templates_empty))
+        EmptyState(message = stringResource(Res.string.templates_empty)) {
+            Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
+            Button(onClick = context.onShowAddDialog) {
+                Text(stringResource(Res.string.templates_add_desc))
+            }
+        }
     } else {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
- What user-facing friction was improved: Added call-to-action buttons to the empty states in Calendar Settings and Templates to make it easier to add items instead of having a dead end.
- Where the change appears: Calendar Settings and Templates screens empty states.
- Why the change matches existing UX patterns: Standardizes empty states to include a primary action, similar to other screens like Areas and Projects.
- How it was validated: Ran standard validation tasks (`:shared:jvmTest` and `:composeApp:compileKotlinJvm`).

---
*PR created automatically by Jules for task [9227911106676863141](https://jules.google.com/task/9227911106676863141) started by @tajemniktv*