### PR TITLE
Fix: Pass missing title prop to Layout in Astro pages

### DIFF
--- a/website/src/pages/app.astro
+++ b/website/src/pages/app.astro
@@ -6,7 +6,7 @@ import Footer from '../components/landing/Footer.astro';
 const title = "APP";
 ---
 
-<Layout>
+<Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
 

--- a/website/src/pages/architecture.astro
+++ b/website/src/pages/architecture.astro
@@ -6,7 +6,7 @@ import Footer from '../components/landing/Footer.astro';
 const title = "ARCHITECTURE";
 ---
 
-<Layout>
+<Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
 

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -6,7 +6,7 @@ import Footer from '../components/landing/Footer.astro';
 const title = "PRICING";
 ---
 
-<Layout>
+<Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -6,7 +6,7 @@ import Footer from '../components/landing/Footer.astro';
 const title = "PRIVACY";
 ---
 
-<Layout>
+<Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   

--- a/website/src/pages/security.astro
+++ b/website/src/pages/security.astro
@@ -6,7 +6,7 @@ import Footer from '../components/landing/Footer.astro';
 const title = "SECURITY";
 ---
 
-<Layout>
+<Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   

--- a/website/src/pages/status.astro
+++ b/website/src/pages/status.astro
@@ -6,7 +6,7 @@ import Footer from '../components/landing/Footer.astro';
 const title = "SYSTEM STATUS";
 ---
 
-<Layout>
+<Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   

--- a/website/src/pages/terms.astro
+++ b/website/src/pages/terms.astro
@@ -6,7 +6,7 @@ import Footer from '../components/landing/Footer.astro';
 const title = "TERMS";
 ---
 
-<Layout>
+<Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   


### PR DESCRIPTION
This PR addresses TypeScript warnings (`ts(6133): 'title' is declared but its value is never read.`) across multiple Astro page components in the `website` project. 

The `title` variable was being initialized but not passed as a prop to the main `<Layout>` component, meaning the pages were not receiving their intended `<title>` tag for the browser tab. This has been corrected by changing `<Layout>` to `<Layout title={title}>` in the affected files.

Affected files:
- `website/src/pages/app.astro`
- `website/src/pages/architecture.astro`
- `website/src/pages/pricing.astro`
- `website/src/pages/privacy.astro`
- `website/src/pages/security.astro`
- `website/src/pages/status.astro`
- `website/src/pages/terms.astro`

Verified locally with `npm run check` and `npm run build` from the `website` directory.

---
*PR created automatically by Jules for task [11962429358606785924](https://jules.google.com/task/11962429358606785924) started by @tajemniktv*