### PR TITLE
fix(ui): add missing title prop to index layout

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -9,7 +9,7 @@ import CTA from "../components/landing/CTA.astro";
 import Footer from "../components/landing/Footer.astro";
 ---
 
-<Layout>
+<Layout title="Home">
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
   <div
     class="fixed top-[-10%] right-[-5%] w-150 h-150 gradient-sphere pointer-events-none -z-10"


### PR DESCRIPTION
Adds a missing `title` property to the `<Layout>` component in the homepage (`index.astro`). This ensures the browser tab and metadata correctly display the title.

---
*PR created automatically by Jules for task [423734131758816391](https://jules.google.com/task/423734131758816391) started by @tajemniktv*