### PR TITLE
🧪 [Testing] Add missing dependency edge case test for PackRegistry

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
@@ -61,4 +61,22 @@ class PackRegistryTest {
             )
         assertTrue(registry.validateEnabledPacks().isEmpty())
     }
+
+    @Test
+    fun packRegistry_reportsMissingDependencies() {
+        // AppPack.FINANCE has a dependency on "maintenance"
+        val registry =
+            PackRegistry(
+                ownedPackKeys = setOf(AppPack.FINANCE.key, AppPack.MAINTENANCE.key),
+                enabledPackKeys = setOf(AppPack.FINANCE.key), // Only FINANCE enabled, missing MAINTENANCE
+            )
+
+        val missing = registry.validateEnabledPacks()
+
+        // Expected string format: "<packKey>:missing:<depKey>"
+        val expectedError = "${AppPack.FINANCE.key}:missing:${AppPack.MAINTENANCE.key}"
+
+        assertTrue(missing.contains(expectedError))
+        assertTrue(missing.size == 1)
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of testing for the negative edge case in `PackRegistry.validateEnabledPacks`. Previously, there was only a test verifying the happy path where no dependencies are missing. 

📊 **Coverage:** What scenarios are now tested
A new test `packRegistry_reportsMissingDependencies` was added. This test creates a scenario where `AppPack.FINANCE` is enabled and owned, but its dependency `AppPack.MAINTENANCE` is not enabled. The test verifies that `validateEnabledPacks()` returns exactly the correct string mapping the missing dependency (`finance:missing:maintenance`).

✨ **Result:** The improvement in test coverage
We now have proper confidence that the `validateEnabledPacks()` method behaves as intended when an enabled pack's dependencies are unsatisfied.

---
*PR created automatically by Jules for task [18100459125321632693](https://jules.google.com/task/18100459125321632693) started by @tajemniktv*