### PR TITLE
[security] Fix: Disable insecure Android app backup

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher_logo"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_logo_round"


### PR DESCRIPTION
- **What risk was reduced**: Prevented the potential extraction of sensitive local application data via ADB backup mechanisms, which is allowed by default.
- **What changed**: Set `android:allowBackup="false"` in `AndroidManifest.xml`.
- **Why the change is low-risk**: It solely modifies an Android manifest configuration to tighten a default security parameter without affecting runtime business logic, UI, or dependencies.
- **How it was validated**: Compiled the `androidApp` module and executed shared JVM compilation and test tasks via `./gradlew test -PexcludeShared` and `./gradlew :composeApp:compileKotlinJvm`.

---
*PR created automatically by Jules for task [12861993705108207920](https://jules.google.com/task/12861993705108207920) started by @tajemniktv*