### PR TITLE
Potential fix for code scanning alert no. 263: Insecure local authentication

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -12,6 +12,8 @@ import android.os.Bundle
 import android.os.ParcelFormatException
 import android.speech.RecognizerIntent
 import android.util.Log
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -41,6 +43,10 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.google.firebase.FirebaseApp
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
 import com.tajemniktv.tajsos.data.createDataStore
 import com.tajemniktv.tajsos.data.createDatabase
 import com.tajemniktv.tajsos.di.SharedModule
@@ -59,6 +65,10 @@ import com.tajemniktv.tajsos.ui.MainViewModel
 class MainActivity : FragmentActivity() {
     companion object {
         private const val TAG = "MainActivity"
+        private const val BIOMETRIC_KEY_ALIAS = "tajsos_biometric_key"
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val CIPHER_TRANSFORMATION =
+            "${KeyProperties.KEY_ALGORITHM_AES}/${KeyProperties.BLOCK_MODE_CBC}/${KeyProperties.ENCRYPTION_PADDING_PKCS7}"
     }
 
     /** The main view model for app-level orchestration. */
@@ -288,6 +298,27 @@ class MainActivity : FragmentActivity() {
         }
     }
 
+    private fun getOrCreateSecretKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        (keyStore.getKey(BIOMETRIC_KEY_ALIAS, null) as? SecretKey)?.let { return it }
+
+        val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+        val keyGenParameterSpec =
+            KeyGenParameterSpec
+                .Builder(
+                    BIOMETRIC_KEY_ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                ).setBlockModes(KeyProperties.BLOCK_MODE_CBC)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                .setUserAuthenticationRequired(true)
+                .setInvalidatedByBiometricEnrollment(true)
+                .build()
+        keyGenerator.init(keyGenParameterSpec)
+        return keyGenerator.generateKey()
+    }
+
+    private fun getCipher(): Cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
+
     /**
      * Displays the system biometric prompt for user authentication.
      * @param viewModel The ViewModel to update upon successful authentication.
@@ -297,6 +328,16 @@ class MainActivity : FragmentActivity() {
             return
         }
 
+        val cipher =
+            try {
+                getCipher().apply {
+                    init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to initialize biometric crypto", e)
+                return
+            }
+
         val executor = ContextCompat.getMainExecutor(this)
         val biometricPrompt =
             BiometricPrompt(
@@ -305,7 +346,10 @@ class MainActivity : FragmentActivity() {
                 object : BiometricPrompt.AuthenticationCallback() {
                     override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
                         super.onAuthenticationSucceeded(result)
-                        viewModel.setAuthenticated(true)
+                        val authCipher = result.cryptoObject?.cipher ?: return
+                        runCatching { authCipher.doFinal("auth".toByteArray()) }
+                            .onSuccess { viewModel.setAuthenticated(true) }
+                            .onFailure { Log.e(TAG, "Biometric crypto operation failed", it) }
                     }
                 },
             )
@@ -318,7 +362,7 @@ class MainActivity : FragmentActivity() {
                     BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL,
                 ).build()
 
-        biometricPrompt.authenticate(promptInfo)
+        biometricPrompt.authenticate(promptInfo, BiometricPrompt.CryptoObject(cipher))
     }
 
     /**

--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -14,6 +14,7 @@ import android.speech.RecognizerIntent
 import android.util.Log
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
+import android.security.keystore.KeyPermanentlyInvalidatedException
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -68,7 +69,7 @@ class MainActivity : FragmentActivity() {
         private const val BIOMETRIC_KEY_ALIAS = "tajsos_biometric_key"
         private const val ANDROID_KEYSTORE = "AndroidKeyStore"
         private const val CIPHER_TRANSFORMATION =
-            "${KeyProperties.KEY_ALGORITHM_AES}/${KeyProperties.BLOCK_MODE_CBC}/${KeyProperties.ENCRYPTION_PADDING_PKCS7}"
+            "${KeyProperties.KEY_ALGORITHM_AES}/${KeyProperties.BLOCK_MODE_GCM}/${KeyProperties.ENCRYPTION_PADDING_NONE}"
     }
 
     /** The main view model for app-level orchestration. */
