### PR TITLE
fix: Prevent script injection in Astro GitHub Actions workflow

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -40,15 +40,15 @@ jobs:
       - name: Detect package manager
         id: detect-package-manager
         env:
-          WORKSPACE: ${{ github.workspace }}
+          GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
-          if [ -f "${WORKSPACE}/website/yarn.lock" ]; then
+          if [ -f "${GITHUB_WORKSPACE}/website/yarn.lock" ]; then
             {
               echo "manager=yarn"
               echo "lockfile=yarn.lock"
             } >> "${GITHUB_OUTPUT}"
             exit 0
-          elif [ -f "${{ github.workspace }}/website/package.json" ]; then
+          elif [ -f "${GITHUB_WORKSPACE}/website/package.json" ]; then
             {
               echo "manager=npm"
               echo "lockfile=package-lock.json"


### PR DESCRIPTION
Replaces direct GitHub Actions context interpolation (`${{ github.workspace }}`) inside a `run:` block in `.github/workflows/astro.yml` with securely bound environment variables (`${GITHUB_WORKSPACE}`). This addresses a widely recognized security risk where maliciously crafted variables can execute arbitrary code on the runner when interpolated directly into bash scripts.

---
*PR created automatically by Jules for task [7644402730488414604](https://jules.google.com/task/7644402730488414604) started by @tajemniktv*