### PR TITLE
feat(ui): improve notes workspace UX

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -4,6 +4,8 @@
 
 package com.tajemniktv.tajsos.ui.screens.notes
 
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -93,8 +95,13 @@ fun NotesContextPanel(
                             showContainer = false,
                         )
                     } else {
-                        selectedNote.tags.forEach {
-                            Text("#$it", color = TajsOSTheme.Text)
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.horizontalScroll(rememberScrollState())
+                        ) {
+                            selectedNote.tags.forEach {
+                                Text("#$it", color = TajsOSTheme.Primary, style = MaterialTheme.typography.bodyMedium)
+                            }
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -40,6 +40,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.TextStyle
@@ -68,6 +71,7 @@ fun NotesEditorPane(
     onToggleFocusMode: () -> Unit,
     onToggleContextPanel: () -> Unit,
     onDuplicate: () -> Unit,
+    onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -84,6 +88,7 @@ fun NotesEditorPane(
         }
 
         val titleFocusRequester = remember(note.id) { FocusRequester() }
+        val clipboardManager = LocalClipboardManager.current
         LaunchedEffect(note.id, focusTitleSignal) {
             if (focusTitleSignal > 0) {
                 titleFocusRequester.requestFocus()
@@ -127,11 +132,16 @@ fun NotesEditorPane(
                         onToggleFocusMode = onToggleFocusMode,
                         onToggleContextPanel = onToggleContextPanel,
                         onDuplicate = onDuplicate,
+                        onCopyContent = {
+                            clipboardManager.setText(AnnotatedString(note.content))
+                        },
+                        onDelete = onDelete
                     )
                     Spacer(Modifier.height(8.dp))
                     BasicTextField(
                         value = note.content,
                         onValueChange = onContentChange,
+                        cursorBrush = SolidColor(TajsOSTheme.Primary),
                         textStyle =
                             MaterialTheme.typography.bodyLarge.merge(
                                 TextStyle(
@@ -167,6 +177,8 @@ fun NotesEditorHeaderActions(
     onToggleFocusMode: () -> Unit,
     onToggleContextPanel: () -> Unit,
     onDuplicate: () -> Unit,
+    onCopyContent: () -> Unit,
+    onDelete: () -> Unit,
 ) {
     var menuOpen by remember { mutableStateOf(false) }
     Row(
@@ -210,6 +222,20 @@ fun NotesEditorHeaderActions(
                     onClick = {
                         menuOpen = false
                         onDuplicate()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text("Copy content") },
+                    onClick = {
+                        menuOpen = false
+                        onCopyContent()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text("Delete note") },
+                    onClick = {
+                        menuOpen = false
+                        onDelete()
                     },
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -20,6 +20,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.IconButton
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Search
@@ -86,6 +90,13 @@ fun NotesListRail(
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                trailingIcon = {
+                    if (searchQuery.isNotEmpty()) {
+                        IconButton(onClick = { onSearchChange("") }) {
+                            Icon(Icons.Default.Close, contentDescription = "Clear search")
+                        }
+                    }
+                },
                 placeholder = { Text("Search notes...") },
             )
             NotesFilterRow(activeFilter = activeFilter, onFilterChange = onFilterChange)
@@ -127,7 +138,7 @@ private fun NotesFilterRow(
     activeFilter: NotesListFilter,
     onFilterChange: (NotesListFilter) -> Unit,
 ) {
-    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+    Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.horizontalScroll(rememberScrollState())) {
         listOf(
             NotesListFilter.ALL to "All",
             NotesListFilter.PINNED to "Pinned",
@@ -149,7 +160,7 @@ private fun NotesDomainRow(
     activeDomain: NotesDomain?,
     onDomainChange: (NotesDomain?) -> Unit,
 ) {
-    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+    Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.horizontalScroll(rememberScrollState())) {
         listOf(
             null to "Any",
             NotesDomain.PERSONAL to "Personal",
@@ -171,7 +182,7 @@ private fun NotesSortPicker(
     sortOrder: NotesSortOrder,
     onSortOrderChange: (NotesSortOrder) -> Unit,
 ) {
-    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+    Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.horizontalScroll(rememberScrollState())) {
         listOf(
             NotesSortOrder.UPDATED to "Updated",
             NotesSortOrder.CREATED to "Created",
@@ -218,7 +229,7 @@ fun NotesListItem(
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = note.title,
+                    text = note.title.ifBlank { "Untitled note" },
                     style = MaterialTheme.typography.titleSmall,
                     color = titleColor,
                     fontWeight = FontWeight.SemiBold,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
@@ -175,7 +175,7 @@ fun NotesRoute(
             scope.launch {
                 val newId =
                     viewModel.addNodeForResult(
-                        title = "Untitled note",
+                        title = "",
                         type = "note",
                         inboxState = false,
                     )
@@ -243,6 +243,10 @@ fun NotesRoute(
                                 focusTitleSignal += 1
                             }
                         },
+                        onDelete = {
+                            viewModel.deleteNodePermanently(selectedNote.source)
+                            mobileInDetail = false
+                        },
                         modifier = Modifier.fillMaxWidth().height(600.dp),
                     )
                     NotesContextPanel(
@@ -306,6 +310,12 @@ fun NotesRoute(
                                     selectedNoteId = newId
                                     focusTitleSignal += 1
                                 }
+                            }
+                        },
+                        onDelete = {
+                            selectedNote?.let { item ->
+                                viewModel.deleteNodePermanently(item.source)
+                                selectedNoteId = -1L
                             }
                         },
                         modifier = Modifier.widthIn(max = 960.dp).fillMaxSize(),
@@ -376,6 +386,12 @@ fun NotesRoute(
                                         selectedNoteId = newId
                                         focusTitleSignal += 1
                                     }
+                                }
+                            },
+                            onDelete = {
+                                selectedNote?.let { item ->
+                                    viewModel.deleteNodePermanently(item.source)
+                                    selectedNoteId = -1L
                                 }
                             },
                             modifier = Modifier.weight(1f),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
@@ -71,7 +71,7 @@ fun NodeWithPin.toNotesWorkspaceItem(
 ): NotesWorkspaceItem =
     NotesWorkspaceItem(
         id = node.id,
-        title = node.title.ifBlank { "Untitled note" },
+        title = node.title,
         content = node.content,
         preview =
             node.content


### PR DESCRIPTION
What user-facing friction was improved: Added clear search button, copy content action, and delete note action. Also improved context panel scrolling and empty state presentation. Fixed empty title issue.
Where the change appears: Notes workspace.
Why the change matches existing UX patterns: Fits standard Material Design patterns.
How it was validated: Ran test suite.

---
*PR created automatically by Jules for task [15863692055394258476](https://jules.google.com/task/15863692055394258476) started by @tajemniktv*