@@ -308,8 +309,8 @@ class MainActivity : FragmentActivity() {
                 .Builder(
                     BIOMETRIC_KEY_ALIAS,
                     KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
-                ).setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                 .setUserAuthenticationRequired(true)
                 .setInvalidatedByBiometricEnrollment(true)
                 .build()

--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -326,7 +326,7 @@ class MainActivity : FragmentActivity() {
                         // Require auth on every key use (timeout = 0 means no time window).
                         setUserAuthenticationParameters(0, KeyProperties.AUTH_BIOMETRIC_STRONG)
                     } else {
-                        // -1 mirrors the "per-use" semantic of timeout = 0 on API 30+.
+                        // On API < 30, -1 is the documented constant for per-use authentication.
                         setUserAuthenticationRequired(true)
                         @Suppress("DEPRECATION")
                         setUserAuthenticationValidityDurationSeconds(-1)
@@ -452,7 +452,7 @@ class MainActivity : FragmentActivity() {
      * cancellation (e.g. pressing Cancel or the back button) rather than a terminal
      * hardware or security failure.
      *
-     * Use this to distinguish errors where calling [com.tajemniktv.tajsos.ui.MainViewModel.setAuthenticated]
+     * Use this to distinguish errors where calling [MainViewModel.setAuthenticated]
      * is unnecessary because the user intends to stay on the lock screen and retry later.
      */
     private fun isBiometricUserCancellation(errorCode: Int): Boolean =

--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -356,8 +356,8 @@ class MainActivity : FragmentActivity() {
                 getCipher().apply {
                     init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
                 }
-            } catch (inner: GeneralSecurityException) {
-                Log.e(TAG, "Failed to reinitialize cipher after key regeneration", inner)
+            } catch (regenerationException: GeneralSecurityException) {
+                Log.e(TAG, "Failed to reinitialize cipher after key regeneration", regenerationException)
                 null
             }
         } catch (e: GeneralSecurityException) {
@@ -403,7 +403,14 @@ class MainActivity : FragmentActivity() {
                     ) {
                         super.onAuthenticationError(errorCode, errString)
                         Log.e(TAG, "Biometric authentication error [$errorCode]: $errString")
-                        viewModel.setAuthenticated(false)
+                        // User-initiated dismissal is not a security failure — the lock screen
+                        // stays visible and the user can retry via the Unlock button.
+                        val isUserCancellation =
+                            errorCode == BiometricPrompt.ERROR_USER_CANCELED ||
+                                errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON
+                        if (!isUserCancellation) {
+                            viewModel.setAuthenticated(false)
+                        }
                     }
 
                     override fun onAuthenticationFailed() {

--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -323,9 +323,13 @@ class MainActivity : FragmentActivity() {
                 .setInvalidatedByBiometricEnrollment(true)
                 .apply {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        // Require auth on every key use (timeout = 0 means no time window).
                         setUserAuthenticationParameters(0, KeyProperties.AUTH_BIOMETRIC_STRONG)
                     } else {
+                        // -1 mirrors the "per-use" semantic of timeout = 0 on API 30+.
                         setUserAuthenticationRequired(true)
+                        @Suppress("DEPRECATION")
+                        setUserAuthenticationValidityDurationSeconds(-1)
                     }
                 }.build()
         keyGenerator.init(spec)
@@ -405,10 +409,7 @@ class MainActivity : FragmentActivity() {
                         Log.e(TAG, "Biometric authentication error [$errorCode]: $errString")
                         // User-initiated dismissal is not a security failure — the lock screen
                         // stays visible and the user can retry via the Unlock button.
-                        val isUserCancellation =
-                            errorCode == BiometricPrompt.ERROR_USER_CANCELED ||
-                                errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON
-                        if (!isUserCancellation) {
+                        if (!isBiometricUserCancellation(errorCode)) {
                             viewModel.setAuthenticated(false)
                         }
                     }
@@ -445,6 +446,18 @@ class MainActivity : FragmentActivity() {
         return biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG) ==
             BiometricManager.BIOMETRIC_SUCCESS
     }
+
+    /**
+     * Returns `true` for [BiometricPrompt] error codes that represent deliberate user
+     * cancellation (e.g. pressing Cancel or the back button) rather than a terminal
+     * hardware or security failure.
+     *
+     * Use this to distinguish errors where calling [com.tajemniktv.tajsos.ui.MainViewModel.setAuthenticated]
+     * is unnecessary because the user intends to stay on the lock screen and retry later.
+     */
+    private fun isBiometricUserCancellation(errorCode: Int): Boolean =
+        errorCode == BiometricPrompt.ERROR_USER_CANCELED ||
+            errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON
 
     /**
      * Called when the activity is no longer visible.

--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -15,6 +15,7 @@ import android.util.Log
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.security.keystore.KeyPermanentlyInvalidatedException
+import java.security.GeneralSecurityException
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -299,45 +300,88 @@ class MainActivity : FragmentActivity() {
         }
     }
 
+    /**
+     * Retrieves the existing Keystore-backed AES key or creates a new one.
+     *
+     * On API 30+ the key is explicitly bound to strong biometric authentication using
+     * [KeyProperties.AUTH_BIOMETRIC_STRONG] via [KeyGenParameterSpec.Builder.setUserAuthenticationParameters].
+     * On earlier API levels [KeyGenParameterSpec.Builder.setUserAuthenticationRequired] is used.
+     * The key is invalidated whenever new biometric enrolment occurs.
+     */
     private fun getOrCreateSecretKey(): SecretKey {
         val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
         (keyStore.getKey(BIOMETRIC_KEY_ALIAS, null) as? SecretKey)?.let { return it }
 
         val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
-        val keyGenParameterSpec =
+        val spec =
             KeyGenParameterSpec
                 .Builder(
                     BIOMETRIC_KEY_ALIAS,
                     KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
                 ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                .setUserAuthenticationRequired(true)
                 .setInvalidatedByBiometricEnrollment(true)
-                .build()
-        keyGenerator.init(keyGenParameterSpec)
+                .apply {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        setUserAuthenticationParameters(0, KeyProperties.AUTH_BIOMETRIC_STRONG)
+                    } else {
+                        setUserAuthenticationRequired(true)
+                    }
+                }.build()
+        keyGenerator.init(spec)
         return keyGenerator.generateKey()
     }
 
+    /** Returns a new [Cipher] instance configured for [CIPHER_TRANSFORMATION]. */
     private fun getCipher(): Cipher = Cipher.getInstance(CIPHER_TRANSFORMATION)
 
     /**
+     * Initialises a [Cipher] in [Cipher.ENCRYPT_MODE] using the Keystore-backed key.
+     *
+     * If the existing key has been permanently invalidated (e.g. after a biometric enrolment
+     * change) it is deleted and a fresh key is provisioned before retrying.
+     *
+     * @return An initialised [Cipher], or `null` if initialisation fails.
+     */
+    private fun initCipher(): Cipher? {
+        return try {
+            getCipher().apply {
+                init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
+            }
+        } catch (e: KeyPermanentlyInvalidatedException) {
+            Log.w(TAG, "Biometric key invalidated, regenerating key", e)
+            try {
+                val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+                keyStore.deleteEntry(BIOMETRIC_KEY_ALIAS)
+                getCipher().apply {
+                    init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
+                }
+            } catch (inner: GeneralSecurityException) {
+                Log.e(TAG, "Failed to reinitialize cipher after key regeneration", inner)
+                null
+            }
+        } catch (e: GeneralSecurityException) {
+            Log.e(TAG, "Failed to initialize biometric cipher", e)
+            null
+        }
+    }
+
+    /**
      * Displays the system biometric prompt for user authentication.
-     * @param viewModel The ViewModel to update upon successful authentication.
+     *
+     * Biometric unlock is cryptographically bound to the Android Keystore through a
+     * [BiometricPrompt.CryptoObject]. Authentication succeeds only when the hardware
+     * biometric sensor approves the operation **and** the Keystore-backed cipher can
+     * complete successfully.
+     *
+     * @param viewModel The ViewModel to update upon successful or failed authentication.
      */
     private fun showBiometricPrompt(viewModel: MainViewModel) {
         if (!isBiometricAvailable()) {
             return
         }
 
-        val cipher =
-            try {
-                getCipher().apply {
-                    init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to initialize biometric crypto", e)
-                return
-            }
+        val cipher = initCipher() ?: return
 
         val executor = ContextCompat.getMainExecutor(this)
         val biometricPrompt =
@@ -352,6 +396,20 @@ class MainActivity : FragmentActivity() {
                             .onSuccess { viewModel.setAuthenticated(true) }
                             .onFailure { Log.e(TAG, "Biometric crypto operation failed", it) }
                     }
+
+                    override fun onAuthenticationError(
+                        errorCode: Int,
+                        errString: CharSequence,
+                    ) {
+                        super.onAuthenticationError(errorCode, errString)
+                        Log.e(TAG, "Biometric authentication error [$errorCode]: $errString")
+                        viewModel.setAuthenticated(false)
+                    }
+
+                    override fun onAuthenticationFailed() {
+                        super.onAuthenticationFailed()
+                        Log.w(TAG, "Biometric authentication attempt failed")
+                    }
                 },
             )
 
@@ -359,23 +417,26 @@ class MainActivity : FragmentActivity() {
             BiometricPrompt.PromptInfo
                 .Builder()
                 .setTitle(getString(R.string.auth_biometric_title))
-                .setAllowedAuthenticators(
-                    BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL,
-                ).build()
+                .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+                .setNegativeButtonText(getString(R.string.auth_biometric_cancel))
+                .build()
 
         biometricPrompt.authenticate(promptInfo, BiometricPrompt.CryptoObject(cipher))
     }
 
     /**
-     * Checks if biometric authentication hardware is available and configured on the device.
+     * Checks if strong biometric authentication hardware is available and enrolled on the device.
      *
-     * @return True if biometrics can be used for authentication.
+     * Only [BiometricManager.Authenticators.BIOMETRIC_STRONG] is checked because the biometric
+     * prompt uses a [BiometricPrompt.CryptoObject] which is incompatible with device-credential
+     * fallback.
+     *
+     * @return `true` if strong biometrics can be used for authentication.
      */
     private fun isBiometricAvailable(): Boolean {
         val biometricManager = BiometricManager.from(this)
-        return biometricManager.canAuthenticate(
-            BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL,
-        ) == BiometricManager.BIOMETRIC_SUCCESS
+        return biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG) ==
+            BiometricManager.BIOMETRIC_SUCCESS
     }
 
     /**

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="next_step">Next step</string>
     <string name="untitled">Untitled</string>
     <string name="auth_biometric_title">Biometric login</string>
+    <string name="auth_biometric_cancel">Cancel</string>
     <string name="voice_speak_now">Speak now...</string>
     <string name="intent_shared_image">Shared Image</string>
     <string name="intent_shared_images">Shared Images</string>


### PR DESCRIPTION
Potential fix for [https://github.com/tajemniktv/TajsOS/security/code-scanning/263](https://github.com/tajemniktv/TajsOS/security/code-scanning/263)

Use Android Keystore-backed cryptography and require biometric success to unlock a cipher operation.

Best fix in this file:
1. Add imports for `KeyGenParameterSpec`, `KeyProperties`, `KeyStore`, `KeyGenerator`, `SecretKey`, and `Cipher`.
2. Define constants for keystore alias and cipher transformation.
3. Add helper methods in `MainActivity`:
   - `getOrCreateSecretKey()`
   - `getCipher()`
4. In `showBiometricPrompt`, initialize cipher in `ENCRYPT_MODE` with the keystore key.
5. Call `biometricPrompt.authenticate(promptInfo, BiometricPrompt.CryptoObject(cipher))` (the overload with `CryptoObject`).
6. In `onAuthenticationSucceeded`, require `result.cryptoObject?.cipher` to be present (and optionally execute `doFinal` on benign challenge bytes) before calling `viewModel.setAuthenticated(true)`.

This keeps existing behavior (successful biometric unlock sets authenticated) while cryptographically binding success to Keystore-backed auth.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
