### PR TITLE
fix: Prevent timing attacks on sync auth by hashing tokens before comparison

### DIFF
--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -26,12 +26,14 @@ fun Application.module() {
         ?: System.getenv("TAJSOS_SYNC_TOKEN")
         ?: error("TAJSOS_SYNC_TOKEN environment variable must be set")
     val expectedTokenBytes = expectedToken.toByteArray(Charsets.UTF_8)
+    val expectedTokenHash = MessageDigest.getInstance("SHA-256").digest(expectedTokenBytes)
 
     install(Authentication) {
         bearer("sync-auth") {
             authenticate { tokenCredential ->
 
-                if (MessageDigest.isEqual(tokenCredential.token.toByteArray(Charsets.UTF_8), expectedTokenBytes)) {
+                val providedTokenHash = MessageDigest.getInstance("SHA-256").digest(tokenCredential.token.toByteArray(Charsets.UTF_8))
+                if (MessageDigest.isEqual(providedTokenHash, expectedTokenHash)) {
                     UserIdPrincipal("sync-client")
                 } else {
                     null


### PR DESCRIPTION
Previously, `MessageDigest.isEqual` was used directly on the user-provided token and the expected token in `server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt`. While `MessageDigest.isEqual` provides a constant-time comparison when lengths match, it fails fast when lengths differ, which leaks the length of the expected token.
To mitigate this length-based timing attack, this commit hashes both the expected token and the provided token with SHA-256 before comparison. The resulting hashes are always 32 bytes, ensuring `MessageDigest.isEqual` performs a true constant-time bitwise comparison regardless of the input token's length.

---
*PR created automatically by Jules for task [5285047970400456021](https://jules.google.com/task/5285047970400456021) started by @tajemniktv* 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a security vulnerability in the sync authentication by preventing timing attacks. Previously, direct comparison of tokens using MessageDigest.isEqual could leak token length when lengths differed. The fix hashes both tokens with SHA-256 before comparison, ensuring constant-time operation.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces SHA-256 hashing for both expected and provided tokens in the bearer authentication block to prevent timing attacks by ensuring constant-time comparison in Application.kt.</li>

</ul>
</details>

</div>