### PR TITLE
test: Strengthen InetAddressParser and add exhaustive negative tests

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
@@ -56,7 +56,13 @@ private fun parseIpv4(host: String): IpAddress.Ipv4? {
     if (parts.size != 4) return null
     var address = 0L
     for (i in 0..3) {
-        val byteVal = parts[i].toLongOrNull() ?: return null
+        val part = parts[i]
+        if (part.isEmpty()) return null
+        // Disallow leading spaces or any other non-digit character implicitly
+        if (part.any { !it.isDigit() }) return null
+        // Disallow leading zeros unless the part is exactly "0"
+        if (part.length > 1 && part.startsWith("0")) return null
+        val byteVal = part.toLongOrNull() ?: return null
         if (byteVal !in 0..255) return null
         address = (address shl 8) or byteVal
     }
@@ -65,6 +71,9 @@ private fun parseIpv4(host: String): IpAddress.Ipv4? {
 
 private fun parseIpv6(host: String): IpAddress.Ipv6? {
     if (!host.contains(":")) return null
+    if (host.startsWith(":") && !host.startsWith("::")) return null
+    if (host.endsWith(":") && !host.endsWith("::")) return null
+
     val rawParts = host.split(":")
 
     val values = LongArray(8) { 0L }
@@ -107,13 +116,16 @@ private fun populateIpv6Values(
     var outputIdx = startOutputIndex
     var count = 0
     for (i in indices) {
-        if (rawParts[i].isEmpty()) {
+        val part = rawParts[i]
+        if (part.isEmpty()) {
             // Empty parts should only exist at the boundaries (e.g. "::1" -> "", "", "1").
             // If we encounter one here during population, and it's not handled by the boundary cases,
             // we skip it, but we already validated that there are no extra "::" in parseIpv6.
             continue
         }
-        val v = rawParts[i].toLongOrNull(16) ?: return -1
+        if (part.length > 4) return -1
+        if (part.startsWith("-") || part.startsWith("+")) return -1
+        val v = part.toLongOrNull(16) ?: return -1
         if (v !in 0..0xFFFF) return -1
         if (outputIdx < 0 || outputIdx >= values.size) return -1
         values[outputIdx] = v
@@ -126,7 +138,10 @@ private fun populateIpv6Values(
 private fun parseIpv6Full(rawParts: List<String>, values: LongArray): Boolean {
     if (rawParts.size != 8) return false
     for (i in 0..7) {
-        val v = rawParts[i].toLongOrNull(16) ?: return false
+        val part = rawParts[i]
+        if (part.length > 4) return false
+        if (part.startsWith("-") || part.startsWith("+")) return false
+        val v = part.toLongOrNull(16) ?: return false
         if (v !in 0..0xFFFF) return false
         values[i] = v
     }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
@@ -106,6 +106,14 @@ private fun parseIpv6Abbreviated(rawParts: List<String>, values: LongArray, doub
     return leftParsed <= (7 - rightParsed)
 }
 
+private fun parseIpv6Segment(part: String): Long? {
+    if (part.length > 4) return null
+    if (part.startsWith("-") || part.startsWith("+")) return null
+    val v = part.toLongOrNull(16) ?: return null
+    if (v !in 0..0xFFFF) return null
+    return v
+}
+
 private fun populateIpv6Values(
     rawParts: List<String>,
     indices: IntProgression,
@@ -123,10 +131,7 @@ private fun populateIpv6Values(
             // we skip it, but we already validated that there are no extra "::" in parseIpv6.
             continue
         }
-        if (part.length > 4) return -1
-        if (part.startsWith("-") || part.startsWith("+")) return -1
-        val v = part.toLongOrNull(16) ?: return -1
-        if (v !in 0..0xFFFF) return -1
+        val v = parseIpv6Segment(part) ?: return -1
         if (outputIdx < 0 || outputIdx >= values.size) return -1
         values[outputIdx] = v
         outputIdx += direction
@@ -138,11 +143,7 @@ private fun populateIpv6Values(
 private fun parseIpv6Full(rawParts: List<String>, values: LongArray): Boolean {
     if (rawParts.size != 8) return false
     for (i in 0..7) {
-        val part = rawParts[i]
-        if (part.length > 4) return false
-        if (part.startsWith("-") || part.startsWith("+")) return false
-        val v = part.toLongOrNull(16) ?: return false
-        if (v !in 0..0xFFFF) return false
+        val v = parseIpv6Segment(rawParts[i]) ?: return false
         values[i] = v
     }
     return true

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
@@ -59,7 +59,7 @@ private fun parseIpv4(host: String): IpAddress.Ipv4? {
         val part = parts[i]
         if (part.isEmpty()) return null
         // Disallow leading spaces or any other non-digit character implicitly
-        if (part.any { !it.isDigit() }) return null
+        if (part.any { it !in '0'..'9' }) return null
         // Disallow leading zeros unless the part is exactly "0"
         if (part.length > 1 && part.startsWith("0")) return null
         val byteVal = part.toLongOrNull() ?: return null

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
@@ -69,22 +69,26 @@ private fun parseIpv4(host: String): IpAddress.Ipv4? {
     return IpAddress.Ipv4(address)
 }
 
+private fun validateIpv6Host(host: String): Boolean {
+    if (!host.contains(":")) return false
+    if (host.startsWith(":") && !host.startsWith("::")) return false
+    if (host.endsWith(":") && !host.endsWith("::")) return false
+
+    // An IPv6 address can only have at most one "::" substitution.
+    // If the first and last occurrences of "::" are not the same, it's invalid.
+    if (host.indexOf("::") != host.lastIndexOf("::")) {
+        return false
+    }
+    return true
+}
+
 private fun parseIpv6(host: String): IpAddress.Ipv6? {
-    if (!host.contains(":")) return null
-    if (host.startsWith(":") && !host.startsWith("::")) return null
-    if (host.endsWith(":") && !host.endsWith("::")) return null
+    if (!validateIpv6Host(host)) return null
 
     val rawParts = host.split(":")
 
     val values = LongArray(8) { 0L }
     val doubleColonIdx = rawParts.indexOf("")
-
-    // An IPv6 address can only have at most one "::" substitution.
-    // If the first and last occurrences of "::" are not the same, it's invalid.
-    if (host.indexOf("::") != host.lastIndexOf("::")) {
-        return null
-    }
-
 
     val success = if (doubleColonIdx != -1) {
         parseIpv6Abbreviated(rawParts, values, doubleColonIdx)

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserNegativeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserNegativeTest.kt
@@ -1,0 +1,34 @@
+package com.tajemniktv.tajsos.calendar
+
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class InetAddressParserNegativeTest {
+    @Test
+    fun testInvalidIpv4Formats() {
+        assertNull(parseIpAddress("1.1.1.01"), "Should reject octets with leading zeros")
+        assertNull(parseIpAddress("1.1.1.-1"), "Should reject negative octets")
+        assertNull(parseIpAddress("1.1.1.1.1"), "Should reject 5 octets")
+        assertNull(parseIpAddress("1.1.1"), "Should reject 3 octets")
+        assertNull(parseIpAddress("..."), "Should reject empty octets")
+        assertNull(parseIpAddress("1..1.1"), "Should reject missing internal octets")
+        assertNull(parseIpAddress("1.1.1.1a"), "Should reject trailing characters")
+        assertNull(parseIpAddress("a1.1.1.1"), "Should reject leading characters")
+    }
+
+    @Test
+    fun testInvalidIpv6Formats() {
+        assertNull(parseIpAddress("::G"), "Should reject non-hex characters")
+        assertNull(parseIpAddress("1::2::3"), "Should reject multiple double colons")
+        assertNull(parseIpAddress(":::"), "Should reject triple colons")
+        assertNull(parseIpAddress("1:::2"), "Should reject triple colons internally")
+        assertNull(parseIpAddress("::1::"), "Should reject leading and trailing double colons")
+        assertNull(parseIpAddress("1:2:3:4:5:6:7:8:9"), "Should reject too many segments")
+        assertNull(parseIpAddress("1:2:3:4:5:6:7:"), "Should reject trailing single colon")
+        assertNull(parseIpAddress(":1:2:3:4:5:6:7"), "Should reject leading single colon")
+        assertNull(parseIpAddress("1:2:3:4:5:6:7:8::"), "Should reject double colon with full segments")
+        assertNull(parseIpAddress("1:2:3:4:5:6:7:8:9:10::"), "Should reject double colon with too many segments")
+        assertNull(parseIpAddress("12345::1"), "Should reject segments with more than 4 hex characters")
+        assertNull(parseIpAddress("-1::1"), "Should reject negative values")
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperEdgeTest.kt
@@ -1,0 +1,100 @@
+package com.tajemniktv.tajsos.ui
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.data.TagEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FilterHelperEdgeTest {
+    private fun createTestNode(
+        id: Long,
+        title: String,
+        content: String = "",
+        type: String = "task",
+        status: String = "active",
+        tags: List<String> = emptyList(),
+        updatedAt: Long = 0L,
+    ): NodeWithPin {
+        return NodeWithPin(
+            node = NodeEntity(
+                id = id,
+                title = title,
+                content = content,
+                type = type,
+                status = status,
+                updatedAt = updatedAt
+            ),
+            pin = null,
+            tags = tags.mapIndexed { index, tag -> TagEntity(id = index.toLong(), name = tag, normalizedName = tag.lowercase()) }
+        )
+    }
+
+    @Test
+    fun testRelevanceScore_emptyQuery() {
+        val node = createTestNode(1, "Test Node")
+        val result = FilterHelper.filterAndSortNodes(
+            nodes = listOf(node),
+            query = "",
+            type = null,
+            status = null,
+            projectId = null,
+            areaId = null,
+            linkedToId = null,
+            maxMins = null,
+            energy = null,
+            friction = null,
+            locationContext = null,
+            energyContext = null,
+            deviceContext = null,
+            socialContext = null,
+            timeWindowContext = null,
+            timeHorizon = null,
+            relations = emptyList(),
+            sortMode = "relevance"
+        )
+        // Ensure that with empty query it still returns nodes and sort mode works without error
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun testRelevanceScore_variousMatches() {
+        val exactMatchNode = createTestNode(1, "exact match", "content", tags = listOf("tag"))
+        val startsWithNode = createTestNode(2, "exact match with suffix", "content", tags = listOf("tag"))
+        val containsTitleNode = createTestNode(3, "prefix exact match", "content", tags = listOf("tag"))
+        val containsContentNode = createTestNode(4, "title", "contains exact match", tags = listOf("tag"))
+        val exactTagMatchNode = createTestNode(5, "title", "content", tags = listOf("exact match"))
+        val containsTagMatchNode = createTestNode(6, "title", "content", tags = listOf("prefix exact match suffix"))
+
+        val nodes = listOf(exactMatchNode, startsWithNode, containsTitleNode, containsContentNode, exactTagMatchNode, containsTagMatchNode)
+
+        val result = FilterHelper.filterAndSortNodes(
+            nodes = nodes,
+            query = "exact match",
+            type = null,
+            status = null,
+            projectId = null,
+            areaId = null,
+            linkedToId = null,
+            maxMins = null,
+            energy = null,
+            friction = null,
+            locationContext = null,
+            energyContext = null,
+            deviceContext = null,
+            socialContext = null,
+            timeWindowContext = null,
+            timeHorizon = null,
+            relations = emptyList(),
+            sortMode = "relevance"
+        )
+
+        // Exact match on title gets 100 + 60 (startsWith) + 30 (contains) + 5 (active status) = 195
+        // Starts with match gets 60 + 30 (contains) + 5 (active status) = 95
+        // exactTagMatchNode gets 20 (exact) + 10 (contains) + 5 = 35
+
+        assertEquals(6, result.size)
+        // Check exact match is first
+        assertEquals(1L, result[0].node.id)
+    }
+}


### PR DESCRIPTION
What changed: Hardened IP address parsing logic and added rigorous negative test cases. Why it changed: Ensure parsing strictly aligns with specifications without relying heavily on implicit error swallowing during conversion to prevent anomalous representations. What risk was reduced: Reduced attack surface by properly failing invalid IPs such as signed components or trailing properties. How it was validated: Executed newly added test suites handling negative test cases for both `Ipv4` and `Ipv6`.

---
*PR created automatically by Jules for task [11366924301105598389](https://jules.google.com/task/11366924301105598389) started by @tajemniktv*