### PR TITLE
fix: Disable allowBackup in AndroidManifest

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher_logo"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_logo_round"


### PR DESCRIPTION
What risk was reduced: This change mitigates the risk of insecure local extraction of potentially sensitive application data (like databases or shared preferences) via ADB backups.
What changed: Set `android:allowBackup="false"` in `androidApp/src/main/AndroidManifest.xml`.
Why the change is low-risk: The modification is a single, well-known boolean flag flip in the manifest. It prevents automatic backups but doesn't affect the core runtime logic or UI of the app.
How it was validated: Verified that the Android app still compiles without errors (`./gradlew :androidApp:assembleDebug --no-daemon`) and that the shared module tests (`./gradlew :shared:jvmTest --no-daemon`) pass to guarantee no build regressions were introduced.

---
*PR created automatically by Jules for task [14625968338057616271](https://jules.google.com/task/14625968338057616271) started by @tajemniktv*