### PR TITLE
docs: add KDocs to core models and network parsers

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
@@ -11,6 +11,9 @@ internal sealed class IpAddress {
 
     fun isPrivateOrLocal(): Boolean = isLoopback() || isLinkLocal() || isSiteLocal()
 
+    /**
+     * Represents an IPv4 address.
+     */
     data class Ipv4(val address: Long) : IpAddress() {
         override fun isLoopback(): Boolean = (address ushr 24) == 127L
         override fun isLinkLocal(): Boolean = (address ushr 16) == 0xA9FEL // 169.254.x.x
@@ -21,6 +24,9 @@ internal sealed class IpAddress {
         }
     }
 
+    /**
+     * Represents an IPv6 address.
+     */
     data class Ipv6(val words: LongArray) : IpAddress() {
         override fun isLoopback(): Boolean = words[0] == 0L && words[1] == 0L && words[2] == 0L && words[3] == 1L
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectModels.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectModels.kt
@@ -20,10 +20,15 @@ import kotlinx.serialization.Serializable
 enum class ItemKind(
     val storageKey: String,
 ) {
+    /** Represents actionable work to be completed. */
     TASK("task"), // NON-NLS
+    /** Represents durable knowledge or reference material. */
     NOTE("note"), // NON-NLS
+    /** Represents a chronological log or reflection. */
     RECORD("record"), // NON-NLS
+    /** Represents an outcome-bearing endeavor. */
     PROJECT("project"), // NON-NLS
+    /** Represents an ongoing area of responsibility. */
     AREA("area"), // NON-NLS
     ;
 


### PR DESCRIPTION
This pull request improves developer onboarding and technical documentation by adding descriptive KDocs to several fundamental, foundational data structures. 

Specifically, it targets the core `ItemKind` enum values in `LifeObjectModels.kt` (`TASK`, `NOTE`, `RECORD`, `PROJECT`, `AREA`) which act as the central spine of the app's typed data model. It also documents the `Ipv4` and `Ipv6` data classes inside `InetAddressParser.kt`, explaining their role in validating external endpoints for the calendar system.

These are purely documentation enhancements and contain no functional logic changes.

---
*PR created automatically by Jules for task [12680960178896486707](https://jules.google.com/task/12680960178896486707) started by @tajemniktv*