### PR TITLE
feat(ui): implement dismissible global notifications in AppShell

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -46,6 +46,8 @@ import com.tajemniktv.tajsos.ui.components.common.CaptureSheet
 import com.tajemniktv.tajsos.ui.components.layout.AppShell
 import com.tajemniktv.tajsos.ui.components.layout.rememberAppShellState
 import com.tajemniktv.tajsos.ui.components.notifications.NotificationUiModel
+import com.tajemniktv.tajsos.ui.components.notifications.NotificationVariant
+import androidx.compose.material.icons.filled.Info
 import com.tajemniktv.tajsos.ui.components.screen.BindScreenHeader
 import com.tajemniktv.tajsos.ui.components.screen.ScreenHeaderController
 import com.tajemniktv.tajsos.ui.components.screen.ScreenHeaderModel
@@ -145,6 +147,30 @@ fun App(
     val userProfile by viewModel.userProfile.collectAsState()
     val sidebarMode by viewModel.sidebarMode.collectAsState()
 
+    var notifications by remember {
+        mutableStateOf(
+            listOf(
+                NotificationUiModel(
+                    id = "SYS-001",
+                    title = "System Online",
+                    body = "Neural link established. Operations normal.",
+                    category = "SYSTEM",
+                    variant = NotificationVariant.INFO,
+                    icon = Icons.Default.Info,
+                    isUnread = true
+                )
+            )
+        )
+    }
+
+    val notificationsWithDismiss = remember(notifications) {
+        notifications.map { notif ->
+            notif.copy(onDismiss = {
+                notifications = notifications.filter { it.id != notif.id }
+            })
+        }
+    }
+
     var showCaptureSheetState by remember { mutableStateOf(value = false) }
     var selectedTasksTab by rememberSaveable { mutableStateOf(TasksTab.COMMAND) }
     val shellState = rememberAppShellState(sidebarMode = sidebarMode)
@@ -227,7 +253,7 @@ fun App(
                 drawerState = drawerState,
                 scope = scope,
                 screenHeader = screenHeaderController.model,
-                notifications = emptyList<NotificationUiModel>(),
+                notifications = notificationsWithDismiss,
             ) {
                 AppScaffold(
                     showCaptureSheet = showCaptureSheetState,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
@@ -19,10 +19,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -154,6 +156,21 @@ fun TajsNotificationCard(
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                     )
+                }
+
+                if (notification.onDismiss != null) {
+                    Spacer(Modifier.width(TajsOSTheme.SpacingSm))
+                    IconButton(
+                        onClick = { notification.onDismiss?.invoke() },
+                        modifier = Modifier.size(24.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Dismiss",
+                            tint = TajsOSTheme.Muted,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationUiModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationUiModel.kt
@@ -30,4 +30,5 @@ data class NotificationUiModel(
     val icon: ImageVector? = null,
     val progress: Float? = null,
     val onClick: () -> Unit = {},
+    val onDismiss: (() -> Unit)? = null,
 )


### PR DESCRIPTION
- What user-facing friction was improved: Users could see system notification previews in components but they weren't hooked into the global app state or dismissible.
- Where the change appears: `AppShell` (header notification bell and dropdown).
- Why the change matches existing UX patterns: Utilizes the existing `TajsNotificationWidget` and `NotificationUiModel` built for this purpose.
- How it was validated: Compiled successfully and tests passed. UI structure relies on standard compose state hoisting.

---
*PR created automatically by Jules for task [3078769242384086286](https://jules.google.com/task/3078769242384086286) started by @tajemniktv* 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request implements dismissible global notifications in the AppShell, addressing user friction where notifications were visible but not interactive. The changes appear in the App component and notification UI components, utilizing existing TajsNotificationWidget and NotificationUiModel for UX consistency. Validation included successful compilation and passing tests, with UI structure relying on standard Compose state hoisting. The implementation adds notification state management to the app level, enables dismiss functionality through UI model callbacks, and integrates with the AppShell for header display.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces global notification state in App.kt with a sample notification and dismiss mapping</li>

<li>Adds onDismiss callback parameter to NotificationUiModel data class</li>

<li>Implements dismiss button in TajsNotificationCard component when onDismiss is available</li>

<li>Updates AppShell invocation to pass notifications instead of an empty list</li>

</ul>
</details>

</div>