### PR TITLE
fix(ui): Polish inline empty state proportions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/EmptyState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/EmptyState.kt
@@ -95,7 +95,7 @@ fun EmptyState(
                     modifier = Modifier.size(if (fillParent) 48.dp else if (showContainer) 40.dp else 32.dp),
                     tint = TajsOSTheme.Primary.copy(alpha = alpha),
                 )
-                Spacer(modifier = Modifier.height(if (fillParent) TajsOSTheme.SpacingMd else TajsOSTheme.SpacingSm))
+Spacer(modifier = Modifier.height(if (fillParent) TajsOSTheme.SpacingMd else if (showContainer) TajsOSTheme.SpacingSm else TajsOSTheme.SpacingXs))
                 Text(
                     text = message,
                     style = MaterialTheme.typography.bodyMedium,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/EmptyState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/EmptyState.kt
@@ -86,16 +86,16 @@ fun EmptyState(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier =
                     Modifier
-                        .defaultMinSize(minHeight = if (fillParent) 200.dp else 120.dp)
-                        .padding(if (fillParent) TajsOSTheme.SpacingXl else TajsOSTheme.SpacingLg),
+                        .defaultMinSize(minHeight = if (fillParent) 200.dp else if (showContainer) 120.dp else 80.dp)
+                        .padding(if (fillParent) TajsOSTheme.SpacingXl else if (showContainer) TajsOSTheme.SpacingLg else TajsOSTheme.SpacingMd),
             ) {
                 Icon(
                     imageVector = icon,
                     contentDescription = null,
-                    modifier = Modifier.size(48.dp),
+                    modifier = Modifier.size(if (fillParent) 48.dp else if (showContainer) 40.dp else 32.dp),
                     tint = TajsOSTheme.Primary.copy(alpha = alpha),
                 )
-                Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
+                Spacer(modifier = Modifier.height(if (fillParent) TajsOSTheme.SpacingMd else TajsOSTheme.SpacingSm))
                 Text(
                     text = message,
                     style = MaterialTheme.typography.bodyMedium,


### PR DESCRIPTION
## What user-facing friction was improved
Inline empty states (like "No items found" inside a small dashboard card) were previously taking up too much vertical space and drawing disproportionate attention due to using the same large padding and 48dp icon size as full-screen empty states.

## Where the change appears
Across the entire application anywhere an `EmptyState` component is rendered inside a smaller context (specifically when `fillParent = false` and `showContainer = false` are passed, such as in various dashboard blocks).

## Why the change matches existing UX patterns
The design system scales components based on hierarchy. Full-screen states get `SpacingXl` and large icons, while container states get `SpacingLg`. This fix correctly applies the next logical step down (`SpacingMd`/`SpacingSm` and smaller icons) for completely inline empty blocks, bringing them in line with standard Material sizing expectations without creating new tokens.

## How it was validated
Ran unit tests and verified via Compose Multiplatform compilation checks. Evaluated sizing tokens against standard Material spacing metrics to ensure they look visually stable inside cards.

---
*PR created automatically by Jules for task [16990309500372944223](https://jules.google.com/task/16990309500372944223) started by @tajemniktv* 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Inline empty states, such as those displayed inside small dashboard cards, were previously occupying excessive vertical space and drawing disproportionate attention by using the same large padding and icon sizes as full-screen empty states. This PR addresses the issue by scaling down the EmptyState component's dimensions when fillParent is false and showContainer is false, ensuring better proportions for inline contexts without creating new design tokens.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>introduces conditional sizing logic in EmptyState component (minHeight, padding, icon size, spacer) based on fillParent and showContainer parameters to reduce vertical space in inline empty states</li>

<li>applies smaller SpacingMd padding and 32.dp icon size for completely inline empty blocks, aligning with Material Design hierarchy</li>

<li>affects EmptyState usages across dashboard blocks in finance, track, relationships, time architecture, notes, and archive screens where fillParent=false and showContainer=false</li>

</ul>
</details>

</div>