### PR TITLE
perf: hoist template filtering in CaptureSheet

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
@@ -350,7 +350,10 @@ fun CaptureSheet(
                 }
             }
 
-            if (templates.isNotEmpty() && !brainDumpMode) {
+            val relevantTemplates = remember(templates, selectedType) {
+                templates.filter { it.nodeType == selectedType }
+            }
+            if (relevantTemplates.isNotEmpty() && !brainDumpMode) {
                 Text(
                     stringResource(Res.string.capture_use_template),
                     style = MaterialTheme.typography.labelSmall,
@@ -360,7 +363,7 @@ fun CaptureSheet(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
                 ) {
-                    items(templates.filter { it.nodeType == selectedType }, key = { it.id }) { template ->
+                    items(relevantTemplates, key = { it.id }) { template ->
                         FilterChip(
                             selected = false,
                             onClick = {


### PR DESCRIPTION
Identified and implemented a safe performance improvement in CaptureSheet.kt. 

By hoisting the inline list filtering operation (`templates.filter { it.nodeType == selectedType }`) out of the `LazyRow`'s `items` block and into a `remember(templates, selectedType)` block, we prevent the UI from redundantly re-calculating the filtered list on every recomposition. 

Additionally, updated the outer UI `if` condition to check `relevantTemplates.isNotEmpty()` instead of `templates.isNotEmpty()`. This prevents the "USE TEMPLATE" header from incorrectly rendering over an empty row if templates exist overall but none match the currently selected type.

---
*PR created automatically by Jules for task [18418479808203400555](https://jules.google.com/task/18418479808203400555) started by @tajemniktv*