### PR TITLE
[reliability] Guard: Intent parsing

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -217,17 +217,7 @@ class MainActivity : FragmentActivity() {
                 viewModel.addNode(title = sharedText, type = "note")
             }
         } else if (type.startsWith("image/")) {
-            val imageUri =
-                try {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
-                    } else {
-                        @Suppress("DEPRECATION")
-                        intent.getParcelableExtra(Intent.EXTRA_STREAM)
-                    }
-                } catch (e: Exception) {
-                    null
-                }
+            val imageUri = intent.getSafeParcelableExtra<Uri>(Intent.EXTRA_STREAM)
             imageUri?.let { uri ->
                 val nodeId =
                     viewModel.addNodeForResult(
@@ -247,17 +237,7 @@ class MainActivity : FragmentActivity() {
     private suspend fun handleActionSendMultiple(intent: Intent) {
         val type = intent.type ?: return
         if (type.startsWith("image/")) {
-            val imageUris =
-                try {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, Uri::class.java)
-                    } else {
-                        @Suppress("DEPRECATION")
-                        intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
-                    }
-                } catch (e: Exception) {
-                    null
-                }
+            val imageUris = intent.getSafeParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
             imageUris?.let { uris ->
                 val nodeId =
                     viewModel.addNodeForResult(
@@ -356,5 +336,38 @@ class MainActivity : FragmentActivity() {
     override fun onStop() {
         super.onStop()
         viewModel.lockApp()
+    }
+
+    /**
+     * Safely extracts a Parcelable extra from an Intent, handling OS version differences
+     * and catching potential unparcelling exceptions (e.g., BadParcelableException).
+     */
+    private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableExtra(name: String): T? {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                getParcelableExtra(name, T::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                getParcelableExtra(name) as? T
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Safely extracts a Parcelable ArrayList extra from an Intent.
+     */
+    private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableArrayListExtra(name: String): java.util.ArrayList<T>? {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                getParcelableArrayListExtra(name, T::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                getParcelableArrayListExtra<T>(name)
+            }
+        } catch (e: Exception) {
+            null
+        }
     }
 }


### PR DESCRIPTION
## 🎯 What failure mode was addressed
When sharing files or content to the app, extracting `Parcelable` data from an external `Intent` (e.g., `Uri` via `getParcelableExtra` or `getParcelableArrayListExtra`) can cause crashes, such as `BadParcelableException` or `ClassCastException`, if the sender provides malformed data or there is a classloader mismatch.

## ✨ What changed
- Extracted inline `try-catch` blocks handling Android SDK versions (Tiramisu and older deprecations) into two private inline helper functions: `getSafeParcelableExtra` and `getSafeParcelableArrayListExtra` in `MainActivity.kt`.
- Refactored the `handleActionSend` and `handleActionSendMultiple` methods to utilize these cleaner, centralized extraction helpers.

## 🛡️ Why the fix is low-risk
The logic remains functionally identical, wrapping the exact same extraction and SDK version fallback methods as before. Using `reified` generics safely passes the class required by newer Android APIs, while the central implementation reduces duplicate error-prone boilerplate. The fallbacks safely return `null` instead of propagating fatal exceptions. 

## 🔬 How it was validated
- Compiled `androidApp` module using `./gradlew :androidApp:compileDebugKotlin --no-daemon`.
- Executed `androidApp` unit tests using `./gradlew :androidApp:testDebugUnitTest --no-daemon` and shared all module tests. All verified no regressions were introduced.

---
*PR created automatically by Jules for task [4546198497221471086](https://jules.google.com/task/4546198497221471086) started by @tajemniktv*