### PR TITLE
perf: hoist list operations in InsightsDashboardBlocks to remember blocks

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsDashboardBlocks.kt
@@ -80,6 +80,16 @@ internal fun InsightsMainBlock(
     val allProjects by viewModel.allProjects.collectAsState()
     val projectsById = remember(allProjects) { allProjects.associateBy { it.id } }
 
+    /**
+     * Hoist dynamic list allocations out of the compose rendering phase to prevent
+     * redundant object creation on every recomposition.
+     */
+    val topAreas = remember(areaSnapshot) { areaSnapshot.areas.take(4) }
+    val highEntropyProjectKeys =
+        remember(insights) {
+            insights.projectEntropy.filter { it.value > 0.5 }.keys.toList()
+        }
+
     LazyColumn(
         modifier =
             Modifier
@@ -182,7 +192,7 @@ internal fun InsightsMainBlock(
                     disappearingCount = areaSnapshot.disappearingAreaIds.size,
                 )
             }
-            items(areaSnapshot.areas.take(4), key = { "area_${it.areaId}" }) { area ->
+            items(topAreas, key = { "area_${it.areaId}" }) { area ->
                 AreaHealthInsightCard(area)
             }
         }
@@ -264,8 +274,7 @@ internal fun InsightsMainBlock(
             }
         }
 
-        val highEntropyProjects = insights.projectEntropy.filter { it.value > 0.5 }
-        if (highEntropyProjects.isNotEmpty()) {
+        if (highEntropyProjectKeys.isNotEmpty()) {
             item {
                 Text(
                     stringResource(Res.string.insights_high_entropy_projects),
@@ -273,10 +282,10 @@ internal fun InsightsMainBlock(
                     color = TajsOSTheme.Error,
                 )
             }
-            items(highEntropyProjects.keys.toList(), key = { "entropy_$it" }) { projectId ->
+            items(highEntropyProjectKeys, key = { "entropy_$it" }) { projectId ->
                 val project = projectsById[projectId]
                 if (project != null) {
-                    ProjectEntropyItem(project, highEntropyProjects[projectId] ?: 0.0) {
+                    ProjectEntropyItem(project, insights.projectEntropy[projectId] ?: 0.0) {
                         onNavigateToProject(project.id)
                     }
                 }


### PR DESCRIPTION
Hoist list filtering and allocations out of the Jetpack Compose rendering phase in `InsightsDashboardBlocks.kt`.

Instead of calculating `areaSnapshot.areas.take(4)` and `insights.projectEntropy.filter { it.value > 0.5 }.keys.toList()` directly during every recomposition (which creates new list instances each time), these operations are now wrapped in `remember` blocks. This ensures they are only re-evaluated when their respective source data (`areaSnapshot` and `insights`) changes, reducing unnecessary CPU overhead and garbage collection pressure.

---
*PR created automatically by Jules for task [2918662926860315337](https://jules.google.com/task/2918662926860315337) started by @tajemniktv*