### PR TITLE
feat(ui): migrate website to tailwind v4 linear gradients

### DIFF
--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -38,7 +38,7 @@ const title = "Changelog";
 </div>
 </div>
 <div class="w-full h-1.5 bg-surface-container-lowest rounded-full overflow-hidden">
-<div class="h-full bg-gradient-to-r from-primary-dim to-primary w-[42%]"></div>
+<div class="h-full bg-linear-to-r from-primary-dim to-primary w-[42%]"></div>
 </div>
 </div>
 <!-- Neural Load -->

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -95,7 +95,7 @@ const title = "PRICING";
 <span>Multi-Kernel Synchronization</span>
 </li>
 </ul>
-<button class="w-full py-4 bg-gradient-to-br from-primary to-primary-dim text-on-primary-fixed font-label font-bold uppercase tracking-widest text-xs rounded-lg shadow-[0_0_20px_rgba(186,158,255,0.3)] hover:shadow-[0_0_30px_rgba(186,158,255,0.5)] transition-all">Inject Protocol</button>
+<button class="w-full py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-label font-bold uppercase tracking-widest text-xs rounded-lg shadow-[0_0_20px_rgba(186,158,255,0.3)] hover:shadow-[0_0_30px_rgba(186,158,255,0.5)] transition-all">Inject Protocol</button>
 </div>
 <!-- Tier 3: Transcend -->
 <div class="bg-surface-container-low glow-hover p-8 rounded-xl flex flex-col transition-all duration-500">

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -157,7 +157,7 @@ const title = "PRIVACY";
 <section class="text-center py-20 border-t border-outline-variant/10">
 <h2 class="font-headline text-5xl font-bold mb-8">Ready to reclaim your <span class="text-primary">digital ghost?</span></h2>
 <div class="flex flex-col sm:flex-row justify-center gap-6">
-<button class="bg-gradient-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold py-4 px-10 rounded-lg hover:scale-105 transition-transform duration-300 flex items-center gap-3 mx-auto sm:mx-0">
+<button class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold py-4 px-10 rounded-lg hover:scale-105 transition-transform duration-300 flex items-center gap-3 mx-auto sm:mx-0">
                     INITIALIZE INTERFACE <span class="material-symbols-outlined" data-icon="bolt">bolt</span>
 </button>
 <button class="bg-surface-container-highest text-on-surface font-headline font-bold py-4 px-10 rounded-lg border border-outline-variant/30 hover:bg-surface-container-high transition-colors mx-auto sm:mx-0">

--- a/website/src/pages/security.astro
+++ b/website/src/pages/security.astro
@@ -191,7 +191,7 @@ const title = "SECURITY";
 <div class="relative">
 <div class="absolute -top-12 -left-12 w-64 h-64 bg-primary/10 rounded-full blur-3xl"></div>
 <img alt="Abstract technical representation of cryptographic layers and data streams" class="w-full aspect-square object-cover rounded-3xl mix-blend-luminosity opacity-40 grayscale" data-alt="Technical visualization of digital encryption layers" src="https://lh3.googleusercontent.com/aida-public/AB6AXuAj8yb6ml9lXksULfmKi8lbt5WsCrxNmfnQ32Vaj_il6eOXEDRCpqrhtB_D9LuEBVztydHUiM9Bt_A0igMJ8EVKhgKet8t2AqsnNEzSEH-DoAifuTw60Tkq-U6w7-7dkVvEhbAeHccIn5lbs_L5DGhE-GaKH3Td7DsCrj7FI2IH57mpXDFcBRbSIdULjs1SgKSH_u8SKpKdt8L7pWZgW0CW7R3IfFT2SGR3Ved6nPLDX_j2c0l-JksjP_UXzDAYvJDaA8B-IQINqSo"/>
-<div class="absolute inset-0 bg-gradient-to-t from-background via-transparent to-transparent"></div>
+<div class="absolute inset-0 bg-linear-to-t from-background via-transparent to-transparent"></div>
 <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex gap-4">
 <div class="glass-panel w-20 h-20 rounded-2xl flex items-center justify-center border-primary/40 neon-glow-primary">
 <span class="font-headline font-bold text-2xl">AES</span>

--- a/website/src/pages/terms.astro
+++ b/website/src/pages/terms.astro
@@ -165,7 +165,7 @@ const title = "TERMS";
 <button class="flex-1 md:flex-none px-8 py-4 bg-surface-container-highest text-on-surface font-label text-sm font-bold rounded-xl border border-outline-variant/30 hover:bg-surface-variant transition-all">
                             Download Whitepaper
                         </button>
-<button class="flex-1 md:flex-none px-12 py-4 bg-gradient-to-br from-primary to-primary-dim text-on-primary font-label text-sm font-bold rounded-xl shadow-[0_0_20px_rgba(186,158,255,0.4)] active:scale-95 transition-all">
+<button class="flex-1 md:flex-none px-12 py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary font-label text-sm font-bold rounded-xl shadow-[0_0_20px_rgba(186,158,255,0.4)] active:scale-95 transition-all">
                             Accept Protocol
                         </button>
 </div>

--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -38,7 +38,7 @@ const title = "WAITLIST";
             </p>
 <!-- Waitlist Module -->
 <div class="w-full max-w-lg group relative">
-<div class="absolute -inset-0.5 bg-gradient-to-r from-primary to-primary-dim rounded-xl blur opacity-20 group-focus-within:opacity-50 transition duration-1000"></div>
+<div class="absolute -inset-0.5 bg-linear-to-r from-primary to-primary-dim rounded-xl blur opacity-20 group-focus-within:opacity-50 transition duration-1000"></div>
 <form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-outline-variant/30 rounded-xl overflow-hidden focus-within:border-primary transition-all duration-500">
 <label for="waitlist-email" class="sr-only">Email address</label>
 <input id="waitlist-email" class="bg-transparent border-none focus:ring-0 text-on-surface placeholder:text-outline font-mono py-5 px-6 w-full text-lg" placeholder="email@example.com" type="email" required autocomplete="email"/>


### PR DESCRIPTION
Replaced deprecated Tailwind CSS v3 `bg-gradient-to-*` utility classes with modern v4 `bg-linear-to-*` classes across the Astro website codebase. This ensures compatibility with current dependencies and clears migration debt for the design system. Verified with Astro check and build.

---
*PR created automatically by Jules for task [8210198050631441961](https://jules.google.com/task/8210198050631441961) started by @tajemniktv*