### PR TITLE
🔒 fix: Disable android backup to prevent insecure local extraction

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher_logo"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_logo_round"


### PR DESCRIPTION
🎯 **What**
This PR disables the `android:allowBackup` flag in the `AndroidManifest.xml`.

⚠️ **Risk**
When `android:allowBackup` is enabled, an attacker with physical access to an unlocked device or a user with USB debugging enabled can use `adb backup` to extract the application's private data, including databases, shared preferences, and other potentially sensitive local files, without needing root access.

🛡️ **Solution**
By setting `android:allowBackup="false"`, the application explicitly opts out of the Android backup and restore infrastructure, preventing unauthorized local data extraction via `adb`. 

**Validation**
This change was validated by running the full suite of unit tests (`./gradlew test --no-daemon`) to ensure no regressions were introduced. The automated code reviewer also verified that the change is safe, correct, and accomplishes the security enhancement goal.

---
*PR created automatically by Jules for task [8831213138063010721](https://jules.google.com/task/8831213138063010721) started by @tajemniktv*