### PR TITLE
fix(ui): replace undefined glass-card with glass-panel in pricing

### DIFF
--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -35,7 +35,7 @@ const title = "PRICING";
 <!-- Pricing Cards -->
 <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-32">
 <!-- Tier 1: Initiate -->
-<div class="glass-card glow-hover p-8 rounded-xl flex flex-col transition-all duration-500">
+<div class="glass-panel hover:shadow-[0_0_50px_rgba(186,158,255,0.08)] p-8 rounded-xl flex flex-col transition-all duration-500">
 <div class="flex justify-between items-start mb-12">
 <div>
 <h3 class="font-headline text-2xl font-bold uppercase tracking-tight mb-2">Initiate</h3>
@@ -66,7 +66,7 @@ const title = "PRICING";
 <button class="w-full py-4 border border-outline-variant hover:border-primary/50 text-on-surface font-label font-bold uppercase tracking-widest text-xs rounded-lg transition-all">Select Protocol</button>
 </div>
 <!-- Tier 2: Synapse (Featured) -->
-<div class="relative glass-card glow-hover p-8 rounded-xl flex flex-col transition-all duration-500 bg-surface-container-high/60 ring-1 ring-primary/40">
+<div class="relative glass-panel hover:shadow-[0_0_50px_rgba(186,158,255,0.08)] p-8 rounded-xl flex flex-col transition-all duration-500 bg-surface-container-high/60 ring-1 ring-primary/40">
 <div class="absolute -top-4 left-1/2 -translate-x-1/2 bg-primary text-on-primary-fixed px-4 py-1 rounded-full text-[10px] font-bold uppercase tracking-widest">Recommended</div>
 <div class="flex justify-between items-start mb-12">
 <div>
@@ -98,7 +98,7 @@ const title = "PRICING";
 <button class="w-full py-4 bg-gradient-to-br from-primary to-primary-dim text-on-primary-fixed font-label font-bold uppercase tracking-widest text-xs rounded-lg shadow-[0_0_20px_rgba(186,158,255,0.3)] hover:shadow-[0_0_30px_rgba(186,158,255,0.5)] transition-all">Inject Protocol</button>
 </div>
 <!-- Tier 3: Transcend -->
-<div class="glass-card glow-hover p-8 rounded-xl flex flex-col transition-all duration-500">
+<div class="glass-panel hover:shadow-[0_0_50px_rgba(186,158,255,0.08)] p-8 rounded-xl flex flex-col transition-all duration-500">
 <div class="flex justify-between items-start mb-12">
 <div>
 <h3 class="font-headline text-2xl font-bold uppercase tracking-tight mb-2">Transcend</h3>
@@ -181,7 +181,7 @@ const title = "PRICING";
 <section class="max-w-4xl">
 <h2 class="font-headline text-4xl font-bold mb-12 tracking-tight">PROTOCOL // <span class="text-primary-dim">FAQ</span></h2>
 <div class="space-y-4">
-<details class="group glass-card rounded-lg overflow-hidden border-none">
+<details class="group glass-panel rounded-lg overflow-hidden border-none">
 <summary class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors">
 <span class="font-label text-sm font-medium tracking-tight">How secure is my neural data payload?</span>
 <span class="material-symbols-outlined group-open:rotate-180 transition-transform">expand_more</span>
@@ -190,7 +190,7 @@ const title = "PRICING";
                         TajsOS employs end-to-end polymorphic encryption. Your data is fragmented across decentralized nodes; only your private neural key can reconstruct the interface.
                     </div>
 </details>
-<details class="group glass-card rounded-lg overflow-hidden border-none">
+<details class="group glass-panel rounded-lg overflow-hidden border-none">
 <summary class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors">
 <span class="font-label text-sm font-medium tracking-tight">Can I downgrade my subscription tier?</span>
 <span class="material-symbols-outlined group-open:rotate-180 transition-transform">expand_more</span>
@@ -199,7 +199,7 @@ const title = "PRICING";
                         Downgrades take effect at the end of the current billing cycle. Data overages will be archived but inaccessible until the tier is restored.
                     </div>
 </details>
-<details class="group glass-card rounded-lg overflow-hidden border-none">
+<details class="group glass-panel rounded-lg overflow-hidden border-none">
 <summary class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors">
 <span class="font-label text-sm font-medium tracking-tight">What happens if my neural link fails?</span>
 <span class="material-symbols-outlined group-open:rotate-180 transition-transform">expand_more</span>


### PR DESCRIPTION
Replaced undefined `glass-card` class with `glass-panel` and `glow-hover` with equivalent tailwind utility class `hover:shadow-[0_0_50px_rgba(186,158,255,0.08)]` in `website/src/pages/pricing.astro`. This standardizes the appearance according to DESIGN.md guidelines.

---
*PR created automatically by Jules for task [9018961268388370171](https://jules.google.com/task/9018961268388370171) started by @tajemniktv*