### PR TITLE
test: Strengthen DomainLensQueries coverage for missing branches

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
@@ -136,7 +136,7 @@ class DomainLensQueriesEdgeTest {
     }
 
     @Test
-    fun sorting_financeDeadlineItems_places_null_dueAt_last() {
+    fun sorting_financeDeadlineItems_sorts_by_dueAt_ascending() {
         // Technically this list won't contain nulls because the filter says: it.node.dueAt != null
         val deadlineLater = createNode(2, "Finance item", dueAt = 2000L)
         val deadlineEarlier = createNode(3, "Finance item", dueAt = 1000L)

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
@@ -121,4 +121,116 @@ class DomainLensQueriesEdgeTest {
         assertEquals(setOf(1L, 2L), result.map { it.node.id }.toSet())
     }
 
+    @Test
+    fun matchesHealthSignal_healthNoteType_no_keywords_matches() {
+        val node = createNode(1, "Daily thoughts", "just another day", type = "note", noteType = "reflection")
+        val result = DomainLensQueries.healthKnowledgeItems(listOf(node))
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun matchesHealthSignal_healthMaintenance_matches() {
+        val node = createNode(1, "Go to doctor", maintenanceType = "appointment")
+        val result = DomainLensQueries.healthActionItems(listOf(node))
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun sorting_financeDeadlineItems_places_null_dueAt_last() {
+        // Technically this list won't contain nulls because the filter says: it.node.dueAt != null
+        val deadlineLater = createNode(2, "Finance item", dueAt = 2000L)
+        val deadlineEarlier = createNode(3, "Finance item", dueAt = 1000L)
+
+        val result = DomainLensQueries.financeDeadlineItems(listOf(deadlineLater, deadlineEarlier))
+        assertEquals(listOf(3L, 2L), result.map { it.node.id })
+    }
+
+    @Test
+    fun sorting_healthKnowledgeItems_sorts_by_updatedAt_descending() {
+        val oldNote = createNode(1, "Health log", updatedAt = 100L, type = "note", tags = listOf("health"))
+        val newNote = createNode(2, "Health update", updatedAt = 300L, type = "note", tags = listOf("health"))
+        val medNote = createNode(3, "Health thoughts", updatedAt = 200L, type = "note", tags = listOf("health"))
+
+        val result = DomainLensQueries.healthKnowledgeItems(listOf(oldNote, newNote, medNote))
+        assertEquals(listOf(2L, 3L, 1L), result.map { it.node.id })
+    }
+
+    @Test
+    fun financeDeadlineItems_excludes_inactive_or_null_dueAt_items() {
+        val activeWithDate = createNode(1, "Finance item", dueAt = 1000L, status = "active", tags = listOf("finance"))
+        val inactiveWithDate = createNode(2, "Finance item", dueAt = 1000L, status = "done", tags = listOf("finance"))
+        val activeNoDate = createNode(3, "Finance item", status = "active", tags = listOf("finance"))
+
+        val result = DomainLensQueries.financeDeadlineItems(listOf(activeWithDate, inactiveWithDate, activeNoDate))
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.id)
+    }
+
+    @Test
+    fun matchesFinanceSignal_is_case_insensitive() {
+        val uppercaseTag = createNode(1, "Item", tags = listOf("FINANCE"))
+        val mixedCaseKeyword = createNode(2, "Pay The INvOICe", "")
+
+        val result = DomainLensQueries.financeActionItems(listOf(uppercaseTag, mixedCaseKeyword))
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun matchesHealthSignal_is_case_insensitive() {
+        val uppercaseTag = createNode(1, "Item", tags = listOf("HEALTH"))
+        val mixedCaseKeyword = createNode(2, "See the DoCtoR", "")
+
+        val result = DomainLensQueries.healthActionItems(listOf(uppercaseTag, mixedCaseKeyword))
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun sorting_financeActionItems_uses_distinct_timestamps_and_places_nulls_last() {
+        val noDate1 = createNode(1, "Finance item")
+        val noDate2 = createNode(2, "Finance item")
+        val later = createNode(3, "Finance item", dueAt = 3000L)
+        val earlier = createNode(4, "Finance item", dueAt = 1000L)
+        val middle = createNode(5, "Finance item", dueAt = 2000L)
+
+        val result = DomainLensQueries.financeActionItems(listOf(noDate1, noDate2, later, earlier, middle))
+        // Expect exact sorted order by approaching deadline, and nulls at the end. Since noDate1 and noDate2 both resolve to Long.MAX_VALUE, their relative order is stable.
+        val ids = result.map { it.node.id }
+        assertEquals(listOf(4L, 5L, 3L, 1L, 2L), ids)
+    }
+
+
+    @Test
+    fun financeMaintenanceItems_handles_empty_active_and_wrong_domain() {
+        val snapshot = com.tajemniktv.tajsos.ui.MaintenanceSnapshot(
+            active = listOf(
+                com.tajemniktv.tajsos.ui.MaintenanceStatusItem(
+                    node = createNode(1, "Unrelated", maintenanceType = "random_chore"),
+                    urgency = "low",
+                    isRecurring = false
+                )
+            ),
+            recurring = emptyList(),
+            overdue = emptyList()
+        )
+        val result = DomainLensQueries.financeMaintenanceItems(snapshot)
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun healthMaintenanceItems_handles_empty_active_and_wrong_domain() {
+         val snapshot = com.tajemniktv.tajsos.ui.MaintenanceSnapshot(
+            active = listOf(
+                com.tajemniktv.tajsos.ui.MaintenanceStatusItem(
+                    node = createNode(1, "Unrelated", maintenanceType = "random_chore"),
+                    urgency = "low",
+                    isRecurring = false
+                )
+            ),
+            recurring = emptyList(),
+            overdue = emptyList()
+        )
+        val result = DomainLensQueries.healthMaintenanceItems(snapshot)
+        assertEquals(0, result.size)
+    }
+
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
@@ -199,9 +199,12 @@ class DomainLensQueriesEdgeTest {
     }
 
 
-    @Test
-    fun financeMaintenanceItems_handles_empty_active_and_wrong_domain() {
-        val snapshot = com.tajemniktv.tajsos.ui.MaintenanceSnapshot(
+
+
+
+
+    private fun createUnrelatedMaintenanceSnapshot(): com.tajemniktv.tajsos.ui.MaintenanceSnapshot {
+        return com.tajemniktv.tajsos.ui.MaintenanceSnapshot(
             active = listOf(
                 com.tajemniktv.tajsos.ui.MaintenanceStatusItem(
                     node = createNode(1, "Unrelated", maintenanceType = "random_chore"),
@@ -212,25 +215,19 @@ class DomainLensQueriesEdgeTest {
             recurring = emptyList(),
             overdue = emptyList()
         )
+    }
+
+    @Test
+    fun financeMaintenanceItems_handles_empty_active_and_wrong_domain() {
+        val snapshot = createUnrelatedMaintenanceSnapshot()
         val result = DomainLensQueries.financeMaintenanceItems(snapshot)
         assertEquals(0, result.size)
     }
 
     @Test
     fun healthMaintenanceItems_handles_empty_active_and_wrong_domain() {
-         val snapshot = com.tajemniktv.tajsos.ui.MaintenanceSnapshot(
-            active = listOf(
-                com.tajemniktv.tajsos.ui.MaintenanceStatusItem(
-                    node = createNode(1, "Unrelated", maintenanceType = "random_chore"),
-                    urgency = "low",
-                    isRecurring = false
-                )
-            ),
-            recurring = emptyList(),
-            overdue = emptyList()
-        )
+        val snapshot = createUnrelatedMaintenanceSnapshot()
         val result = DomainLensQueries.healthMaintenanceItems(snapshot)
         assertEquals(0, result.size)
     }
-
 }


### PR DESCRIPTION
🎯 What
Adds missing edge case test coverage for DomainLensQueries to strengthen resilience around boundary inputs.

📊 Coverage
- Handling of null or absent timestamps (`financeDeadlineItems`, sorting constraints).
- Case insensitivity when matching heuristic tags and content keywords for finance and health domains.
- Safely handling snapshots lacking matches or populated with unrelated domains in maintenance lists.

✨ Result
Expanded test robustness ensuring that DomainLensQueries handles edge inputs predictably without failure, improving raw coverage and regression safety.

---
*PR created automatically by Jules for task [4287368039026547345](https://jules.google.com/task/4287368039026547345) started by @tajemniktv*