### PR TITLE
docs: Add missing KDocs for core domain lens queries and entities

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
@@ -700,7 +700,12 @@ data class NodeSnapshotEntity(
 )
 
 /**
- * NodeWithPin is a "POJO" used by Room to perform a JOIN.
+ * NodeWithPin is a "POJO" used by Room to perform a JOIN, creating a rich read-model.
+ *
+ * @property node The core entity data.
+ * @property pin The pinning status, joining the node with any active pin for today.
+ * @property tags The list of tags associated with the node, retrieved via a junction table.
+ * @property snapshots The historical content snapshots associated with the node.
  */
 @Immutable
 data class NodeWithPin(
@@ -727,5 +732,8 @@ data class NodeWithPin(
     )
     val snapshots: List<NodeSnapshotEntity> = emptyList(),
 ) {
+    /**
+     * Helper to quickly determine if the node is currently pinned to today's view.
+     */
     val isPinnedToToday: Boolean get() = pin != null
 }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -10,8 +10,19 @@ import com.tajemniktv.tajsos.data.isTaskItem
 import com.tajemniktv.tajsos.ui.MaintenanceSnapshot
 import com.tajemniktv.tajsos.ui.MaintenanceStatusItem
 
+/**
+ * Explicit maintenance item types that classify as financial responsibilities.
+ */
 private val financeMaintenanceTypes = setOf("bill", "subscription", "renewal")
+
+/**
+ * Explicit maintenance item types that classify as health and medical responsibilities.
+ */
 private val healthMaintenanceTypes = setOf("appointment", "prescription", "med_refill")
+
+/**
+ * Set of normalized tag names used to heuristically detect finance-related items.
+ */
 private val financeTagMarkers =
     setOf(
         "finance",
@@ -29,6 +40,10 @@ private val financeTagMarkers =
         "receipt",
         "insurance",
     )
+
+/**
+ * List of substring keywords used to search titles and content for financial context.
+ */
 private val financeTitleKeywords =
     listOf(
         "finance",
@@ -47,6 +62,10 @@ private val financeTitleKeywords =
         "salary",
         "paycheck",
     )
+
+/**
+ * Set of normalized tag names used to heuristically detect health-related items.
+ */
 private val healthTagMarkers =
     setOf(
         "health",
@@ -58,6 +77,10 @@ private val healthTagMarkers =
         "wellbeing",
         "mental_health",
     )
+
+/**
+ * List of substring keywords used to search titles and content for health and medical context.
+ */
 private val healthTitleKeywords =
     listOf(
         "health",


### PR DESCRIPTION
Adds missing KDocs to clarify implicit domain classification heuristics in DomainLensQueries and Room relation constraints in Entities.

---
*PR created automatically by Jules for task [1071403462316907573](https://jules.google.com/task/1071403462316907573) started by @tajemniktv*