### PR TITLE
🧪 Add unit test for PackRegistry.isDependencySatisfied

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
@@ -61,4 +61,21 @@ class PackRegistryTest {
             )
         assertTrue(registry.validateEnabledPacks().isEmpty())
     }
+
+    @Test
+    fun isDependencySatisfied_returnsCorrectStatus() {
+        val registryNoDeps = PackRegistry(emptySet(), setOf(AppPack.MAINTENANCE.key))
+        val registryWithDeps = PackRegistry(emptySet(), setOf(AppPack.MAINTENANCE.key, AppPack.FINANCE.key))
+        val registryMissingDeps = PackRegistry(emptySet(), setOf(AppPack.FINANCE.key))
+
+        // STUDENT has no dependencies
+        assertTrue(registryNoDeps.isDependencySatisfied(AppPack.STUDENT))
+
+        // MAINTENANCE has no dependencies
+        assertTrue(registryNoDeps.isDependencySatisfied(AppPack.MAINTENANCE))
+
+        // FINANCE has dependency on MAINTENANCE
+        assertTrue(registryWithDeps.isDependencySatisfied(AppPack.FINANCE))
+        assertFalse(registryMissingDeps.isDependencySatisfied(AppPack.FINANCE))
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added missing unit test coverage for `PackRegistry.isDependencySatisfied` to ensure it properly validates dependencies against enabled packs.
📊 **Coverage:** Covered scenarios for packs with no dependencies, packs where dependencies are satisfied, and packs where dependencies are missing.
✨ **Result:** Improved test coverage and reliability for pack dependency validation logic.

---
*PR created automatically by Jules for task [684652241331605415](https://jules.google.com/task/684652241331605415) started by @tajemniktv*