### PR TITLE
feat(ui): Add ghost border styling for secondary ActionButtons

### DIFF
--- a/androidApp/src/main/res/values-pl/strings.xml
+++ b/androidApp/src/main/res/values-pl/strings.xml
@@ -8,6 +8,7 @@
     <string name="next_step">Następny krok</string>
     <string name="untitled">Bez tytułu</string>
     <string name="auth_biometric_title">Logowanie biometryczne</string>
+    <string name="auth_biometric_cancel">Anuluj</string>
     <string name="voice_speak_now">Mów teraz...</string>
     <string name="intent_shared_image">Udostępniony obraz</string>
     <string name="intent_shared_images">Udostępnione obrazy</string>

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -44,11 +44,18 @@ fun ActionButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    containerColor: Color = TajsOSTheme.Surface,
+    containerColor: Color = TajsOSTheme.SurfaceHighest,
     contentColor: Color = TajsOSTheme.Text,
     icon: ImageVector? = null,
 ) {
     val isPrimary = containerColor == TajsOSTheme.Primary
+    val isGhost = containerColor == Color.Transparent
+    val buttonBorder = if (!isPrimary && !isGhost) {
+        androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.GhostBorder)
+    } else {
+        null
+    }
+
     val finalModifier = modifier.height(48.dp).then(
         if (isPrimary && enabled) {
             Modifier.background(
@@ -73,6 +80,7 @@ fun ActionButton(
             contentColor = if (isPrimary && contentColor == TajsOSTheme.Text) TajsOSTheme.Background else contentColor,
         ),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        border = buttonBorder,
         contentPadding = PaddingValues(horizontal = 16.dp),
     ) {
         if (icon != null) {


### PR DESCRIPTION
This PR introduces the styling described in `DESIGN.md` for secondary ActionButtons. It ensures that standard buttons (not transparent and not `TajsOSTheme.Primary`) receive a 1dp `BorderStroke` using the designated `GhostBorder` color.

Additionally, the default `containerColor` has been updated to `TajsOSTheme.SurfaceHighest` to provide a subtle background lift compared to standard surfaces.

---
*PR created automatically by Jules for task [8730352025412425510](https://jules.google.com/task/8730352025412425510) started by @tajemniktv*