### PR TITLE
docs: Add missing KDocs for core action dispatchers and MainViewModel

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -131,7 +131,7 @@ import kotlin.time.Clock
  *
  * @property repository The [AppRepository] acting as the single source of truth for the local database.
  * @property preferencesRepository The [PreferencesRepository] handling app configuration and user settings.
- * @property calendarManager The [CalendarManager] responsible for fetching and synchronizing calendar events.
+ * @property calendarManager The [com.tajemniktv.tajsos.calendar.CalendarManager] responsible for fetching and synchronizing calendar events.
  * @property nextStepFallbackLabel Default label for generated next-step nodes.
  * @property untitledFallbackLabel Default label for nodes created without a title.
  */

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -124,6 +124,17 @@ import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.json.Json
 import kotlin.time.Clock
 
+/**
+ * The central ViewModel coordinating the primary UI state and user interactions for TajsOS.
+ *
+ * It aggregates data from the repository, exposes state snapshots for rendering, and delegates action handling to specialized command classes.
+ *
+ * @property repository The [AppRepository] acting as the single source of truth for the local database.
+ * @property preferencesRepository The [PreferencesRepository] handling app configuration and user settings.
+ * @property calendarManager The [CalendarManager] responsible for fetching and synchronizing calendar events.
+ * @property nextStepFallbackLabel Default label for generated next-step nodes.
+ * @property untitledFallbackLabel Default label for nodes created without a title.
+ */
 @Stable
 class MainViewModel(
     private val repository: AppRepository,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
@@ -24,6 +24,20 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 
+/**
+ * A core command dispatcher responsible for executing state changes and maintenance operations on nodes.
+ *
+ * This class orchestrates operations like sweeping stale tasks, shifting items to the inbox, and generating recurring node instances.
+ *
+ * @property repository The [AppRepository] used for direct database updates.
+ * @property scope The [CoroutineScope] in which all asynchronous database operations execute.
+ * @property currentTodayNodes A lambda supplier providing real-time access to the list of active nodes for today.
+ * @property currentAllNodes A lambda supplier providing real-time access to the list of all active nodes.
+ * @property parseInternalLinks A lambda function injected to trigger internal link parsing on a node.
+ * @property setTagOnNode A suspended lambda function injected to attach or detach string tags on a node.
+ * @property defaultNextStepLabel A lambda providing the default title for next step nodes.
+ * @property defaultUntitledLabel A lambda providing the default title for untitled nodes.
+ */
 class NodeCommands(
     private val repository: AppRepository,
     private val scope: CoroutineScope,


### PR DESCRIPTION
Adds missing KDocs to the `MainViewModel` and `NodeCommands` classes to clearly define their intent, assumptions, and properties. These classes act as central command dispatchers for the UI and lack class-level documentation, which increases the onboarding friction.

**What Changed**:
- Added class-level KDoc to `MainViewModel` detailing its role as the central state coordinator.
- Added class-level KDoc to `NodeCommands` detailing its orchestration of stale task sweeps, recurring nodes, and inbox management.

**Why the Change Reduces Risk**:
By documenting these foundational public classes, future maintainers can immediately understand their intended purpose without reverse-engineering the codebase.

**How it was Validated**:
Manual verification via `git diff`. (Automated module tests failed locally due to an unrelated environment JVM mismatch, but these changes are purely documentation comments).

---
*PR created automatically by Jules for task [10798685774020570696](https://jules.google.com/task/10798685774020570696) started by @tajemniktv*