### PR TITLE
fix: Prevent crash on malformed Intent Parcelable extraction

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -349,38 +349,40 @@ class MainActivity : FragmentActivity() {
      * Safely extracts a Parcelable extra from an Intent, handling OS version differences
      * and catching potential unparcelling exceptions (e.g., BadParcelableException).
      */
-    private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableExtra(name: String): T? =
+    private inline fun <T> safeIntentExtraction(name: String, block: () -> T?): T? =
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                getParcelableExtra(name, T::class.java)
-            } else {
-                @Suppress("DEPRECATION")
-                getParcelableExtra(name) as? T
-            }
+            block()
         } catch (e: BadParcelableException) {
             Log.e(TAG, "Failed to read parcelable extra: $name", e)
             null
         } catch (e: ParcelFormatException) {
             Log.e(TAG, "Failed to read parcelable extra (bad parcel format): $name", e)
             null
+        } catch (e: ClassCastException) {
+            Log.e(TAG, "Failed to read parcelable extra (class cast): $name", e)
+            null
+        }
+
+    private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableExtra(name: String): T? =
+        safeIntentExtraction(name) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                getParcelableExtra(name, T::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                getParcelableExtra(name) as? T
+            }
         }
 
     /**
      * Safely extracts a Parcelable ArrayList extra from an Intent.
      */
     private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableArrayListExtra(name: String): java.util.ArrayList<T>? =
-        try {
+        safeIntentExtraction(name) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 getParcelableArrayListExtra(name, T::class.java)
             } else {
                 @Suppress("DEPRECATION")
                 getParcelableArrayListExtra<T>(name)
             }
-        } catch (e: BadParcelableException) {
-            Log.e(TAG, "Failed to read parcelable array list extra: $name", e)
-            null
-        } catch (e: ParcelFormatException) {
-            Log.e(TAG, "Failed to read parcelable array list extra (bad parcel format): $name", e)
-            null
         }
 }


### PR DESCRIPTION
What risk was reduced:
Reduced the risk of Local Denial of Service via Intent Spoofing. Previously, extracting `Parcelable` data from incoming Intents (`getParcelableExtra` / `getParcelableArrayListExtra`) could crash the application (e.g., throwing a `ClassCastException`) if an untrusted source sent an Intent with an unexpected extra type.

What changed:
Extracted the duplicated `try-catch` wrapper for Intent extraction in `MainActivity.kt` into a single private inline helper function `safeIntentExtraction`. Added a catch block for `ClassCastException` to this new helper, alongside the existing `BadParcelableException` and `ParcelFormatException` handlers. Updated the existing extension functions to use this shared helper.

Why the change is low-risk:
The change utilizes an inline function, so it has negligible performance impact and does not change the core execution path. Catching the exception and returning `null` safely allows the existing downstream logic (which already gracefully handles nulls via safe calls like `?.let`) to proceed without crashing the app.

How it was validated:
Compiled the `:androidApp` module to ensure syntax and Android API compatibility, and ran the global test suite (`./gradlew test --no-daemon`) to ensure no regressions were introduced. Evaluated manually that the null return behaves identically to the existing code's behavior on bad parcelables.

---
*PR created automatically by Jules for task [5235345284817974984](https://jules.google.com/task/5235345284817974984) started by @tajemniktv*