### PR TITLE
fix(ui): use ghost border in EmptyState per design system

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/EmptyState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/EmptyState.kt
@@ -122,7 +122,7 @@ Spacer(modifier = Modifier.height(if (fillParent) TajsOSTheme.SpacingMd else if 
                 border =
                     androidx.compose.foundation.BorderStroke(
                         1.dp,
-                        TajsOSTheme.Primary.copy(alpha = 0.2f),
+                        TajsOSTheme.GhostBorder,
                     ),
             ) {
                 contentComposable()


### PR DESCRIPTION
Replaces hardcoded Primary color with GhostBorder in EmptyState composable.

---
*PR created automatically by Jules for task [16056784617146545676](https://jules.google.com/task/16056784617146545676) started by @tajemniktv*