### PR TITLE
test: Add edge tests for DomainLensQueries overdue and deadline logic

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesDeadlineItemsEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesDeadlineItemsEdgeTest.kt
@@ -1,0 +1,70 @@
+package com.tajemniktv.tajsos.domain.lens
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.data.TagEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DomainLensQueriesDeadlineItemsEdgeTest {
+    private fun createNode(
+        id: Long,
+        title: String,
+        content: String = "",
+        type: String = "task",
+        status: String = "active",
+        tags: List<String> = emptyList(),
+        maintenanceType: String? = null,
+        noteType: String? = null,
+        dueAt: Long? = null,
+        updatedAt: Long = 0L,
+    ): NodeWithPin {
+        return NodeWithPin(
+            node = NodeEntity(
+                id = id,
+                title = title,
+                content = content,
+                type = type,
+                status = status,
+                maintenanceType = maintenanceType,
+                noteType = noteType,
+                dueAt = dueAt,
+                updatedAt = updatedAt,
+            ),
+            pin = null,
+            tags = tags.mapIndexed { index, tag -> TagEntity(id = index.toLong(), name = tag, normalizedName = tag.lowercase()) },
+        )
+    }
+
+    @Test
+    fun financeDeadlineItems_includes_only_items_with_due_date_and_sorts_correctly() {
+        // Includes notes, tasks, etc., as long as it has dueAt and matches finance signal
+        val noteNoDate = createNode(1, "Tax stuff", type = "note", dueAt = null, tags = listOf("finance"))
+        val taskNoDate = createNode(2, "Pay bills", type = "task", dueAt = null, tags = listOf("finance"))
+        val recordNoDate = createNode(3, "Budget record", type = "record", dueAt = null, tags = listOf("finance"))
+
+        val taskLater = createNode(4, "Pay more bills", type = "task", dueAt = 5000L, tags = listOf("finance"))
+        val taskEarlier = createNode(5, "Urgent tax", type = "task", dueAt = 1000L, tags = listOf("finance"))
+        val noteMiddle = createNode(6, "Important finance note", type = "note", dueAt = 3000L, tags = listOf("finance"))
+
+        val unrelatedTask = createNode(7, "Grocery list", type = "task", dueAt = 1000L) // No finance signal
+
+        val allNodes = listOf(noteNoDate, taskNoDate, recordNoDate, taskLater, taskEarlier, noteMiddle, unrelatedTask)
+
+        val result = DomainLensQueries.financeDeadlineItems(allNodes)
+
+        // Should only include items with a due date that match the finance signal
+        assertEquals(3, result.size)
+
+        // Items without due dates or unrelated items should be excluded completely
+        val resultIds = result.map { it.node.id }
+        assertTrue(!resultIds.contains(1L))
+        assertTrue(!resultIds.contains(2L))
+        assertTrue(!resultIds.contains(3L))
+        assertTrue(!resultIds.contains(7L))
+
+        // Sort order should be earlier deadline first
+        assertEquals(listOf(5L, 6L, 4L), resultIds)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesOverdueItemsEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesOverdueItemsEdgeTest.kt
@@ -1,0 +1,70 @@
+package com.tajemniktv.tajsos.domain.lens
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.ui.MaintenanceSnapshot
+import com.tajemniktv.tajsos.ui.MaintenanceStatusItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DomainLensQueriesOverdueItemsEdgeTest {
+    private fun createMaintenanceItem(
+        id: Long,
+        maintenanceType: String?,
+        title: String = "Test Item"
+    ): MaintenanceStatusItem {
+        return MaintenanceStatusItem(
+            node = NodeWithPin(
+                node = NodeEntity(
+                    id = id,
+                    title = title,
+                    type = "maintenance",
+                    maintenanceType = maintenanceType,
+                    status = "active"
+                ),
+                pin = null,
+                tags = emptyList()
+            ),
+            urgency = "high",
+            isRecurring = true
+        )
+    }
+
+    @Test
+    fun financeOverdueItems_filters_by_maintenance_type() {
+        val financeBill = createMaintenanceItem(1, "bill")
+        val financeSubscription = createMaintenanceItem(2, "subscription")
+        val healthPrescription = createMaintenanceItem(3, "prescription")
+        val unknownType = createMaintenanceItem(4, "unknown_type")
+
+        // They are all overdue
+        val snapshot = MaintenanceSnapshot(
+            active = emptyList(),
+            recurring = emptyList(),
+            overdue = listOf(financeBill, financeSubscription, healthPrescription, unknownType)
+        )
+
+        val result = DomainLensQueries.financeOverdueItems(snapshot)
+        assertEquals(2, result.size)
+        assertEquals(listOf(1L, 2L).sorted(), result.map { it.node.node.id }.sorted())
+    }
+
+    @Test
+    fun healthOverdueItems_filters_by_maintenance_type() {
+        val financeBill = createMaintenanceItem(1, "bill")
+        val healthAppointment = createMaintenanceItem(2, "appointment")
+        val healthPrescription = createMaintenanceItem(3, "prescription")
+        val unknownType = createMaintenanceItem(4, "unknown_type")
+
+        // They are all overdue
+        val snapshot = MaintenanceSnapshot(
+            active = emptyList(),
+            recurring = emptyList(),
+            overdue = listOf(financeBill, healthAppointment, healthPrescription, unknownType)
+        )
+
+        val result = DomainLensQueries.healthOverdueItems(snapshot)
+        assertEquals(2, result.size)
+        assertEquals(listOf(2L, 3L).sorted(), result.map { it.node.node.id }.sorted())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesOverdueItemsEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesOverdueItemsEdgeTest.kt
@@ -46,7 +46,7 @@ class DomainLensQueriesOverdueItemsEdgeTest {
 
         val result = DomainLensQueries.financeOverdueItems(snapshot)
         assertEquals(2, result.size)
-        assertEquals(listOf(1L, 2L).sorted(), result.map { it.node.node.id }.sorted())
+        assertEquals(setOf(1L, 2L), result.map { it.node.node.id }.toSet())
     }
 
     @Test
@@ -65,6 +65,6 @@ class DomainLensQueriesOverdueItemsEdgeTest {
 
         val result = DomainLensQueries.healthOverdueItems(snapshot)
         assertEquals(2, result.size)
-        assertEquals(listOf(2L, 3L).sorted(), result.map { it.node.node.id }.sorted())
+        assertEquals(setOf(2L, 3L), result.map { it.node.node.id }.toSet())
     }
 }


### PR DESCRIPTION
Added edge tests to verify the behavior of `financeOverdueItems`, `healthOverdueItems`, and `financeDeadlineItems` in `DomainLensQueries`.

---
*PR created automatically by Jules for task [7659195993473554666](https://jules.google.com/task/7659195993473554666) started by @tajemniktv*