### PR TITLE
fix(website): use BASE_URL for waitlist API fetch call

### DIFF
--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -123,7 +123,7 @@ const title = "WAITLIST";
     if (waitlistButtonText) waitlistButtonText.classList.add("invisible");
 
     try {
-      const response = await fetch("/api/waitlist", {
+      const response = await fetch(`${import.meta.env.BASE_URL}api/waitlist`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),


### PR DESCRIPTION
Fixes waitlist API url when site is hosted on a base path, using `${import.meta.env.BASE_URL}api/waitlist` instead of hardcoded `/api/waitlist` in `website/src/pages/waitlist.astro`.

---
*PR created automatically by Jules for task [10587351676364751736](https://jules.google.com/task/10587351676364751736) started by @tajemniktv*