### PR TITLE
fix(ui): Polish empty states

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 
 /**
  * Premium "system-monitor" notification card with futuristic aesthetics.
@@ -218,19 +219,13 @@ fun TajsNotificationWidget(
         }
 
         if (notifications.isEmpty()) {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = TajsOSTheme.SpacingLg),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    "No active system alerts.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = TajsOSTheme.Muted.copy(alpha = 0.5f),
-                )
-            }
+            EmptyState(
+                message = "No active system alerts.",
+                description = null,
+                fillParent = false,
+                showContainer = false,
+                modifier = Modifier.padding(vertical = TajsOSTheme.SpacingLg),
+            )
         } else {
             notifications.forEach { notification ->
                 TajsNotificationCard(notification = notification)

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt
@@ -48,6 +48,7 @@ import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.cal_agenda_title
 import kotlin.time.Clock
 import kotlin.time.Instant
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 
 object CalendarDashboardBlocks {
     private val renderers: Map<String, CalendarDashboardBlockRenderer> =
@@ -217,10 +218,11 @@ internal fun CalendarMainBlock(
                                 )
                             }
                             if (pendingNodes.isEmpty()) {
-                                Text(
-                                    "No pending nodes due soon.",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = TajsOSTheme.Muted,
+                                EmptyState(
+                                    message = "No pending nodes due soon.",
+                                    description = null,
+                                    fillParent = false,
+                                    showContainer = false,
                                 )
                             } else {
                                 pendingNodes.forEach { node ->

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
@@ -73,6 +73,7 @@ import tajsos.composeapp.generated.resources.profile_select_avatar
 import tajsos.composeapp.generated.resources.profile_time_zone
 import tajsos.composeapp.generated.resources.profile_unsaved
 import tajsos.composeapp.generated.resources.profile_website
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 
 private val profileBlockRenderers: Map<String, ProfileDashboardBlockRenderer> =
     mapOf(
@@ -397,10 +398,11 @@ private fun renderMedicationsModuleBlock(context: ProfileScreenContext) {
             }
         }
         if (context.medications.isEmpty()) {
-            Text(
-                "No medication entries configured.",
-                style = MaterialTheme.typography.bodySmall,
-                color = TajsOSTheme.Muted,
+            EmptyState(
+                message = "No medication entries configured.",
+                description = null,
+                fillParent = false,
+                showContainer = false,
             )
         } else {
             context.medications.forEach { med ->

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -75,6 +75,7 @@ import tajsos.composeapp.generated.resources.settings_force_crash
 import tajsos.composeapp.generated.resources.settings_theme_mode
 import tajsos.composeapp.generated.resources.settings_theme_mode_desc
 import tajsos.composeapp.generated.resources.settings_theme_settings
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 
 object SettingsDashboardBlocks {
     private val renderers: Map<String, SettingsDashboardBlockRenderer> =
@@ -119,10 +120,11 @@ private fun renderSettingsHealth(context: SettingsDashboardContext) {
         Spacer(Modifier.height(TajsOSTheme.SpacingMd))
 
         if (context.medications.isEmpty()) {
-            Text(
-                "No medication entries configured yet.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = TajsOSTheme.Muted,
+            EmptyState(
+                message = "No medication entries configured yet.",
+                description = null,
+                fillParent = false,
+                showContainer = false,
             )
         } else {
             context.medications.forEach { medication ->

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -99,42 +99,9 @@ private fun renderSettingsHealth(context: SettingsDashboardContext) {
         title = "HEALTH",
         description = "Manage medications used by tracking and health workflows.",
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                stringResource(Res.string.profile_medications),
-                style = MaterialTheme.typography.titleMedium,
-                color = TajsOSTheme.Text,
-            )
-            OutlinedButton(
-                onClick = { showAddMedicationDialog = true },
-                shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
-            ) {
-                Text(stringResource(Res.string.profile_add_med))
-            }
-        }
-
+        SettingsHealthHeader(onAddMedicationClick = { showAddMedicationDialog = true })
         Spacer(Modifier.height(TajsOSTheme.SpacingMd))
-
-        if (context.medications.isEmpty()) {
-            EmptyState(
-                message = "No medication entries configured yet.",
-                description = null,
-                fillParent = false,
-                showContainer = false,
-            )
-        } else {
-            context.medications.forEach { medication ->
-                SettingsMedicationItem(
-                    medication = medication,
-                    onDelete = { context.onDeleteMedication(medication) },
-                )
-                Spacer(Modifier.height(TajsOSTheme.SpacingSm))
-            }
-        }
+        SettingsHealthMedicationList(context = context)
     }
 
     if (showAddMedicationDialog) {
@@ -145,6 +112,47 @@ private fun renderSettingsHealth(context: SettingsDashboardContext) {
                 showAddMedicationDialog = false
             },
         )
+    }
+}
+
+@Composable
+private fun SettingsHealthHeader(onAddMedicationClick: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            stringResource(Res.string.profile_medications),
+            style = MaterialTheme.typography.titleMedium,
+            color = TajsOSTheme.Text,
+        )
+        OutlinedButton(
+            onClick = onAddMedicationClick,
+            shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
+        ) {
+            Text(stringResource(Res.string.profile_add_med))
+        }
+    }
+}
+
+@Composable
+private fun SettingsHealthMedicationList(context: SettingsDashboardContext) {
+    if (context.medications.isEmpty()) {
+        EmptyState(
+            message = "No medication entries configured yet.",
+            description = null,
+            fillParent = false,
+            showContainer = false,
+        )
+    } else {
+        context.medications.forEach { medication ->
+            SettingsMedicationItem(
+                medication = medication,
+                onDelete = { context.onDeleteMedication(medication) },
+            )
+            Spacer(Modifier.height(TajsOSTheme.SpacingSm))
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
@@ -274,82 +274,108 @@ private fun renderTimeCadenceAnchors(context: TimeArchitectureDashboardContext) 
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingMd),
     ) {
-        Surface(
+        TimeArchitectureCadenceCard(
             modifier = Modifier.weight(1f),
-            color = TajsOSTheme.SurfaceLow,
-            shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-            border = BorderStroke(1.dp, TajsOSTheme.GhostBorder.copy(alpha = 0.15f)),
+            snapshot = snapshot,
+            onRunMonthlyReset = { viewModel.runMonthlyReset() }
+        )
+
+        TimeArchitectureAnchorsCard(
+            modifier = Modifier.weight(1f),
+            snapshot = snapshot,
+            onAddAnchor = { viewModel.addLifePeriodMarker("New period marker") }
+        )
+    }
+}
+
+@Composable
+private fun TimeArchitectureCadenceCard(
+    modifier: Modifier = Modifier,
+    snapshot: com.tajemniktv.tajsos.ui.TimeArchitectureSnapshot,
+    onRunMonthlyReset: () -> Unit
+) {
+    Surface(
+        modifier = modifier,
+        color = TajsOSTheme.SurfaceLow,
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
+        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder.copy(alpha = 0.15f)),
+    ) {
+        Column(
+            modifier = Modifier.padding(TajsOSTheme.SpacingMd),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            Column(
-                modifier = Modifier.padding(TajsOSTheme.SpacingMd),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
+            Text(
+                "Resets & Cadence",
+                style = MaterialTheme.typography.headlineSmall,
+                color = TajsOSTheme.Text,
+            )
+            CadenceRow(
+                title = "Daily startup",
+                detail = "${snapshot.todayLayer.size} items in today's horizon",
+                status = "Active",
+            )
+            CadenceRow(
+                title = "Weekly alignment",
+                detail = "${snapshot.weekLayer.size} items mapped this week",
+                status = "Live",
+            )
+            CadenceRow(
+                title = "Monthly reset",
+                detail = if (snapshot.monthlyResetDate.isNotBlank()) snapshot.monthlyResetDate else "Not set",
+                status = "Pending",
+            )
+            Button(onClick = onRunMonthlyReset) {
+                Text("Run Monthly Reset")
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimeArchitectureAnchorsCard(
+    modifier: Modifier = Modifier,
+    snapshot: com.tajemniktv.tajsos.ui.TimeArchitectureSnapshot,
+    onAddAnchor: () -> Unit
+) {
+    Surface(
+        modifier = modifier,
+        color = TajsOSTheme.SurfaceLow,
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
+        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder.copy(alpha = 0.15f)),
+    ) {
+        Column(
+            modifier = Modifier.padding(TajsOSTheme.SpacingMd),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    "Resets & Cadence",
+                    "Temporal Anchors",
                     style = MaterialTheme.typography.headlineSmall,
                     color = TajsOSTheme.Text,
                 )
-                CadenceRow(
-                    title = "Daily startup",
-                    detail = "${snapshot.todayLayer.size} items in today's horizon",
-                    status = "Active",
+                AssistChip(
+                    onClick = onAddAnchor,
+                    label = { Text("Add Anchor") },
                 )
-                CadenceRow(
-                    title = "Weekly alignment",
-                    detail = "${snapshot.weekLayer.size} items mapped this week",
-                    status = "Live",
-                )
-                CadenceRow(
-                    title = "Monthly reset",
-                    detail = if (snapshot.monthlyResetDate.isNotBlank()) snapshot.monthlyResetDate else "Not set",
-                    status = "Pending",
-                )
-                Button(onClick = { viewModel.runMonthlyReset() }) {
-                    Text("Run Monthly Reset")
-                }
             }
-        }
-
-        Surface(
-            modifier = Modifier.weight(1f),
-            color = TajsOSTheme.SurfaceLow,
-            shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-            border = BorderStroke(1.dp, TajsOSTheme.GhostBorder.copy(alpha = 0.15f)),
-        ) {
-            Column(
-                modifier = Modifier.padding(TajsOSTheme.SpacingMd),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                ) {
-                    Text(
-                        "Temporal Anchors",
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = TajsOSTheme.Text,
+            val anchorRows = snapshot.buildAnchorRows()
+            if (anchorRows.isEmpty()) {
+                EmptyState(
+                    message = "No anchor markers yet.",
+                    description = null,
+                    fillParent = false,
+                    showContainer = false,
+                )
+            } else {
+                anchorRows.take(6).forEach { anchor ->
+                    AnchorRow(
+                        title = anchor.title,
+                        coordinate = anchor.coordinate,
+                        level = anchor.level,
                     )
-                    AssistChip(
-                        onClick = { viewModel.addLifePeriodMarker("New period marker") },
-                        label = { Text("Add Anchor") },
-                    )
-                }
-                val anchorRows = snapshot.buildAnchorRows()
-                if (anchorRows.isEmpty()) {
-                    EmptyState(
-                        message = "No anchor markers yet.",
-                        description = null,
-                        fillParent = false,
-                        showContainer = false,
-                    )
-                } else {
-                    anchorRows.take(6).forEach { anchor ->
-                        AnchorRow(
-                            title = anchor.title,
-                            coordinate = anchor.coordinate,
-                            level = anchor.level,
-                        )
-                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
@@ -50,6 +50,7 @@ import tajsos.composeapp.generated.resources.time_architecture_reserve_tracked
 import tajsos.composeapp.generated.resources.time_architecture_reserve_window
 import tajsos.composeapp.generated.resources.time_architecture_status_summary
 import tajsos.composeapp.generated.resources.time_architecture_title
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 
 object TimeArchitectureDashboardBlocks {
     private val renderers: Map<String, TimeArchitectureDashboardBlockRenderer> =
@@ -335,10 +336,11 @@ private fun renderTimeCadenceAnchors(context: TimeArchitectureDashboardContext) 
                 }
                 val anchorRows = snapshot.buildAnchorRows()
                 if (anchorRows.isEmpty()) {
-                    Text(
-                        "No anchor markers yet.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = TajsOSTheme.Muted,
+                    EmptyState(
+                        message = "No anchor markers yet.",
+                        description = null,
+                        fillParent = false,
+                        showContainer = false,
                     )
                 } else {
                     anchorRows.take(6).forEach { anchor ->

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
@@ -614,7 +614,7 @@ private data class AnchorMarkerRow(
     val level: String,
 )
 
-private fun TimeArchitectureSnapshot.buildAnchorRows(): List<AnchorMarkerRow> {
+private fun com.tajemniktv.tajsos.ui.TimeArchitectureSnapshot.buildAnchorRows(): List<AnchorMarkerRow> {
     val markerRows =
         lifePeriodMarkers.map { marker ->
             AnchorMarkerRow(


### PR DESCRIPTION
## What user-facing friction was improved
Many empty states in secondary views (e.g., empty calendars, notifications, settings) used generic raw text, leading to a fragmented, unpolished user experience. 

## Where the change appears
The empty states across the Notification widget, Calendar agenda view, Profile medications block, Settings medications list, and Time Architecture anchor lists.

## Why the change matches existing UX patterns
The application already has a centralized, robust `EmptyState` component used extensively across primary dashboard views (like Tasks, Notes, Vaults) which provides consistent styling and animated icon hints. This PR brings the secondary screens inline with that established pattern.

## How it was validated
- Verified code logic locally.
- Extensively ran `compileKotlinJvm` and `allTests` modules ensuring the refactor didn't introduce syntax regressions or behavioral changes.
- Checked automated PR review for structural compliance.

---
*PR created automatically by Jules for task [17922885067292884095](https://jules.google.com/task/17922885067292884095) started by @tajemniktv*