### PR TITLE
fix(ui): use EmptyState component in Notes detail screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -55,6 +55,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -113,9 +114,11 @@ fun NotesWorkspaceDetail(
     val projects by viewModel.allProjects.collectAsState()
 
     if (current == null) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(stringResource(Res.string.notes_empty), color = TajsOSTheme.Muted)
-        }
+        EmptyState(
+            message = stringResource(Res.string.notes_empty),
+            fillParent = true,
+            showContainer = false,
+        )
         return
     }
 
@@ -404,9 +407,11 @@ fun NotesWorkspaceDetail(
                 icon = Icons.Default.Hub,
             ) {
                 if (linked.isEmpty()) {
-                    Text(
-                        stringResource(Res.string.detail_no_linked_items),
-                        color = TajsOSTheme.Muted,
+                    EmptyState(
+                        message = stringResource(Res.string.detail_no_linked_items),
+                        fillParent = false,
+                        showContainer = false,
+                        description = null,
                     )
                 } else {
                     linked.take(6).forEach { id ->
@@ -431,9 +436,11 @@ fun NotesWorkspaceDetail(
                 icon = Icons.Default.Attachment,
             ) {
                 if (attachments.isEmpty()) {
-                    Text(
-                        stringResource(Res.string.detail_no_attachments_simple),
-                        color = TajsOSTheme.Muted,
+                    EmptyState(
+                        message = stringResource(Res.string.detail_no_attachments_simple),
+                        fillParent = false,
+                        showContainer = false,
+                        description = null,
                     )
                 } else {
                     attachments.take(4).forEach {
@@ -447,7 +454,12 @@ fun NotesWorkspaceDetail(
                 icon = Icons.Default.History,
             ) {
                 if (snapshots.isEmpty()) {
-                    Text(stringResource(Res.string.detail_no_snapshots), color = TajsOSTheme.Muted)
+                    EmptyState(
+                        message = stringResource(Res.string.detail_no_snapshots),
+                        fillParent = false,
+                        showContainer = false,
+                        description = null,
+                    )
                 } else {
                     snapshots.take(4).forEach { snapshot ->
                         val label =

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -118,6 +118,7 @@ fun NotesWorkspaceDetail(
             message = stringResource(Res.string.notes_empty),
             fillParent = true,
             showContainer = false,
+            description = null,
         )
         return
     }


### PR DESCRIPTION
🎯 **What**
Refactored the `NotesWorkspaceDetail.kt` screen to utilize the standard `EmptyState` composable rather than simple, generic `Text` composables when data arrays are empty. 

💡 **Why**
This ensures UI consistency across all dashboards and detailed screens. When a side panel or workspace has missing linked relations, attachments, snapshots, or even if the currently selected note resolves to null, a visually distinct and standardized empty state layout is provided rather than plain text. 

✅ **Verification**
Verified that the build task `:composeApp:compileKotlinJvm` succeeds to ensure syntactical correctness and standard UI dependencies were respected. 

✨ **Result**
Improved UX and more polished screen layout with consistent component usage without introducing functional changes.

---
*PR created automatically by Jules for task [9560706790607070665](https://jules.google.com/task/9560706790607070665) started by @tajemniktv* 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>The PR refactors the NotesWorkspaceDetail screen to use the EmptyState component for empty data states, ensuring UI consistency across dashboards and detail screens. It replaces plain Text with EmptyState when data arrays are empty, such as for missing notes, linked relations, attachments, or snapshots, providing a visually distinct and standardized layout. This improves UX and polishes the screen without introducing functional changes.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Added import for EmptyState component in NotesWorkspaceDetail.kt</li>

<li>Replaced plain Text with EmptyState when no note is selected, using fillParent=true for full-screen display</li>

<li>Replaced plain Text with EmptyState when linked items are empty, using fillParent=false for inline display</li>

<li>Replaced plain Text with EmptyState when attachments are empty, using fillParent=false for inline display</li>

<li>Replaced plain Text with EmptyState when snapshots are empty, using fillParent=false for inline display</li>

</ul>
</details>

</div>