### PR TITLE
docs: Document implicit vs explicit domain classification

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
@@ -118,9 +118,10 @@ data class RecordFacetEntity(
  *
  * Domains remain read-model classifications over shared objects rather than hard containers.
  *
- * Note: These explicit mappings are currently stored but frequently bypassed by UI lenses
- * (e.g., DomainLensQueries), which prefer implicit terminology matching (tags, titles, maintenance type)
- * over these explicit DB associations. This provides resilience against users forgetting to assign domains.
+ * Note: These explicit mappings are currently stored but intentionally bypassed by primary UI lenses
+ * (e.g., DomainLensQueries), which prefer implicit terminology matching (tags, titles, content,
+ * maintenance type, and note type) over these explicit DB associations. This provides resilience
+ * against users forgetting to assign domains.
  */
 @Entity(
     tableName = "item_domains",

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
@@ -117,6 +117,10 @@ data class RecordFacetEntity(
  * Lens-oriented domain associations for any life object.
  *
  * Domains remain read-model classifications over shared objects rather than hard containers.
+ *
+ * Note: These explicit mappings are currently stored but frequently bypassed by UI lenses
+ * (e.g., DomainLensQueries), which prefer implicit terminology matching (tags, titles, maintenance type)
+ * over these explicit DB associations. This provides resilience against users forgetting to assign domains.
  */
 @Entity(
     tableName = "item_domains",

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -197,6 +197,10 @@ object DomainLensQueries {
      * Classification uses hardcoded marker constants ([financeTagMarkers],
      * [financeTitleKeywords], and [financeMaintenanceTypes]) plus non-constant node-state
      * checks such as reference-note matching (`noteType == "reference"`).
+     *
+     * Note: This intentionally bypasses explicit `ItemDomainEntity` database associations
+     * to provide a zero-configuration experience, ensuring finance items are surfaced even
+     * if the user forgets to manually assign the finance domain.
      */
     private fun matchesFinanceSignal(node: NodeWithPin): Boolean {
         val title = node.node.title.lowercase()
@@ -217,6 +221,10 @@ object DomainLensQueries {
      *
      * Classification relies on checking against hardcoded marker constants ([healthTagMarkers],
      * [healthTitleKeywords], [healthMaintenanceTypes]) and specific note types (e.g., "reflection").
+     *
+     * Note: This intentionally bypasses explicit `ItemDomainEntity` database associations
+     * to provide a zero-configuration experience, ensuring health items are surfaced even
+     * if the user forgets to manually assign the health domain.
      */
     private fun matchesHealthSignal(node: NodeWithPin): Boolean {
         val title = node.node.title.lowercase()


### PR DESCRIPTION
This PR adds documentation to `ItemDomainEntity` and `DomainLensQueries` (`matchesFinanceSignal`, `matchesHealthSignal`) to explain the non-obvious behavior where explicit domain mappings stored in the database (`item_domains`) are intentionally bypassed by the primary UI lenses.

These lenses instead rely on implicit terminology matching (tags, titles, content) to provide a zero-configuration experience, ensuring items surface in lenses even if the user forgets to manually assign a domain.

This documentation reduces onboarding friction and maintenance risk by clearly defining the intent and boundaries between the data model's explicit storage and the UI's heuristic-based lens queries.

---
*PR created automatically by Jules for task [13969882647218020045](https://jules.google.com/task/13969882647218020045) started by @tajemniktv* 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds documentation to ItemDomainEntity and DomainLensQueries (matchesFinanceSignal, matchesHealthSignal) to explain the non-obvious behavior where explicit domain mappings stored in the database (item_domains) are intentionally bypassed by the primary UI lenses. These lenses instead rely on implicit terminology matching (tags, titles, content) to provide a zero-configuration experience, ensuring items surface in lenses even if the user forgets to manually assign a domain. This documentation reduces onboarding friction and maintenance risk by clearly defining the intent and boundaries between the data model's explicit storage and the UI's heuristic-based lens queries.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds documentation to ItemDomainEntity class explaining that explicit domain mappings are stored but bypassed by UI lenses in favor of implicit terminology matching</li>

<li>Adds documentation to matchesFinanceSignal function noting intentional bypass of explicit ItemDomainEntity associations for zero-configuration finance item surfacing</li>

<li>Adds documentation to matchesHealthSignal function noting intentional bypass of explicit ItemDomainEntity associations for zero-configuration health item surfacing</li>

</ul>
</details>

</div>