### PR TITLE
fix: Disable android allowBackup

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher_logo"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_logo_round"


### PR DESCRIPTION
**What risk was reduced:**
Disabling `android:allowBackup` prevents attackers with physical access and USB debugging enabled from extracting sensitive private application data via `adb backup`.

**What changed:**
Set `android:allowBackup="false"` in `androidApp/src/main/AndroidManifest.xml`.

**Why the change is low-risk:**
It only disables system-level backup and does not affect the core functionality of the application.

**How it was validated:**
Verified by running Android app compilation using `./gradlew :androidApp:compileDebugKotlin` and executing all shared and composeApp JVM tests.

---
*PR created automatically by Jules for task [5440709240518242329](https://jules.google.com/task/5440709240518242329) started by @tajemniktv*