### PR TITLE
fix: prevent fail-open authentication on missing biometrics

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -290,13 +290,10 @@ class MainActivity : FragmentActivity() {
 
     /**
      * Displays the system biometric prompt for user authentication.
-     * Automatically authenticates if hardware is unavailable.
-     *
      * @param viewModel The ViewModel to update upon successful authentication.
      */
     private fun showBiometricPrompt(viewModel: MainViewModel) {
         if (!isBiometricAvailable()) {
-            viewModel.setAuthenticated(true)
             return
         }
 


### PR DESCRIPTION
Removes the vulnerability where the application would automatically authenticate a user if biometric hardware was unavailable while biometrics were enabled. The `showBiometricPrompt` function now securely exits (fails-closed) when `!isBiometricAvailable()`, rather than calling `viewModel.setAuthenticated(true)`.

Also removes the outdated documentation asserting the fail-open behavior.

---
*PR created automatically by Jules for task [16668114598410964815](https://jules.google.com/task/16668114598410964815) started by @tajemniktv*