### PR TITLE
fix: resolve timing/length attack in auth token verification

### DIFF
--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -26,14 +26,12 @@ fun Application.module() {
         ?: System.getenv("TAJSOS_SYNC_TOKEN")
         ?: error("TAJSOS_SYNC_TOKEN environment variable must be set")
     val expectedTokenBytes = expectedToken.toByteArray(Charsets.UTF_8)
-    val expectedTokenHash = MessageDigest.getInstance("SHA-256").digest(expectedTokenBytes)
-
     install(Authentication) {
         bearer("sync-auth") {
             authenticate { tokenCredential ->
 
-                val providedTokenHash = MessageDigest.getInstance("SHA-256").digest(tokenCredential.token.toByteArray(Charsets.UTF_8))
-                if (MessageDigest.isEqual(providedTokenHash, expectedTokenHash)) {
+                val providedTokenBytes = tokenCredential.token.toByteArray(Charsets.UTF_8)
+                if (MessageDigest.isEqual(providedTokenBytes, expectedTokenBytes)) {
                     UserIdPrincipal("sync-client")
                 } else {
                     null


### PR DESCRIPTION
Identified a security vulnerability in Ktor auth layer where hashing user-supplied payload strings before comparing hashes exposed the server to DoS vectors and length leakage. The fix switches to direct `MessageDigest.isEqual` comparison of byte arrays. Tests executed successfully.

---
*PR created automatically by Jules for task [18101446176733366574](https://jules.google.com/task/18101446176733366574) started by @tajemniktv*