### PR TITLE
fix(ui): Polish empty states in Notes workspace

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -498,6 +498,7 @@
     <string name="notes_notes">NOTES</string>
     <string name="notes_resources">REFERENCE</string>
     <string name="notes_empty">NO KNOWLEDGE FOUND</string>
+    <string name="notes_empty_desc">Create your first note to start building your knowledge workspace.</string>
     <string name="notes_no_results">NO MATCHING RESULTS</string>
     <string name="notes_tab_workspace">Workspace</string>
     <string name="notes_tab_recent">Recent</string>

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
@@ -38,6 +38,10 @@ import com.tajemniktv.tajsos.data.isNoteItem
 import com.tajemniktv.tajsos.ui.MainViewModel
 import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.components.screen.ScreenScaffold
+import org.jetbrains.compose.resources.stringResource
+import tajsos.composeapp.generated.resources.Res
+import tajsos.composeapp.generated.resources.notes_empty
+import tajsos.composeapp.generated.resources.notes_empty_desc
 import com.tajemniktv.tajsos.ui.components.screen.ScreenScrollBehavior
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import kotlinx.coroutines.launch
@@ -333,8 +337,8 @@ fun NotesRoute(
                     )
                     if (allNotes.isEmpty()) {
                         EmptyState(
-                            message = "No notes",
-                            description = "Create your first note to start building your knowledge workspace.",
+                            message = stringResource(Res.string.notes_empty),
+                            description = stringResource(Res.string.notes_empty_desc),
                             modifier = Modifier.weight(1f),
                         )
                     } else {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.isNoteItem
 import com.tajemniktv.tajsos.ui.MainViewModel
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -113,9 +114,12 @@ fun NotesWorkspaceDetail(
     val projects by viewModel.allProjects.collectAsState()
 
     if (current == null) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(stringResource(Res.string.notes_empty), color = TajsOSTheme.Muted)
-        }
+        EmptyState(
+            message = stringResource(Res.string.notes_empty),
+            description = null,
+            showContainer = false,
+            fillParent = true,
+        )
         return
     }
 


### PR DESCRIPTION
What user-facing friction was improved: Replaced hardcoded raw text with properly localized and styled EmptyState component.
Where the change appears: Notes workspace detail screen and notes route empty list states.
Why the change matches existing UX patterns: Standardizes empty state representation using the existing common EmptyState component.
How it was validated: Local UI compilation and test suite execution.

---
*PR created automatically by Jules for task [12341895772622137800](https://jules.google.com/task/12341895772622137800) started by @tajemniktv*