### PR TITLE
refactor: replace OnConflictStrategy.REPLACE with @Upsert in DAOs

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -7,10 +7,10 @@ package com.tajemniktv.tajsos.data
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
-import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
+import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -103,13 +103,13 @@ interface NodeDao {
      * @param node The [NodeEntity] to insert.
      * @return The auto-generated or existing primary key ID of the inserted node.
      */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertNode(node: NodeEntity): Long
 
     /**
      * Inserts multiple nodes, returning their generated identifiers.
      */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertNodes(nodes: List<NodeEntity>): List<Long>
 
     /**
@@ -134,7 +134,7 @@ interface NodeDao {
      *
      * @param pin The [TodayPinEntity] representing the pinned state.
      */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun pinToToday(pin: TodayPinEntity)
 
     /**
@@ -163,7 +163,7 @@ interface FocusSessionDao {
     @Query("SELECT * FROM focus_sessions ORDER BY startedAt DESC")
     fun getAllSessions(): Flow<List<FocusSessionEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertSession(session: FocusSessionEntity): Long
 
     @Update
@@ -181,13 +181,13 @@ interface TrackDao {
     @Query("SELECT * FROM track_entries ORDER BY date DESC, createdAt DESC")
     fun getAllTrackEntries(): Flow<List<TrackEntryEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long
 
     @Query("SELECT * FROM track_entries WHERE date = :date LIMIT 1")
     suspend fun getTrackEntryByDate(date: String): TrackEntryEntity?
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertTrackMedication(join: TrackMedicationJoinEntity)
 
     @Query("SELECT * FROM track_medications WHERE trackEntryId = :trackEntryId")
@@ -202,10 +202,10 @@ interface RelationDao {
     @Query("SELECT * FROM relations WHERE fromNodeId = :nodeId OR toNodeId = :nodeId")
     fun getRelationsForNode(nodeId: Long): Flow<List<RelationEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertRelation(relation: RelationEntity)
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertRelations(relations: List<RelationEntity>)
 
     @Delete
@@ -251,7 +251,7 @@ interface TagDao {
     @Query("SELECT * FROM tags")
     fun getAllTags(): Flow<List<TagEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertTag(tag: TagEntity): Long
 
     @Transaction
@@ -264,7 +264,7 @@ interface TagDao {
     )
     fun getTagsForNode(nodeId: Long): Flow<List<TagEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun attachTagToNode(nodeTag: NodeTagEntity)
 
     @Query("DELETE FROM node_tags WHERE nodeId = :nodeId AND tagId = :tagId")
@@ -288,10 +288,10 @@ interface EventLogDao {
     @Query("SELECT * FROM event_log WHERE nodeId = :nodeId OR relatedNodeId = :nodeId ORDER BY timestamp DESC")
     fun getLogsForNode(nodeId: Long): Flow<List<EventLogEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertLog(log: EventLogEntity)
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertLogs(logs: List<EventLogEntity>)
 }
 
@@ -306,7 +306,7 @@ interface AttachmentDao {
     @Query("SELECT * FROM attachments WHERE nodeId = :nodeId")
     fun getAttachmentsForNode(nodeId: Long): Flow<List<AttachmentEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertAttachment(attachment: AttachmentEntity)
 
     @Delete
@@ -336,7 +336,7 @@ interface InboxEntryDao {
     @Query("SELECT * FROM inbox_entries WHERE id = :id")
     suspend fun getInboxEntryById(id: Long): InboxEntryEntity?
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertInboxEntry(entry: InboxEntryEntity): Long
 
     @Update
@@ -357,7 +357,7 @@ interface TaskFacetDao {
     @Query("SELECT * FROM task_facets WHERE itemId = :itemId")
     fun observeTaskFacet(itemId: Long): Flow<TaskFacetEntity?>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertTaskFacet(facet: TaskFacetEntity)
 
     @Query("DELETE FROM task_facets WHERE itemId = :itemId")
@@ -378,7 +378,7 @@ interface NoteFacetDao {
     @Query("SELECT * FROM note_facets WHERE itemId = :itemId")
     fun observeNoteFacet(itemId: Long): Flow<NoteFacetEntity?>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertNoteFacet(facet: NoteFacetEntity)
 
     @Query("DELETE FROM note_facets WHERE itemId = :itemId")
@@ -399,7 +399,7 @@ interface ProjectFacetDao {
     @Query("SELECT * FROM project_facets WHERE itemId = :itemId")
     fun observeProjectFacet(itemId: Long): Flow<ProjectFacetEntity?>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertProjectFacet(facet: ProjectFacetEntity)
 
     @Query("DELETE FROM project_facets WHERE itemId = :itemId")
@@ -420,7 +420,7 @@ interface AreaFacetDao {
     @Query("SELECT * FROM area_facets WHERE itemId = :itemId")
     fun observeAreaFacet(itemId: Long): Flow<AreaFacetEntity?>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertAreaFacet(facet: AreaFacetEntity)
 
     @Query("DELETE FROM area_facets WHERE itemId = :itemId")
@@ -441,7 +441,7 @@ interface RecordFacetDao {
     @Query("SELECT * FROM record_facets WHERE itemId = :itemId")
     fun observeRecordFacet(itemId: Long): Flow<RecordFacetEntity?>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertRecordFacet(facet: RecordFacetEntity)
 
     @Query("DELETE FROM record_facets WHERE itemId = :itemId")
@@ -459,7 +459,7 @@ interface ItemDomainDao {
     @Query("SELECT * FROM item_domains WHERE itemId = :itemId ORDER BY isPrimary DESC, assignedAt ASC")
     fun getDomainsForItem(itemId: Long): Flow<List<ItemDomainEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertDomain(domain: ItemDomainEntity)
 
     @Query("DELETE FROM item_domains WHERE itemId = :itemId AND domainKey = :domainKey")
@@ -489,7 +489,7 @@ interface RichContentDocumentDao {
     @Query("SELECT * FROM rich_content_documents WHERE itemId = :itemId")
     suspend fun getDocumentForItem(itemId: Long): RichContentDocumentEntity?
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertDocument(document: RichContentDocumentEntity)
 
     @Query("DELETE FROM rich_content_documents WHERE itemId = :itemId")
@@ -538,10 +538,10 @@ interface ScheduleEntryDao {
     @Query("DELETE FROM schedule_entries WHERE itemId = :itemId")
     suspend fun deleteScheduleEntriesForItem(itemId: Long)
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertScheduleEntry(entry: ScheduleEntryEntity): Long
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertScheduleEntries(entries: List<ScheduleEntryEntity>)
 }
 
@@ -556,7 +556,7 @@ interface SavedViewDao {
     @Query("SELECT * FROM saved_views WHERE id = :id")
     suspend fun getSavedViewById(id: Long): SavedViewEntity?
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertSavedView(view: SavedViewEntity): Long
 
     @Update
@@ -571,7 +571,7 @@ interface SavedViewDao {
     @Query("SELECT * FROM saved_view_source_kinds WHERE viewId = :viewId")
     suspend fun getSourceKindsForView(viewId: Long): List<SavedViewSourceKindEntity>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertSavedViewSourceKinds(sourceKinds: List<SavedViewSourceKindEntity>)
 
     @Query("DELETE FROM saved_view_source_kinds WHERE viewId = :viewId")
@@ -583,7 +583,7 @@ interface SavedViewDao {
     @Query("SELECT * FROM saved_view_filters WHERE viewId = :viewId ORDER BY position ASC")
     suspend fun getFiltersForView(viewId: Long): List<SavedViewFilterEntity>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertSavedViewFilters(filters: List<SavedViewFilterEntity>)
 
     @Query("DELETE FROM saved_view_filters WHERE viewId = :viewId")
@@ -595,7 +595,7 @@ interface SavedViewDao {
     @Query("SELECT * FROM saved_view_sorts WHERE viewId = :viewId ORDER BY position ASC")
     suspend fun getSortsForView(viewId: Long): List<SavedViewSortEntity>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertSavedViewSorts(sorts: List<SavedViewSortEntity>)
 
     @Query("DELETE FROM saved_view_sorts WHERE viewId = :viewId")
@@ -607,7 +607,7 @@ interface SavedViewDao {
     @Query("SELECT * FROM saved_view_visible_fields WHERE viewId = :viewId ORDER BY position ASC")
     suspend fun getVisibleFieldsForView(viewId: Long): List<SavedViewVisibleFieldEntity>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertSavedViewVisibleFields(fields: List<SavedViewVisibleFieldEntity>)
 
     @Query("DELETE FROM saved_view_visible_fields WHERE viewId = :viewId")
@@ -622,10 +622,10 @@ interface TemplateDao {
     @Query("SELECT * FROM templates")
     fun getAllTemplates(): Flow<List<TemplateEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertTemplate(template: TemplateEntity)
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertTemplates(templates: List<TemplateEntity>)
 
     @Update
@@ -643,7 +643,7 @@ interface NodeSnapshotDao {
     @Query("SELECT * FROM node_snapshots WHERE nodeId = :nodeId ORDER BY timestamp DESC")
     fun getSnapshotsForNode(nodeId: Long): Flow<List<NodeSnapshotEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertSnapshot(snapshot: NodeSnapshotEntity)
 
     @Delete
@@ -661,7 +661,7 @@ interface ReviewDao {
     @Query("SELECT * FROM reviews ORDER BY completedAt DESC")
     fun getAllReviews(): Flow<List<ReviewEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertReview(review: ReviewEntity): Long
 
     @Query("SELECT * FROM reviews WHERE type = :type ORDER BY completedAt DESC LIMIT 1")
@@ -676,7 +676,7 @@ interface CalendarProviderDao {
     @Query("SELECT * FROM calendar_providers")
     fun getAllProviders(): Flow<List<CalendarProviderEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertProvider(provider: CalendarProviderEntity): Long
 
     @Update
@@ -700,13 +700,13 @@ interface CalendarEventDao {
         to: Long,
     ): Flow<List<CalendarEventEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEvents(events: List<CalendarEventEntity>)
 
     @Query("DELETE FROM calendar_events WHERE providerId = :providerId")
     suspend fun deleteEventsByProvider(providerId: Long)
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEvent(event: CalendarEventEntity): Long
 
     @Update
@@ -724,7 +724,7 @@ interface ModeDao {
     @Query("SELECT * FROM modes ORDER BY sortOrder ASC")
     fun getAllModes(): Flow<List<ModeEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertMode(mode: ModeEntity): Long
 
     @Update
@@ -736,25 +736,25 @@ interface ModeDao {
     @Query("SELECT * FROM mode_preferences WHERE modeId = :modeId")
     fun getPreferencesForMode(modeId: Long): Flow<ModePreferenceEntity?>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertPreference(preference: ModePreferenceEntity)
 
     @Query("SELECT * FROM mode_area_filters WHERE modeId = :modeId")
     fun getAreaFiltersForMode(modeId: Long): Flow<List<ModeAreaFilterEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertAreaFilter(filter: ModeAreaFilterEntity)
 
     @Query("SELECT * FROM mode_type_filters WHERE modeId = :modeId")
     fun getTypeFiltersForMode(modeId: Long): Flow<List<ModeTypeFilterEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertTypeFilter(filter: ModeTypeFilterEntity)
 
     @Query("SELECT * FROM mode_usage_logs ORDER BY activatedAt DESC")
     fun getAllUsageLogs(): Flow<List<ModeUsageLogEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertUsageLog(log: ModeUsageLogEntity): Long
 
     @Query("UPDATE mode_usage_logs SET deactivatedAt = :timestamp WHERE id = :id")
@@ -772,7 +772,7 @@ interface ProtocolDao {
     @Query("SELECT * FROM protocol_history ORDER BY executedAt DESC")
     fun getAllProtocolHistory(): Flow<List<ProtocolHistoryEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertProtocolHistory(history: ProtocolHistoryEntity): Long
 }
 
@@ -784,7 +784,7 @@ interface DecisionDao {
     @Query("SELECT * FROM decision_options WHERE decisionNodeId = :nodeId")
     fun getOptionsForDecision(nodeId: Long): Flow<List<DecisionOptionEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertDecisionOption(option: DecisionOptionEntity): Long
 
     @Update
@@ -802,7 +802,7 @@ interface UserDao {
     @Query("SELECT * FROM users WHERE id = 1 LIMIT 1")
     fun getUser(): Flow<UserEntity?>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertUser(user: UserEntity)
 
     @Update
@@ -817,7 +817,7 @@ interface MedicationDao {
     @Query("SELECT * FROM medications WHERE isEnabled = 1")
     fun getAllMedications(): Flow<List<MedicationEntity>>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertMedication(medication: MedicationEntity): Long
 
     @Update


### PR DESCRIPTION
Migrates all Room Data Access Objects (DAOs) in `shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt` from using `@Insert(onConflict = OnConflictStrategy.REPLACE)` to Room's `@Upsert` annotation.

Using `REPLACE` inherently causes a DELETE followed by an INSERT, which can trigger unintended cascading deletes on foreign keys and lead to silent data loss in related tables. Replacing it with `@Upsert` significantly improves database operation reliability, predictability, and safety, ensuring records are correctly inserted if new or updated if existing without triggering destructive constraints.

---
*PR created automatically by Jules for task [9260481119996079198](https://jules.google.com/task/9260481119996079198) started by @tajemniktv*