### PR TITLE
docs: Reorganize TajsOS documentation using Starlight IA

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -21,6 +21,35 @@ export default defineConfig({
   integrations: [starlight({
     title: 'Docs',
     description: 'TajsOS Documentation',
+
+    sidebar: [
+      {
+        label: 'Introduction',
+        items: [
+          { label: 'Overview', slug: 'overview' },
+          { label: 'Current Status', slug: 'current-status' },
+          { label: 'Product Philosophy', slug: 'product-philosophy' },
+          { label: 'Roadmap', slug: 'roadmap' },
+        ],
+      },
+      {
+        label: 'Architecture & Model',
+        items: [
+          { label: 'Core Object Model', slug: 'core-object-model' },
+          { label: 'Local-First Architecture', slug: 'local-first-architecture' },
+          { label: 'App Surfaces & Layering', slug: 'app-surfaces' },
+          { label: 'Tech Stack', slug: 'tech-stack' },
+        ],
+      },
+      {
+        label: 'Development & Design',
+        items: [
+          { label: 'Design System', slug: 'design-system' },
+          { label: 'Agent & Contributor Rules', slug: 'agent-rules' },
+        ],
+      },
+    ],
+
     logo: {
       src: './src/assets/logo.png',
       alt: 'TajsOS Logo'

--- a/website/src/components/landing/Navbar.astro
+++ b/website/src/components/landing/Navbar.astro
@@ -22,6 +22,10 @@
     <div class="hidden md:flex gap-12">
       <a
         class="font-mono text-[10px] tracking-widest uppercase font-bold text-on-surface-variant hover:text-on-surface transition-colors"
+        href={`${import.meta.env.BASE_URL}overview`}>DOCS</a
+      >
+      <a
+        class="font-mono text-[10px] tracking-widest uppercase font-bold text-on-surface-variant hover:text-on-surface transition-colors"
         href={`${import.meta.env.BASE_URL}app`}>APP</a
       >
       <a

--- a/website/src/content/docs/agent-rules.md
+++ b/website/src/content/docs/agent-rules.md
@@ -1,0 +1,23 @@
+---
+title: Agent & Contributor Rules
+description: Guidelines for humans and AI agents.
+---
+
+## Guidelines for AI Agents
+
+You are working on TajsOS, a Kotlin Multiplatform + Compose Multiplatform app.
+
+### Commit Message Convention
+
+Use the format: `<type>(OptionalScope): <ShortDescription>`
+
+**Types:**
+- `feat` - new user-facing or developer-facing capability
+- `fix` - bug fix
+- `refactor` - structural/code cleanup without behavior change
+- `perf` - measurable performance improvement
+- `docs` - README, architecture docs, agent docs, comments if docs-only
+- `test` - add/update tests
+- `build` - Gradle, dependencies, etc.
+- `ci` - GitHub Actions, etc.
+- `chore` - repo maintenance

--- a/website/src/content/docs/app-surfaces.md
+++ b/website/src/content/docs/app-surfaces.md
@@ -1,0 +1,10 @@
+---
+title: App Surfaces & UI Layering
+description: How the UI is constructed.
+---
+
+The Compose app separates UI composition into explicit layers:
+
+- **`AppShell`**: For persistent chrome such as the sidebar, top header, shell spacing, and route host.
+- **`ScreenScaffold` / `SplitScreenScaffold`**: For reusable page-level structure, width policy, and scroll behavior.
+- **Screen Route/Content Composables**: For state collection and screen-specific rendering only.

--- a/website/src/content/docs/core-object-model.md
+++ b/website/src/content/docs/core-object-model.md
@@ -1,0 +1,15 @@
+---
+title: Core Object Model
+description: How data is organized in TajsOS.
+---
+
+The app is built around a small set of shared life objects that stay connected:
+
+- **Inbox captures** for fast intake before forced classification.
+- **Tasks** for execution.
+- **Notes** for durable knowledge and reference.
+- **Records** for chronological reflections, logs, and observations.
+- **Projects** for outcomes.
+- **Areas** for ongoing responsibility.
+
+Relations, schedules, and reminders act as shared layers across the system. Focus, review, and tracking data act as read models over shared life objects.

--- a/website/src/content/docs/current-status.md
+++ b/website/src/content/docs/current-status.md
@@ -1,0 +1,21 @@
+---
+title: Current Status
+description: The current stage of TajsOS development.
+---
+
+TajsOS is in a **highly experimental** stage. The product, architecture, and UX may still change significantly.
+
+## Current Priorities
+
+1. **Foundation before expansion**
+   - Strengthen core architecture boundaries.
+   - Reduce ad hoc screen structure.
+   - Improve consistency of state, layout, and interaction patterns.
+   - Keep the domain model coherent.
+
+2. **Polish a small number of core flows**
+   - Priority depth over breadth, especially around the dashboard/now surfaces, notes, tasks, capture/inbox, and detail flows.
+
+3. **Platform Focus**
+   - Primary: Android, Desktop
+   - Other platforms and integrations may be explored later.

--- a/website/src/content/docs/design-system.md
+++ b/website/src/content/docs/design-system.md
@@ -1,0 +1,17 @@
+---
+title: Design System
+description: The Neural Interface and visual principles.
+---
+
+## Creative North Star: "Digital Life System"
+
+This design system is not a utility; it is an intelligence. The UI must feel like a high-end, tactile instrument—a bespoke glass cockpit in a high-performance spacecraft.
+
+We embrace **Organic Industrialism**. This means breaking the rigid, predictable grid through intentional asymmetry, overlapping containers, and a focus on depth over structure. The layout should feel editorial and cinematic.
+
+## Colors
+
+The palette is anchored in high-contrast depths and singular, high-energy accents.
+
+- **Background:** `#0e0e12` (The Void) / `#f8f9fa` (High-Key Industrial)
+- **Primary (Neon Purple):** `#ba9eff`

--- a/website/src/content/docs/docs/index.md
+++ b/website/src/content/docs/docs/index.md
@@ -1,6 +1,0 @@
----
-title: TajsOS Docs
-description: Learn more about TajsOS in this docs site built with Starlight.
----
-
-Welcome to TajsOS!

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -1,0 +1,18 @@
+---
+title: Welcome to TajsOS
+description: The official handbook and documentation for TajsOS.
+hero:
+  tagline: A local-first personal operating system for life, projects, thoughts, execution, and insight.
+  actions:
+    - text: Get Started
+      link: /TajsOS/overview/
+      icon: right-arrow
+      variant: primary
+---
+
+Welcome to the **TajsOS project handbook**. This site explains the architecture, product philosophy, and technical decisions behind TajsOS for future contributors, coding agents, and curious users.
+
+## How to use these docs
+
+If you are just getting to know the project, check out the **[Overview](/TajsOS/overview)**.
+If you are an AI agent or a contributor, make sure you understand the **[Agent & Contributor Rules](/TajsOS/agent-rules)** and our **[Local-First Architecture](/TajsOS/local-first-architecture)**.

--- a/website/src/content/docs/local-first-architecture.md
+++ b/website/src/content/docs/local-first-architecture.md
@@ -1,0 +1,28 @@
+---
+title: Local-First Architecture
+description: Data persistence and structural boundaries.
+---
+
+## Core Architectural Stance
+
+TajsOS is:
+- Local-first
+- Multiplatform
+- Opinionated
+- Modular enough to preserve boundaries
+- Pragmatic rather than framework-worshipping
+
+The architecture should help the app feel like one system without becoming an abstraction museum.
+
+## Local Persistence Shape
+
+The local model keeps a compatibility `NodeEntity` spine for the current app shell, while moving deeper behavior into typed companion tables.
+
+- `InboxEntryEntity` stores raw capture before triage.
+- `NodeEntity` remains the shared local identity row for task/note/record/project/area items.
+- Typed companion tables (`TaskFacet`, `NoteFacet`, `RecordFacet`, `ProjectFacet`, `AreaFacet`) hold object-specific state.
+- `RelationEntity`, tags, attachments, and domain assignments stay cross-cutting and first-class.
+- `ScheduleEntryEntity` stores time-supporting structure with epoch-based local date support.
+- `RichContentDocumentEntity` provides optional long-form/structured bodies.
+
+Saved views are persisted as projections over typed shared objects.

--- a/website/src/content/docs/overview.md
+++ b/website/src/content/docs/overview.md
@@ -1,0 +1,15 @@
+---
+title: Overview
+description: High-level introduction to TajsOS.
+---
+
+**TajsOS** is a local-first personal operating system for life, projects, thoughts, execution, and insight. It is not necessarily for ADHD brains, but it is designed with neurodivergent brains in mind.
+
+## Features
+
+- A **command center** for what matters now.
+- A **knowledge layer** for notes, records, and reference.
+- A **project/life manager** for keeping different domains organized.
+- An **insight layer** for lightweight patterns, reviews, and self-understanding.
+
+Instead of splitting everything into isolated tools, TajsOS tries to make them work as one unified system.

--- a/website/src/content/docs/product-philosophy.md
+++ b/website/src/content/docs/product-philosophy.md
@@ -1,0 +1,16 @@
+---
+title: Product Philosophy
+description: The mindset behind TajsOS.
+---
+
+TajsOS aims to replace overwhelming lists with a mechanical, satisfying control center that makes task capture and execution feel like operating heavy machinery.
+
+It is designed to be a cohesive system for:
+- Capture
+- Execution
+- Knowledge
+- Review
+- Life-domain organization
+- Lightweight insight
+
+The goal is not maximum feature count. The goal is a system that feels coherent, deliberate, and satisfying to operate. The product should feel like one coherent system with multiple lenses over shared life data, not a collection of disconnected feature silos.

--- a/website/src/content/docs/roadmap.md
+++ b/website/src/content/docs/roadmap.md
@@ -1,0 +1,19 @@
+---
+title: Roadmap
+description: Phased roadmap and direction.
+---
+
+This roadmap is directional, not contractual.
+
+## Current Product Direction
+
+TajsOS is moving toward a cohesive local-first system for capture, execution, knowledge, review, life-domain organization, and lightweight insight.
+
+## Platform Focus
+
+**Primary:**
+- Android
+- Desktop
+
+**Secondary:**
+- iOS/Web/Sync (to be explored later)

--- a/website/src/content/docs/tech-stack.md
+++ b/website/src/content/docs/tech-stack.md
@@ -1,0 +1,24 @@
+---
+title: Tech Stack
+description: Languages, frameworks, and tools used in TajsOS.
+---
+
+- **Language:** Kotlin
+- **App Model:** Kotlin Multiplatform
+- **UI:** Compose Multiplatform
+- **Design System:** Material 3
+- **Architecture:** Pragmatic layered architecture
+- **State Management:** ViewModel + StateFlow + immutable UI state
+- **Async:** Kotlin Coroutines
+- **Persistence:** Room + DataStore
+- **Backend:** Ktor (for sync / remote features)
+- **Build System:** Gradle Kotlin DSL
+
+## Repository Structure
+
+- `androidApp/`: Android-specific app entrypoint
+- `composeApp/`: Shared Compose UI and navigation
+- `shared/`: Core data models, entities, repository, business logic
+- `server/`: Ktor backend for sync / remote features
+- `website/`: Website / documentation built with Astro + Starlight
+- `iosApp/`: iOS scaffold


### PR DESCRIPTION
Turn the placeholder documentation into a useful TajsOS project handbook using Astro + Starlight.
- Removes generic `docs/index.md` placeholder.
- Creates new files pulling canonical facts from README, DESIGN, ARCHITECTURE, and AGENTS docs.
- Configures `astro.config.mjs` sidebar with correct links.
- Adds DOCS link to the main `Navbar.astro`.
- Ensures website build passes link validation.

---
*PR created automatically by Jules for task [18405364360821053562](https://jules.google.com/task/18405364360821053562) started by @tajemniktv*