### PR TITLE
🧪 Add tests for IcsCalendarProvider line unfolding edge cases

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProviderTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProviderTest.kt
@@ -305,4 +305,46 @@ class IcsCalendarProviderTest {
                 assertEquals(expectedCount, events.size, "Failed for URL: $url")
             }
         }
+
+    @Test
+    fun `test fold lines edge cases`(): TestResult =
+        runTest {
+            val ics =
+                "BEGIN:VCALENDAR\r\n" +
+                "BEGIN:VEVENT\r\n" +
+                "UID:edge-cases\r\n" +
+                // Tab continuation
+                "SUMMARY:Tab\r\n" +
+                "\tContinuation\r\n" +
+                // Empty string case - tested implicitly by parser not failing
+                "\r\n" +
+                // Trailing spaces on the continued line
+                "DESCRIPTION:Line 1\r\n" +
+                "  Line 2\r\n" +
+                "\t Line 3\r\n" +
+                // Multi-byte char split across folds (technically invalid ICS, but supported textually)
+                "LOCATION:🚀\r\n" +
+                " 🛸\r\n" +
+                "DTSTART:20231024T100000Z\r\n" +
+                "END:VEVENT\r\n" +
+                "END:VCALENDAR\r\n"
+
+            val provider = createProviderWithIcs(ics)
+            val events = provider.fetchEvents(testProviderEntity, defaultFrom, defaultTo)
+
+            assertEquals(1, events.size)
+            val event = events[0]
+
+            // "SUMMARY:Tab" + "	Continuation"
+            assertEquals("TabContinuation", event.title)
+
+            // "DESCRIPTION:Line 1" + "  Line 2" + "	 Line 3"
+            // Note: IcsCalendarProvider unescapeIcs might do something, let's assume it doesn't strip spaces
+            // " Line 2" -> " Line 2"
+            // " Line 3" -> " Line 3"
+            assertEquals("Line 1 Line 2 Line 3", event.description)
+
+            // "LOCATION:🚀" + " 🛸"
+            assertEquals("🚀🛸", event.location)
+        }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProviderTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProviderTest.kt
@@ -318,13 +318,13 @@ class IcsCalendarProviderTest {
                 "\tContinuation\r\n" +
                 // Empty string case - tested implicitly by parser not failing
                 "\r\n" +
-                // Trailing spaces on the continued line
-                "DESCRIPTION:Line 1\r\n" +
+                // Trailing spaces on the continued line (should be preserved)
+                "DESCRIPTION:Line 1 \r\n" +
                 "  Line 2\r\n" +
                 "\t Line 3\r\n" +
-                // Multi-byte char split across folds (technically invalid ICS, but supported textually)
-                "LOCATION:🚀\r\n" +
-                " 🛸\r\n" +
+                // Multi-byte char (surrogate pair) split across folds
+                "LOCATION:\uD83D\r\n" +
+                " \uDE80\r\n" +
                 "DTSTART:20231024T100000Z\r\n" +
                 "END:VEVENT\r\n" +
                 "END:VCALENDAR\r\n"
@@ -338,13 +338,10 @@ class IcsCalendarProviderTest {
             // "SUMMARY:Tab" + "	Continuation"
             assertEquals("TabContinuation", event.title)
 
-            // "DESCRIPTION:Line 1" + "  Line 2" + "	 Line 3"
-            // Note: IcsCalendarProvider unescapeIcs might do something, let's assume it doesn't strip spaces
-            // " Line 2" -> " Line 2"
-            // " Line 3" -> " Line 3"
-            assertEquals("Line 1 Line 2 Line 3", event.description)
+            // "DESCRIPTION:Line 1 " + " Line 2" + " Line 3"
+            assertEquals("Line 1  Line 2 Line 3", event.description)
 
-            // "LOCATION:🚀" + " 🛸"
-            assertEquals("🚀🛸", event.location)
+            // "LOCATION:\uD83D" + "\uDE80"
+            assertEquals("🚀", event.location)
         }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the `unfoldLines` method in `IcsCalendarProvider`, specifically focusing on edge cases involving folding, whitespace characters, and multi-byte characters.

📊 **Coverage:** The new test covers:
- Tab continuations
- Trailing spaces on folded lines
- Empty lines within folded sections (implicitly handled)
- Multi-byte characters (emojis) split across folds

✨ **Result:** Improved test coverage for ICS file parsing, resulting in increased confidence that the parser correctly handles unusual folding patterns according to the specification.

---
*PR created automatically by Jules for task [12267492128728967986](https://jules.google.com/task/12267492128728967986) started by @tajemniktv*