### PR TITLE
fix: disable android backup to prevent insecure data extraction

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <application
         android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher_logo"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_logo_round"

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher_logo"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_logo_round"


### PR DESCRIPTION
🎯 **What risk was reduced:**
The risk of insecure local extraction of potentially sensitive application data (like databases, shared preferences) via `adb backup` or automated cloud backups.

🛠️ **What changed:**
Set `android:allowBackup="false"` in `androidApp/src/main/AndroidManifest.xml`.

🛡️ **Why the change is low-risk:**
This is a standard security configuration change that does not affect runtime application logic, UI, or performance. The only side effect is disabling automatic app data restoration on new devices, which is a common trade-off for enhanced security.

✅ **How it was validated:**
Verified the change via `cat` and successfully ran `./gradlew test --no-daemon` to ensure no build regressions or test failures were introduced.

---
*PR created automatically by Jules for task [651671895652132748](https://jules.google.com/task/651671895652132748) started by @tajemniktv*