### PR TITLE
perf: hoist project state collection in InsightsDashboardBlocks

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsDashboardBlocks.kt
@@ -76,6 +76,7 @@ internal fun InsightsMainBlock(
     val recentLogs by viewModel.recentLogs.collectAsState()
     val allAreas by viewModel.allAreas.collectAsState()
     val areaSnapshot by viewModel.areaHealthSnapshot.collectAsState()
+    val allProjects by viewModel.allProjects.collectAsState()
 
     LazyColumn(
         modifier =
@@ -271,11 +272,7 @@ internal fun InsightsMainBlock(
                 )
             }
             items(highEntropyProjects.keys.toList(), key = { "entropy_$it" }) { projectId ->
-                val project =
-                    viewModel.allProjects
-                        .collectAsState()
-                        .value
-                        .find { it.id == projectId }
+                val project = allProjects.find { it.id == projectId }
                 if (project != null) {
                     ProjectEntropyItem(project, highEntropyProjects[projectId] ?: 0.0) {
                         onNavigateToProject(project.id)


### PR DESCRIPTION
## What was improved
Identified and fixed a performance issue where flow state (`allProjects.collectAsState()`) was being collected inside the `items` builder block of a `LazyColumn` for high entropy projects.

## What changed
Hoisted the `allProjects` state collection to the top level of the `InsightsMainBlock` composable block, ensuring it only subscribes to the flow once instead of N times (where N is the number of rendered projects). The items loop now safely references this single hoisted state list.

## Why the change is low-risk
It preserves the identical mapping logic (`allProjects.find { it.id == projectId }`) but simply shifts *when* the data collection begins. There are no UI/layout changes and no behavior is altered.

## How it was validated
- Checked UI compilations with `./gradlew :composeApp:compileKotlinJvm`
- Checked core logic tests with `./gradlew :shared:jvmTest`

---
*PR created automatically by Jules for task [2744935634758318482](https://jules.google.com/task/2744935634758318482) started by @tajemniktv*