### PR TITLE
feat(ui): Polish app shell header and briefing screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -221,13 +221,19 @@ fun HeaderGreeting(
             overflow = TextOverflow.Ellipsis,
         )
         Spacer(Modifier.height(2.dp))
-        Text(
-            text = protocolText.uppercase(),
-            style = MaterialTheme.typography.labelSmall,
-            color = TajsOSTheme.Muted,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        androidx.compose.material3.Surface(
+            color = TajsOSTheme.Primary.copy(alpha = 0.1f),
+            shape = RoundedCornerShape(4.dp),
+        ) {
+            Text(
+                text = protocolText.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = TajsOSTheme.Primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -221,9 +221,9 @@ fun HeaderGreeting(
             overflow = TextOverflow.Ellipsis,
         )
         Spacer(Modifier.height(2.dp))
-        androidx.compose.material3.Surface(
+        Surface(
             color = TajsOSTheme.Primary.copy(alpha = 0.1f),
-            shape = RoundedCornerShape(4.dp),
+            shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
         ) {
             Text(
                 text = protocolText.uppercase(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
@@ -324,7 +324,7 @@ private fun BriefingMainPane(
                 ) {
                     Surface(
                         color = TajsOSTheme.Primary.copy(alpha = 0.1f),
-                        shape = RoundedCornerShape(16.dp),
+                        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
                     ) {
                         Text(
                             text = prioritiesLine,
@@ -335,7 +335,7 @@ private fun BriefingMainPane(
                     }
                     Surface(
                         color = TajsOSTheme.SurfaceLow,
-                        shape = RoundedCornerShape(16.dp),
+                        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
                         border = androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.Border.copy(alpha = 0.5f))
                     ) {
                         Text(
@@ -347,7 +347,7 @@ private fun BriefingMainPane(
                     }
                     Surface(
                         color = TajsOSTheme.SurfaceLow,
-                        shape = RoundedCornerShape(16.dp),
+                        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
                         border = androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.Border.copy(alpha = 0.5f))
                     ) {
                         Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
@@ -319,34 +319,44 @@ private fun BriefingMainPane(
                     color = TajsOSTheme.Muted,
                 )
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = prioritiesLine,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = TajsOSTheme.Primary,
-                    )
-                    Text(
-                        text = "•",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = TajsOSTheme.Muted,
-                    )
-                    Text(
-                        text = eventsLine,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = TajsOSTheme.Muted,
-                    )
-                    Text(
-                        text = "•",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = TajsOSTheme.Muted,
-                    )
-                    Text(
-                        text = notesLine,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = TajsOSTheme.Muted,
-                    )
+                    Surface(
+                        color = TajsOSTheme.Primary.copy(alpha = 0.1f),
+                        shape = RoundedCornerShape(16.dp),
+                    ) {
+                        Text(
+                            text = prioritiesLine,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = TajsOSTheme.Primary,
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                        )
+                    }
+                    Surface(
+                        color = TajsOSTheme.SurfaceLow,
+                        shape = RoundedCornerShape(16.dp),
+                        border = androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.Border.copy(alpha = 0.5f))
+                    ) {
+                        Text(
+                            text = eventsLine,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = TajsOSTheme.Text,
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                        )
+                    }
+                    Surface(
+                        color = TajsOSTheme.SurfaceLow,
+                        shape = RoundedCornerShape(16.dp),
+                        border = androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.Border.copy(alpha = 0.5f))
+                    ) {
+                        Text(
+                            text = notesLine,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = TajsOSTheme.Text,
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                        )
+                    }
                 }
             }
 
@@ -531,6 +541,7 @@ private fun BriefingSignalCard(
         color = TajsOSTheme.SurfaceLow.copy(alpha = 0.55f),
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
+        border = androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.Border.copy(alpha = 0.5f))
     ) {
         Column(
             modifier = Modifier.padding(16.dp),


### PR DESCRIPTION
What user-facing friction was improved: Enhanced visual hierarchy of the greeting and briefing screens, making the first impression more structured and scannable.
Where the change appears: Global app shell header (protocol badge) and the Briefing screen (summary chips and signal card borders).
Why the change matches existing UX patterns: Uses existing theme colors and standard surface shapes to create subtle badges and defined card boundaries, improving structure without inventing new patterns.
How it was validated: Compiled UI and ran unit tests.

---
*PR created automatically by Jules for task [3545884365502794643](https://jules.google.com/task/3545884365502794643) started by @tajemniktv* 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR enhances the visual hierarchy of the app shell header and briefing screens by introducing subtle badges and chips, making the first impression more structured and scannable. The changes utilize existing theme colors and Material3 surfaces to improve UI polish without introducing new patterns.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces a badge for the protocol text in the app shell header using a Surface with primary color background in HeaderGreeting composable.</li>

<li>Replaces plain text with chip-like Surfaces for priorities, events, and notes in the briefing screen summary within BriefingMainPane composable.</li>

<li>Adds borders to signal cards in the briefing screen for better definition in BriefingSignalCard composable.</li>

<li>Changes leverage existing TajsOS theme and Material3 components for consistency.</li>

</ul>
</details>

</div>