### PR TITLE
test: Add FilterHelper comma-separated status test

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperEdgeTest.kt
@@ -103,4 +103,36 @@ class FilterHelperEdgeTest {
         assertEquals(1L, result[1].node.id)
     }
 
+
+    @Test
+    fun testFilterStatus_commaSeparated() {
+        val nodeActive = buildTestNode(1, "title", status = "active")
+        val nodeOnHold = buildTestNode(2, "title", status = "on_hold")
+        val nodeArchived = buildTestNode(3, "title", status = "archived")
+
+        val result = FilterHelper.filterAndSortNodes(
+            nodes = listOf(nodeActive, nodeOnHold, nodeArchived),
+            query = "",
+            type = null,
+            status = "active, on_hold",
+            projectId = null,
+            areaId = null,
+            linkedToId = null,
+            maxMins = null,
+            energy = null,
+            friction = null,
+            locationContext = null,
+            energyContext = null,
+            deviceContext = null,
+            socialContext = null,
+            timeWindowContext = null,
+            timeHorizon = null,
+            relations = emptyList(),
+            sortMode = "relevance"
+        )
+
+        assertEquals(2, result.size)
+        assertEquals(listOf(1L, 2L), result.map { it.node.id }.sorted())
+    }
+
 }


### PR DESCRIPTION
## What user-facing friction was improved?
Adds safety coverage for the node filtering engine by validating the comma-separated status input edge case.

## Where the change appears
`FilterHelperEdgeTest.kt` inside `shared/src/commonTest`.

## Why the change matches existing UX patterns
Follows the repo's existing test structure without modifying any production logic to accommodate the test.

## How it was validated
Tested locally by running `./gradlew :shared:jvmTest --tests "*FilterHelperEdgeTest*"` successfully.

---
*PR created automatically by Jules for task [6085057319733502405](https://jules.google.com/task/6085057319733502405) started by @tajemniktv*