### PR TITLE
fix: Disable android:allowBackup to prevent insecure data extraction

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher_logo"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_logo_round"


### PR DESCRIPTION
**🎯 What risk was reduced:**
The application's `AndroidManifest.xml` had `android:allowBackup` enabled, which allows an attacker with physical access or ADB access to potentially extract and back up sensitive, locally stored application data to an external machine. This exposes internal databases, shared preferences, and other sensitive state.

**✨ What changed:**
Set `android:allowBackup="false"` in `androidApp/src/main/AndroidManifest.xml`.

**🛡️ Why the change is low-risk:**
This is a standard security hardening practice for modern Android applications that do not explicitly require Google Drive or external local ADB backup workflows. It does not alter runtime behavior, logic, or UI.

**✅ How it was validated:**
Verified the manifest XML logic and compiled locally.

---
*PR created automatically by Jules for task [17002376291622283244](https://jules.google.com/task/17002376291622283244) started by @tajemniktv*