### PR TITLE
perf: Hoist redundant mapping and distinct evaluations out of Compose Lazy lists

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsDashboardBlocks.kt
@@ -80,6 +80,13 @@ internal fun InsightsMainBlock(
     val allProjects by viewModel.allProjects.collectAsState()
     val projectsById = remember(allProjects) { allProjects.associateBy { it.id } }
 
+    /**
+     * Hoist mapping and filtering computations for entropy projects outside of the lazy list.
+     * This avoids redundant collection sorting/mapping each time LazyColumn triggers a composition update.
+     */
+    val highEntropyProjects = remember(insights.projectEntropy) { insights.projectEntropy.filter { it.value > 0.5 } }
+    val highEntropyProjectKeys = remember(highEntropyProjects) { highEntropyProjects.keys.toList() }
+
     LazyColumn(
         modifier =
             Modifier
@@ -264,7 +271,6 @@ internal fun InsightsMainBlock(
             }
         }
 
-        val highEntropyProjects = insights.projectEntropy.filter { it.value > 0.5 }
         if (highEntropyProjects.isNotEmpty()) {
             item {
                 Text(
@@ -273,7 +279,7 @@ internal fun InsightsMainBlock(
                     color = TajsOSTheme.Error,
                 )
             }
-            items(highEntropyProjects.keys.toList(), key = { "entropy_$it" }) { projectId ->
+            items(highEntropyProjectKeys, key = { "entropy_$it" }) { projectId ->
                 val project = projectsById[projectId]
                 if (project != null) {
                     ProjectEntropyItem(project, highEntropyProjects[projectId] ?: 0.0) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -146,6 +146,13 @@ private fun renderSearchRecent(context: SearchDashboardContext) {
 @Composable
 private fun renderSearchFilters(context: SearchDashboardContext) {
     val viewModel = context.viewModel
+
+    /** Pre-calculate areas list to avoid mapping allocation inside LazyRow composition on every frame. */
+    val areasList = remember(context.areasById) { context.areasById.values.toList() }
+
+    /** Pre-calculate projects list to avoid mapping allocation inside LazyRow composition on every frame. */
+    val projectsList = remember(context.projectsById) { context.projectsById.values.toList() }
+
     if (!context.showFilters) return
     val activeSummary =
         remember(context) {
@@ -347,7 +354,7 @@ private fun renderSearchFilters(context: SearchDashboardContext) {
                         )
                     }
                 }
-                items(context.areasById.values.toList(), key = { it.id }) { area ->
+                items(areasList, key = { it.id }) { area ->
                     FilterChip(
                         selected = context.searchAreaFilter == area.id,
                         onClick = { viewModel.updateSearchAreaFilter(if (context.searchAreaFilter == area.id) null else area.id) },
@@ -361,7 +368,7 @@ private fun renderSearchFilters(context: SearchDashboardContext) {
                         },
                     )
                 }
-                items(context.projectsById.values.toList(), key = { it.id }) { project ->
+                items(projectsList, key = { it.id }) { project ->
                     FilterChip(
                         selected = context.searchProjectFilter == project.id,
                         onClick = {
@@ -476,6 +483,8 @@ private fun RecentQueriesRow(
     queries: List<String>,
     onQueryClick: (String) -> Unit,
 ) {
+    /** Pre-calculate unique query suggestions to prevent distinct evaluations on each recomposition. */
+    val distinctQueries = remember(queries) { queries.distinct() }
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(
             "RECENT QUERIES",
@@ -484,7 +493,7 @@ private fun RecentQueriesRow(
         )
         Spacer(modifier = Modifier.width(TajsOSTheme.SpacingSm))
         LazyRow(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-            items(queries.distinct(), key = { it }) { query ->
+            items(distinctQueries, key = { it }) { query ->
                 Surface(
                     shape = RoundedCornerShape(999.dp),
                     color = TajsOSTheme.SurfaceHigh,


### PR DESCRIPTION
Identify and implement performance improvement with clear reasoning and low risk.

### 🎯 What
Extracted list operations like `.toList()`, `.distinct()`, and `.filter()` from the inner bodies of `LazyColumn` and `LazyRow` components inside `SearchDashboardBlocks.kt` and `InsightsDashboardBlocks.kt`, wrapping them in `remember` blocks. Added explanatory KDocs.

### 💡 Why
The body lambda of Compose's `LazyColumn` and `LazyRow` is evaluated frequently during recomposition and layout. Leaving list transformations (like creating a new list from map values or calculating distinct strings) inside these scopes forces redundant evaluations and memory allocations on every frame or state change. Hoisting them guarantees they only re-evaluate when their dependencies change.

### ✅ Verification
- Analyzed the codebase and identified candidate loops mapped directly inline.
- Scripted precise code replacements ensuring valid `@Composable` invocation scopes.
- Verified compilation and test suite execution passing without regressions.
- Code reviewed and approved by automated systems.

### ✨ Result
Improved list recomposition performance with reduced CPU cycles and garbage collection pressure in Search and Insight screens.

---
*PR created automatically by Jules for task [2897377665608080065](https://jules.google.com/task/2897377665608080065) started by @tajemniktv*