### PR TITLE
[reliability] Guard: Disable allowBackup to secure app data

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher_logo"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_logo_round"


### PR DESCRIPTION
What failure mode was addressed:
Prevented insecure local extraction of potentially sensitive application data through Android's Auto Backup mechanism, which could lead to unpredictable states upon restore or unauthorized data access.

What changed:
Updated the `application` tag in `androidApp/src/main/AndroidManifest.xml` to set `android:allowBackup="false"`.

Why the fix is low-risk:
This is a standard security configuration change that does not affect runtime application logic, UI, or local app data access, simply disabling the OS-level cloud backup of local files.

How it was validated:
Compiled and verified the project builds correctly across shared JVM tests, composeApp, and androidApp using the provided Gradle wrapper.

---
*PR created automatically by Jules for task [6487509461491342789](https://jules.google.com/task/6487509461491342789) started by @tajemniktv*