### PR TITLE
fix: Secure /sync endpoint with Bearer authentication

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,7 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 slf4j-android = { module = "uk.uuid.slf4j:slf4j-android", version.ref = "slf4j-android" }
 ktor-serverCore = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
 ktor-serverNetty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
+ktor-serverAuth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
 ktor-serverTestHost = { module = "io.ktor:ktor-server-test-host-jvm", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.logback)
     implementation(libs.ktor.serverCore)
     implementation(libs.ktor.serverNetty)
+    implementation(libs.ktor.serverAuth)
     implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
     implementation(libs.ktor.serialization.kotlinx.json)
 

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -1,5 +1,7 @@
 package com.tajemniktv.tajsos
 
+import java.security.MessageDigest
+
 import com.tajemniktv.tajsos.routes.healthRoutes
 import com.tajemniktv.tajsos.routes.syncRoutes
 import io.ktor.serialization.kotlinx.json.*
@@ -9,6 +11,8 @@ import io.ktor.server.netty.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.server.auth.*
+
 import kotlinx.serialization.json.Json
 
 fun main() {
@@ -18,6 +22,23 @@ fun main() {
 }
 
 fun Application.module() {
+    val expectedToken = environment.config.propertyOrNull("TAJSOS_SYNC_TOKEN")?.getString()
+        ?: System.getenv("TAJSOS_SYNC_TOKEN")
+        ?: error("TAJSOS_SYNC_TOKEN environment variable must be set")
+
+    install(Authentication) {
+        bearer("sync-auth") {
+            authenticate { tokenCredential ->
+
+                if (MessageDigest.isEqual(tokenCredential.token.toByteArray(), expectedToken.toByteArray())) {
+                    UserIdPrincipal("sync-client")
+                } else {
+                    null
+                }
+            }
+        }
+    }
+
     install(ContentNegotiation) {
         json(Json {
             prettyPrint = true

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -25,12 +25,13 @@ fun Application.module() {
     val expectedToken = environment.config.propertyOrNull("TAJSOS_SYNC_TOKEN")?.getString()
         ?: System.getenv("TAJSOS_SYNC_TOKEN")
         ?: error("TAJSOS_SYNC_TOKEN environment variable must be set")
+    val expectedTokenBytes = expectedToken.toByteArray(Charsets.UTF_8)
 
     install(Authentication) {
         bearer("sync-auth") {
             authenticate { tokenCredential ->
 
-                if (MessageDigest.isEqual(tokenCredential.token.toByteArray(), expectedToken.toByteArray())) {
+                if (MessageDigest.isEqual(tokenCredential.token.toByteArray(Charsets.UTF_8), expectedTokenBytes)) {
                     UserIdPrincipal("sync-client")
                 } else {
                     null

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/routes/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/routes/SyncRoutes.kt
@@ -13,13 +13,16 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.server.auth.*
+
 import kotlinx.coroutines.CancellationException
 
 private val syncStore = LinkedHashMap<String, SyncItem>()
 private val syncStoreLock = Any()
 
 fun Route.syncRoutes() {
-    route("/sync") {
+    authenticate("sync-auth") {
+        route("/sync") {
         post {
             try {
                 // Manually check content type but use match to handle charsets correctly
@@ -86,5 +89,6 @@ fun Route.syncRoutes() {
                 )
             }
         }
+    }
     }
 }

--- a/server/src/test/kotlin/com/tajemniktv/tajsos/ApplicationTest.kt
+++ b/server/src/test/kotlin/com/tajemniktv/tajsos/ApplicationTest.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos
 
+import io.ktor.client.request.header
 import com.tajemniktv.tajsos.dto.HealthResponse
 import com.tajemniktv.tajsos.dto.SyncItem
 import com.tajemniktv.tajsos.dto.SyncRequest
@@ -29,7 +30,26 @@ import kotlinx.serialization.json.Json
 @Suppress("unused")
 class ApplicationTest {
     @Test
+    fun testSyncEndpoint_Unauthorized(): TestResult = testApplication {
+        environment {
+            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+        }
+        application {
+            module()
+        }
+        val response =
+            client.post("/sync") {
+                setBody("{\"lastSyncTime\": 0, \"items\": []}")
+            }
+
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+    }
+
+    @Test
     fun testRoot(): TestResult = testApplication {
+        environment {
+            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+        }
         application {
             module()
         }
@@ -40,6 +60,9 @@ class ApplicationTest {
 
     @Test
     fun testHealthEndpoint(): TestResult = testApplication {
+        environment {
+            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+        }
         application {
             module()
         }
@@ -65,6 +88,9 @@ class ApplicationTest {
 
     @Test
     fun testSyncEndpoint_HappyPath(): TestResult = testApplication {
+        environment {
+            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+        }
         application {
             module()
         }
@@ -96,6 +122,8 @@ class ApplicationTest {
 
         val response =
             clientWithNegotiation.post("/sync") {
+                header(io.ktor.http.HttpHeaders.Authorization, "Bearer default-dev-token")
+
                 contentType(ContentType.Application.Json)
                 setBody(requestPayload)
             }
@@ -112,11 +140,16 @@ class ApplicationTest {
 
     @Test
     fun testSyncEndpoint_BadPayload(): TestResult = testApplication {
+        environment {
+            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+        }
         application {
             module()
         }
         val response =
             client.post("/sync") {
+                header(io.ktor.http.HttpHeaders.Authorization, "Bearer default-dev-token")
+
                 contentType(ContentType.Application.Json)
                 setBody("{\"malformed\": \"json\"}")
             }
@@ -128,6 +161,9 @@ class ApplicationTest {
 
     @Test
     fun testSyncEndpoint_returnsDeltaAndConflict(): TestResult = testApplication {
+        environment {
+            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+        }
         application {
             module()
         }
@@ -159,6 +195,8 @@ class ApplicationTest {
 
         val firstResponse =
             clientWithNegotiation.post("/sync") {
+                header(io.ktor.http.HttpHeaders.Authorization, "Bearer default-dev-token")
+
                 contentType(ContentType.Application.Json)
                 setBody(firstRequest)
             }
@@ -181,6 +219,8 @@ class ApplicationTest {
 
         val secondResponse =
             clientWithNegotiation.post("/sync") {
+                header(io.ktor.http.HttpHeaders.Authorization, "Bearer default-dev-token")
+
                 contentType(ContentType.Application.Json)
                 setBody(staleUpdate)
             }
@@ -193,11 +233,16 @@ class ApplicationTest {
 
     @Test
     fun testSyncEndpoint_MissingContentType(): TestResult = testApplication {
+        environment {
+            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+        }
         application {
             module()
         }
         val response =
             client.post("/sync") {
+                header(io.ktor.http.HttpHeaders.Authorization, "Bearer default-dev-token")
+
                 setBody("{\"lastSyncTime\": 0, \"items\": []}")
             }
 


### PR DESCRIPTION
- Adds Ktor `ktor-server-auth` dependency to the server module.
- Configures a Bearer token provider (`sync-auth`) in `Application.kt` that retrieves its expected token securely and fails fast during application boot if the environment configuration is missing.
- Enforces the `sync-auth` policy on the `/sync` route.
- Updates existing tests to supply the required token config and authorization headers.
- Adds an explicit test case `testSyncEndpoint_Unauthorized` to ensure missing headers are correctly blocked.

---
*PR created automatically by Jules for task [17176604548817402459](https://jules.google.com/task/17176604548817402459) started by @tajemniktv* 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR secures the /sync endpoint by implementing Bearer authentication using Ktor's auth plugin, requiring valid tokens for access while updating tests to validate the security measures.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces Bearer token authentication in Application.kt to validate requests against a securely configured environment variable, preventing unauthorized access to the sync functionality.</li>

<li>Adds ktor-server-auth dependency in build files to support authentication features.</li>

<li>Enforces authentication on the /sync route in SyncRoutes.kt, blocking unauthenticated requests.</li>

<li>Updates all tests in ApplicationTest.kt to include token configuration and authorization headers, and adds a new unauthorized test case.</li>

</ul>
</details>

</div>