### PR TITLE
docs: Add KDocs for PreferencesRepository and SyncRoutes constraints

### DIFF
--- a/server/src/main/kotlin/com/tajemniktv/tajsos/routes/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/routes/SyncRoutes.kt
@@ -15,9 +15,25 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.CancellationException
 
+/**
+ * In-memory development stub for storing synchronized items.
+ *
+ * NOTE: This is strictly for development and testing purposes.
+ * It does not provide long-term persistence, clustering, or multi-user tenant separation.
+ */
 private val syncStore = LinkedHashMap<String, SyncItem>()
+
+/**
+ * Concurrency lock for safe access to the development in-memory [syncStore].
+ */
 private val syncStoreLock = Any()
 
+/**
+ * Configures the `/sync` endpoint for processing TajsOS synchronization payloads.
+ *
+ * NOTE: This endpoint currently relies on the in-memory [syncStore] as a development stub.
+ * It is not intended for long-term multi-user persistence in its current state.
+ */
 fun Route.syncRoutes() {
     route("/sync") {
         post {

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/routes/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/routes/SyncRoutes.kt
@@ -29,9 +29,9 @@ private val syncStore = LinkedHashMap<String, SyncItem>()
 private val syncStoreLock = Any()
 
 /**
- * Configures the `/sync` endpoint for processing TajsOS synchronization payloads.
+ * Configures the /sync endpoint for processing TajsOS synchronization payloads.
  *
- * NOTE: This endpoint currently relies on the in-memory [syncStore] as a development stub.
+ * NOTE: This endpoint currently relies on an internal in-memory store as a development stub.
  * It is not intended for long-term multi-user persistence in its current state.
  */
 fun Route.syncRoutes() {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -34,7 +34,7 @@ class PreferencesRepository(
     }
 
     /**
-     * Whether biometric authentication (like fingerprint or Face ID) is enabled.
+     * Whether biometric authentication (like fingerprint or Face ID) is enabled. Defaults to false.
      */
     val isBiometricEnabled: Flow<Boolean> =
         dataStore.data
@@ -52,7 +52,7 @@ class PreferencesRepository(
             }
 
     /**
-     * Whether the dark theme is enabled globally across the application.
+     * Whether the dark theme is enabled globally across the application. Defaults to true.
      */
     val isDarkThemeEnabled: Flow<Boolean> =
         dataStore.data

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -33,18 +33,27 @@ class PreferencesRepository(
         val ENABLED_PACKS = stringSetPreferencesKey("enabled_packs")
     }
 
+    /**
+     * Whether biometric authentication (like fingerprint or Face ID) is enabled.
+     */
     val isBiometricEnabled: Flow<Boolean> =
         dataStore.data
             .map { preferences ->
                 preferences[PreferencesKeys.BIOMETRIC_ENABLED] ?: false
             }
 
+    /**
+     * The unique identifier of the currently active operating mode, or null if using the default mode.
+     */
     val activeModeId: Flow<Long?> =
         dataStore.data
             .map { preferences ->
                 preferences[PreferencesKeys.ACTIVE_MODE_ID]
             }
 
+    /**
+     * Whether the dark theme is enabled globally across the application.
+     */
     val isDarkThemeEnabled: Flow<Boolean> =
         dataStore.data
             .map { preferences ->


### PR DESCRIPTION
Added missing KDocs to PreferencesRepository.kt to document public flows and functions. Added KDocs to SyncRoutes.kt to explicitly document the development-stub in-memory storage and constraints.

---
*PR created automatically by Jules for task [17235763918279870659](https://jules.google.com/task/17235763918279870659) started by @tajemniktv*