### PR TITLE
rel: migrate Room DAOs to Upsert

### DIFF
--- a/androidApp/src/main/res/values-pl/strings.xml
+++ b/androidApp/src/main/res/values-pl/strings.xml
@@ -11,4 +11,5 @@
     <string name="voice_speak_now">Mów teraz...</string>
     <string name="intent_shared_image">Udostępniony obraz</string>
     <string name="intent_shared_images">Udostępnione obrazy</string>
+    <string name="auth_biometric_cancel">Anuluj</string>
 </resources>

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -11,5 +11,5 @@ toolchainUrl.UNIX.AARCH64=https\://api.foojay.io/disco/v3.0/ids/c62cde58307f80ae
 toolchainUrl.UNIX.X86_64=https\://api.foojay.io/disco/v3.0/ids/a270f8fac04d83e81466c2ba13927394/redirect
 toolchainUrl.WINDOWS.AARCH64=https\://api.foojay.io/disco/v3.0/ids/11475beef5ea78d49677154a79375860/redirect
 toolchainUrl.WINDOWS.X86_64=https\://api.foojay.io/disco/v3.0/ids/0b126bb77c99f12f4d12f803b8df887c/redirect
-#toolchainVendor=JETBRAINS
+toolchainVendor=JETBRAINS
 toolchainVersion=25

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -11,5 +11,5 @@ toolchainUrl.UNIX.AARCH64=https\://api.foojay.io/disco/v3.0/ids/c62cde58307f80ae
 toolchainUrl.UNIX.X86_64=https\://api.foojay.io/disco/v3.0/ids/a270f8fac04d83e81466c2ba13927394/redirect
 toolchainUrl.WINDOWS.AARCH64=https\://api.foojay.io/disco/v3.0/ids/11475beef5ea78d49677154a79375860/redirect
 toolchainUrl.WINDOWS.X86_64=https\://api.foojay.io/disco/v3.0/ids/0b126bb77c99f12f4d12f803b8df887c/redirect
-toolchainVendor=JETBRAINS
+#toolchainVendor=JETBRAINS
 toolchainVersion=25

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -102,13 +102,13 @@ interface NodeDao {
      * @param node The [NodeEntity] to insert.
      * @return The auto-generated or existing primary key ID of the inserted node.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertNode(node: NodeEntity): Long
 
     /**
      * Inserts multiple nodes, returning their generated or existing identifiers.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertNodes(nodes: List<NodeEntity>): List<Long>
 
     /**
@@ -133,7 +133,7 @@ interface NodeDao {
      *
      * @param pin The [TodayPinEntity] representing the pinned state.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun pinToToday(pin: TodayPinEntity)
 
     /**
@@ -180,7 +180,7 @@ interface TrackDao {
     @Query("SELECT * FROM track_entries ORDER BY date DESC, createdAt DESC")
     fun getAllTrackEntries(): Flow<List<TrackEntryEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long
 
     @Query("SELECT * FROM track_entries WHERE date = :date LIMIT 1")
@@ -201,10 +201,10 @@ interface RelationDao {
     @Query("SELECT * FROM relations WHERE fromNodeId = :nodeId OR toNodeId = :nodeId")
     fun getRelationsForNode(nodeId: Long): Flow<List<RelationEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertRelation(relation: RelationEntity)
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertRelations(relations: List<RelationEntity>)
 
     @Delete
@@ -699,13 +699,13 @@ interface CalendarEventDao {
         to: Long,
     ): Flow<List<CalendarEventEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEvents(events: List<CalendarEventEntity>)
 
     @Query("DELETE FROM calendar_events WHERE providerId = :providerId")
     suspend fun deleteEventsByProvider(providerId: Long)
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEvent(event: CalendarEventEntity): Long
 
     @Update


### PR DESCRIPTION
Migrated all `@Insert(onConflict = REPLACE)` annotations to `@Upsert` in `Daos.kt` to prevent silent data loss from cascading deletes and improve performance.

---
*PR created automatically by Jules for task [16459330640199737684](https://jules.google.com/task/16459330640199737684) started by @tajemniktv*