### PR TITLE
[reliability] Guard: Extract duplicate parcelable extraction code

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -339,16 +339,18 @@ class MainActivity : FragmentActivity() {
     }
 
     /**
-     * Safely extracts a Parcelable extra from an Intent, handling OS version differences
-     * and catching potential unparcelling exceptions (e.g., BadParcelableException).
+     * Helper to safely extract Parcelables, handling OS version differences
+     * and catching potential unparcelling exceptions.
      */
-    private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableExtra(name: String): T? {
+    private inline fun <T> safeParcelableExtraction(
+        tiramisuExtractor: () -> T?,
+        legacyExtractor: () -> T?
+    ): T? {
         return try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                getParcelableExtra(name, T::class.java)
+                tiramisuExtractor()
             } else {
-                @Suppress("DEPRECATION")
-                getParcelableExtra(name) as? T
+                legacyExtractor()
             }
         } catch (e: Exception) {
             null
@@ -356,18 +358,29 @@ class MainActivity : FragmentActivity() {
     }
 
     /**
+     * Safely extracts a Parcelable extra from an Intent, handling OS version differences
+     * and catching potential unparcelling exceptions (e.g., BadParcelableException).
+     */
+    private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableExtra(name: String): T? {
+        return safeParcelableExtraction(
+            tiramisuExtractor = { getParcelableExtra(name, T::class.java) },
+            legacyExtractor = {
+                @Suppress("DEPRECATION")
+                getParcelableExtra(name) as? T
+            }
+        )
+    }
+
+    /**
      * Safely extracts a Parcelable ArrayList extra from an Intent.
      */
     private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableArrayListExtra(name: String): java.util.ArrayList<T>? {
-        return try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                getParcelableArrayListExtra(name, T::class.java)
-            } else {
+        return safeParcelableExtraction(
+            tiramisuExtractor = { getParcelableArrayListExtra(name, T::class.java) },
+            legacyExtractor = {
                 @Suppress("DEPRECATION")
                 getParcelableArrayListExtra<T>(name)
             }
-        } catch (e: Exception) {
-            null
-        }
+        )
     }
 }


### PR DESCRIPTION
🎯 What failure mode was addressed:
The code duplicated OS version checks (`Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU`) and `try-catch` blocks across multiple methods for parsing `Parcelable` and `ArrayList<Parcelable>` extras from incoming Intents. This violates CodeScene's "Code Duplication" advisory rule and increases the risk of future additions omitting the critical `try-catch` wrapper needed to prevent `BadParcelableException` crashes.

🛠️ What changed:
Extracted the duplicated logic into a unified `safeParcelableExtraction` helper method in `MainActivity.kt`. 

🛡️ Why the fix is low-risk:
The new helper is marked as `inline` to ensure reified generics passed at the call sites continue to resolve correctly at compile-time without adding reflection overhead or breaking type inference. Runtime behavior is 100% functionally identical to the previous implementation.

✅ How it was validated:
- Local build passed (`./gradlew :androidApp:compileDebugKotlin --no-daemon`) after adding a mock `google-services.json`.
- Full project test suite passed (`./gradlew test :shared:allTests :composeApp:allTests --no-daemon`).
- Automated code review confirmed safety and functionality parity.

---
*PR created automatically by Jules for task [16101461330983905340](https://jules.google.com/task/16101461330983905340) started by @tajemniktv*