### PR TITLE
perf: Use @Upsert instead of @Insert(onConflict = OnConflictStrategy.REPLACE) in DAOs

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -102,13 +102,13 @@ interface NodeDao {
      * @param node The [NodeEntity] to insert.
      * @return The auto-generated or existing primary key ID of the inserted node.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @androidx.room.Upsert
     suspend fun insertNode(node: NodeEntity): Long
 
     /**
      * Inserts multiple nodes, returning their generated or existing identifiers.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @androidx.room.Upsert
     suspend fun insertNodes(nodes: List<NodeEntity>): List<Long>
 
     /**
@@ -133,7 +133,7 @@ interface NodeDao {
      *
      * @param pin The [TodayPinEntity] representing the pinned state.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @androidx.room.Upsert
     suspend fun pinToToday(pin: TodayPinEntity)
 
     /**
@@ -180,7 +180,7 @@ interface TrackDao {
     @Query("SELECT * FROM track_entries ORDER BY date DESC, createdAt DESC")
     fun getAllTrackEntries(): Flow<List<TrackEntryEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @androidx.room.Upsert
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long
 
     @Query("SELECT * FROM track_entries WHERE date = :date LIMIT 1")
@@ -201,10 +201,10 @@ interface RelationDao {
     @Query("SELECT * FROM relations WHERE fromNodeId = :nodeId OR toNodeId = :nodeId")
     fun getRelationsForNode(nodeId: Long): Flow<List<RelationEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @androidx.room.Upsert
     suspend fun insertRelation(relation: RelationEntity)
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @androidx.room.Upsert
     suspend fun insertRelations(relations: List<RelationEntity>)
 
     @Delete
@@ -699,13 +699,13 @@ interface CalendarEventDao {
         to: Long,
     ): Flow<List<CalendarEventEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @androidx.room.Upsert
     suspend fun insertEvents(events: List<CalendarEventEntity>)
 
     @Query("DELETE FROM calendar_events WHERE providerId = :providerId")
     suspend fun deleteEventsByProvider(providerId: Long)
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @androidx.room.Upsert
     suspend fun insertEvent(event: CalendarEventEntity): Long
 
     @Update

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeProtocolDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeProtocolDao.kt
@@ -4,6 +4,16 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 class FakeProtocolDao : ProtocolDao {
-    override fun getAllProtocolHistory(): Flow<List<ProtocolHistoryEntity>> = flowOf(emptyList())
-    override suspend fun insertProtocolHistory(history: ProtocolHistoryEntity): Long = 0
+    private val historyList = mutableListOf<ProtocolHistoryEntity>()
+    private var nextId = 1L
+    private val historyFlow = kotlinx.coroutines.flow.MutableStateFlow(historyList.toList())
+
+    override fun getAllProtocolHistory(): Flow<List<ProtocolHistoryEntity>> = historyFlow
+
+    override suspend fun insertProtocolHistory(history: ProtocolHistoryEntity): Long {
+        val id = nextId++
+        historyList.add(history.copy(id = id))
+        historyFlow.value = historyList.toList()
+        return id
+    }
 }


### PR DESCRIPTION
Replaced `@Insert(onConflict = OnConflictStrategy.REPLACE)` with `@Upsert` in `Daos.kt`.
This is a well-known Room optimization. `REPLACE` performs a `DELETE` followed by an `INSERT`, which introduces overhead by updating indices twice and can unintentionally break foreign keys or trigger `CASCADE DELETE` anomalies. `@Upsert` correctly checks for existence and performs an `UPDATE` if the record exists, bypassing the deletion step entirely.

Also updated `FakeProtocolDao` to be functional (backed by `MutableStateFlow`) to fix a failing unit test in `ProtocolCommandsTest`.

---
*PR created automatically by Jules for task [8629254209774548322](https://jules.google.com/task/8629254209774548322) started by @tajemniktv*