### PR TITLE
feat(ui): use EmptyState in NotesWorkspaceDetail

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -113,9 +113,7 @@ fun NotesWorkspaceDetail(
     val projects by viewModel.allProjects.collectAsState()
 
     if (current == null) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(stringResource(Res.string.notes_empty), color = TajsOSTheme.Muted)
-        }
+        com.tajemniktv.tajsos.ui.components.common.EmptyState(message = stringResource(Res.string.notes_empty))
         return
     }
 


### PR DESCRIPTION
What user-facing friction was improved: The notes workspace detail empty state was a simple Box/Text combination, appearing unpolished and lacking visual cues. Where the change appears: In the notes workspace detail view (`NotesWorkspaceDetail.kt`) when there is no current note selected. Why the change matches existing UX patterns: Other empty states in the application use the `EmptyState` component for consistent, styled representation of an empty interface state. How it was validated: Local validation by compiling the app and successfully running all tests to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [6122572264034650286](https://jules.google.com/task/6122572264034650286) started by @tajemniktv*