### PR TITLE
docs: Add missing KDoc to FilterHelper and SidebarMode

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/FilterHelper.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/FilterHelper.kt
@@ -199,6 +199,17 @@ object FilterHelper {
         }
     }
 
+    /**
+     * Calculates a relevance score for a node based on how well it matches a given query.
+     *
+     * The score is determined by factors such as exact title match, title prefix match,
+     * title inclusion, content inclusion, tag matches, and whether the node is pinned
+     * or currently active.
+     *
+     * @param nodeWithPin The wrapper object containing the node entity and its associated tags.
+     * @param query The clean query string to evaluate against.
+     * @return An integer score representing the node's relevance. Higher is better.
+     */
     private fun relevanceScore(
         nodeWithPin: NodeWithPin,
         query: String,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/FilterHelper.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/FilterHelper.kt
@@ -207,7 +207,7 @@ object FilterHelper {
      * or currently active.
      *
      * @param nodeWithPin The wrapper object containing the node entity and its associated tags.
-     * @param query The clean query string to evaluate against.
+     * @param query The query string to evaluate against (will be trimmed and lowercased).
      * @return An integer score representing the node's relevance. Higher is better.
      */
     private fun relevanceScore(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/SidebarMode.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/SidebarMode.kt
@@ -8,7 +8,16 @@ package com.tajemniktv.tajsos.ui
  * Sidebar behavior modes supported by the shell.
  */
 enum class SidebarMode {
+    /**
+     * Sidebar is fully visible, taking up horizontal space.
+     */
     EXPANDED,
+    /**
+     * Sidebar is minimized to an icon-only strip to save horizontal space.
+     */
     COLLAPSED,
+    /**
+     * Sidebar is collapsed but temporarily overlays content when hovered.
+     */
     HOVER_EXPAND,
 }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/SidebarMode.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/SidebarMode.kt
@@ -17,7 +17,7 @@ enum class SidebarMode {
      */
     COLLAPSED,
     /**
-     * Sidebar is collapsed but temporarily overlays content when hovered.
+     * Sidebar is collapsed but temporarily expands when hovered.
      */
     HOVER_EXPAND,
 }


### PR DESCRIPTION
# What user-facing friction was improved
Added missing KDoc to critical shared codebase files to reduce onboarding and maintenance friction.

# What changed
- Added comprehensive KDoc to `relevanceScore` in `FilterHelper.kt` detailing scoring logic.
- Added KDoc for `SidebarMode` enum values in `SidebarMode.kt` describing their visual behavior.

# Why the change matches existing UX patterns
These additions clarify intent, contract, and non-obvious behavior for future contributors without altering existing functionality.

# How it was validated
- Read the modified files locally and verified documentation formatting.
- Executed `:shared:allTests` to ensure compilation and regressions passed successfully.

---
*PR created automatically by Jules for task [10503640538713546728](https://jules.google.com/task/10503640538713546728) started by @tajemniktv*