### PR TITLE
fix: mitigate script injection in GitHub Actions workflows

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -39,8 +39,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Detect package manager
         id: detect-package-manager
+        env:
+          WORKSPACE: ${{ github.workspace }}
         run: |
-          if [ -f "${{ github.workspace }}/website/yarn.lock" ]; then
+          if [ -f "${WORKSPACE}/website/yarn.lock" ]; then
             {
               echo "manager=yarn"
               echo "lockfile=yarn.lock"
@@ -67,8 +69,10 @@ jobs:
         uses: actions/configure-pages@v6
       - name: Install dependencies
         shell: bash
+        env:
+          MANAGER: ${{ steps.detect-package-manager.outputs.manager }}
         run: |
-          if [ "${{ steps.detect-package-manager.outputs.manager }}" = "yarn" ]; then
+          if [ "${MANAGER}" = "yarn" ]; then
             yarn install
           else
             npm ci
@@ -76,8 +80,10 @@ jobs:
         working-directory: ${{ env.BUILD_PATH }}
       - name: Check with Astro
         shell: bash
+        env:
+          MANAGER: ${{ steps.detect-package-manager.outputs.manager }}
         run: |
-          if [ "${{ steps.detect-package-manager.outputs.manager }}" = "yarn" ]; then
+          if [ "${MANAGER}" = "yarn" ]; then
             yarn run check
           else
             npm run check
@@ -86,15 +92,19 @@ jobs:
 
       - name: Build with Astro
         shell: bash
+        env:
+          MANAGER: ${{ steps.detect-package-manager.outputs.manager }}
+          SITE_ORIGIN: ${{ steps.pages.outputs.origin }}
+          SITE_BASE: ${{ steps.pages.outputs.base_path }}
         run: |
-          if [ "${{ steps.detect-package-manager.outputs.manager }}" = "yarn" ]; then
+          if [ "${MANAGER}" = "yarn" ]; then
             yarn astro build \
-              --site "${{ steps.pages.outputs.origin }}" \
-              --base "${{ steps.pages.outputs.base_path }}"
+              --site "${SITE_ORIGIN}" \
+              --base "${SITE_BASE}"
           else
             npx --no-install astro build \
-              --site "${{ steps.pages.outputs.origin }}" \
-              --base "${{ steps.pages.outputs.base_path }}"
+              --site "${SITE_ORIGIN}" \
+              --base "${SITE_BASE}"
           fi
         working-directory: ${{ env.BUILD_PATH }}
       - name: Upload artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,25 +56,29 @@ jobs:
       - name: Classify run scope
         id: classify
         shell: bash
+        env:
+          FILTER_DOCS: ${{ steps.filter.outputs.docs }}
+          FILTER_WEBSITE: ${{ steps.filter.outputs.website }}
+          FILTER_KMP: ${{ steps.filter.outputs.kmp }}
         run: |
           docs_only=false
           website_only=false
           run_gradle=false
           run_website=false
 
-          if [[ "${{ steps.filter.outputs.docs }}" == "true" && "${{ steps.filter.outputs.website }}" != "true" && "${{ steps.filter.outputs.kmp }}" != "true" ]]; then
+          if [[ "${FILTER_DOCS}" == "true" && "${FILTER_WEBSITE}" != "true" && "${FILTER_KMP}" != "true" ]]; then
             docs_only=true
           fi
 
-          if [[ "${{ steps.filter.outputs.website }}" == "true" && "${{ steps.filter.outputs.kmp }}" != "true" ]]; then
+          if [[ "${FILTER_WEBSITE}" == "true" && "${FILTER_KMP}" != "true" ]]; then
             website_only=true
           fi
 
-          if [[ "${{ steps.filter.outputs.kmp }}" == "true" ]]; then
+          if [[ "${FILTER_KMP}" == "true" ]]; then
             run_gradle=true
           fi
 
-          if [[ "${{ steps.filter.outputs.website }}" == "true" ]]; then
+          if [[ "${FILTER_WEBSITE}" == "true" ]]; then
             run_website=true
           fi
 
@@ -260,21 +264,31 @@ jobs:
     steps:
       - name: Write summary
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          CHANGES_KMP: ${{ needs.changes.outputs.kmp }}
+          CHANGES_WEBSITE: ${{ needs.changes.outputs.website }}
+          CHANGES_DOCS: ${{ needs.changes.outputs.docs }}
+          CHANGES_DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+          CHANGES_WEBSITE_ONLY: ${{ needs.changes.outputs.website_only }}
+          GRADLE_RESULT: ${{ needs.gradle.result || 'skipped' }}
+          WEBSITE_RESULT: ${{ needs.website.result || 'skipped' }}
         run: |
           {
             echo "## CI Summary"
             echo ""
-            echo "- Ref: \`${{ github.ref_name }}\`"
-            echo "- Event: \`${{ github.event_name }}\`"
-            echo "- KMP changes: \`${{ needs.changes.outputs.kmp }}\`"
-            echo "- Website changes: \`${{ needs.changes.outputs.website }}\`"
-            echo "- Docs changes: \`${{ needs.changes.outputs.docs }}\`"
-            echo "- Docs-only change: \`${{ needs.changes.outputs.docs_only }}\`"
-            echo "- Website-only change: \`${{ needs.changes.outputs.website_only }}\`"
+            echo "- Ref: \`${REF_NAME}\`"
+            echo "- Event: \`${EVENT_NAME}\`"
+            echo "- KMP changes: \`${CHANGES_KMP}\`"
+            echo "- Website changes: \`${CHANGES_WEBSITE}\`"
+            echo "- Docs changes: \`${CHANGES_DOCS}\`"
+            echo "- Docs-only change: \`${CHANGES_DOCS_ONLY}\`"
+            echo "- Website-only change: \`${CHANGES_WEBSITE_ONLY}\`"
             echo ""
             echo "### Jobs"
-            echo "- Gradle job: \`${{ needs.gradle.result || 'skipped' }}\`"
-            echo "- Website job: \`${{ needs.website.result || 'skipped' }}\`"
+            echo "- Gradle job: \`${GRADLE_RESULT}\`"
+            echo "- Website job: \`${WEBSITE_RESULT}\`"
             echo ""
             echo "### Artifacts"
             echo "- Failure reports: uploaded only when Gradle job fails"


### PR DESCRIPTION
This PR addresses a critical security vulnerability related to bash script injection in the project's GitHub Actions workflows (`ci.yml` and `astro.yml`).

Previously, context variables like `${{ github.ref_name }}`, `${{ github.event_name }}`, and variables from `steps.filter.outputs.*` were interpolated directly into bash `run:` blocks using the `${{ }}` syntax. This pattern allows for command injection if an attacker crafts malicious input, such as pushing a branch with a name containing shell metacharacters.

The fix binds these context variables to environment variables within the `env:` block of each step, and references the environment variables natively within the bash scripts. This guarantees the input is treated strictly as data, fully mitigating the injection vector.

---
*PR created automatically by Jules for task [3803021433270745393](https://jules.google.com/task/3803021433270745393) started by @tajemniktv*