### PR TITLE
feat(ui): refine components to match design system guidelines

### DIFF
--- a/website/src/components/landing/CTA.astro
+++ b/website/src/components/landing/CTA.astro
@@ -29,7 +29,7 @@ import { SITE } from '../../data/site';
     </p>
     <div class="flex flex-col md:flex-row items-center justify-center gap-16">
       <a href={`${import.meta.env.BASE_URL}${SITE.waitlistUrl}`}
-        class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-mono font-bold px-20 py-10 rounded-xl text-xl uppercase tracking-[0.2em] hover:bg-primary-dim hover:scale-105 transition-all shadow-[0_0_80px_rgba(186,158,255,0.4)] block"
+        class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-mono font-bold px-20 py-10 rounded-xl text-xl uppercase tracking-[0.2em] hover:scale-105 transition-all shadow-[0_0_80px_rgba(186,158,255,0.4)] block"
       >
         [ Join Waitlist ]
       </a>

--- a/website/src/components/landing/CTA.astro
+++ b/website/src/components/landing/CTA.astro
@@ -29,7 +29,7 @@ import { SITE } from '../../data/site';
     </p>
     <div class="flex flex-col md:flex-row items-center justify-center gap-16">
       <a href={`${import.meta.env.BASE_URL}${SITE.waitlistUrl}`}
-        class="bg-primary text-on-primary-fixed font-mono font-bold px-20 py-10 rounded-2xl text-xl uppercase tracking-[0.2em] hover:bg-primary-dim hover:scale-105 transition-all shadow-[0_0_80px_rgba(186,158,255,0.4)] block"
+        class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-mono font-bold px-20 py-10 rounded-xl text-xl uppercase tracking-[0.2em] hover:bg-primary-dim hover:scale-105 transition-all shadow-[0_0_80px_rgba(186,158,255,0.4)] block"
       >
         [ Join Waitlist ]
       </a>

--- a/website/src/components/landing/Footer.astro
+++ b/website/src/components/landing/Footer.astro
@@ -3,7 +3,7 @@
 import { SITE, FOOTER_LINKS } from '../../data/site';
 ---
 
-<footer class="w-full border-t border-primary/10 bg-surface py-24 px-12">
+<footer class="w-full bg-surface-container-low py-24 px-12">
   <div
     class="max-w-400 mx-auto flex flex-col md:flex-row justify-between items-start gap-16"
   >

--- a/website/src/components/landing/Hero.astro
+++ b/website/src/components/landing/Hero.astro
@@ -31,7 +31,7 @@ import { SITE } from '../../data/site';
       </p>
       <div class="flex flex-col gap-6 pt-4">
         <a href={`${import.meta.env.BASE_URL}${SITE.waitlistUrl}`}
-          class="w-fit bg-primary text-on-primary-fixed font-mono font-bold px-10 py-6 rounded text-sm uppercase tracking-[0.2em] hover:shadow-[0_0_50px_rgba(186,158,255,0.4)] transition-all"
+          class="w-fit bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-mono font-bold px-10 py-6 rounded-xl text-sm uppercase tracking-[0.2em] hover:shadow-[0_0_50px_rgba(186,158,255,0.4)] transition-all"
         >
           [ Join_Waitlist ]
         </a>

--- a/website/src/components/landing/InstrumentPanel.astro
+++ b/website/src/components/landing/InstrumentPanel.astro
@@ -3,11 +3,10 @@
 ---
 
 <section class="relative mb-80">
-  <div class="flex items-center gap-6 mb-32 border-b border-primary/10 pb-12">
+  <div class="flex items-center justify-between mb-32 pb-12">
     <h2 class="font-headline text-7xl font-bold uppercase tracking-tighter">
       Project Manager
     </h2>
-    <div class="grow h-px bg-linear-to-r from-primary/20 to-transparent"></div>
     <div
       class="font-mono text-[10px] tracking-widest text-on-surface-variant/50"
     >
@@ -48,7 +47,7 @@
           friction, total retention for neural offloading.
         </p>
       </div>
-      <div class="mt-20 grid grid-cols-3 border-t border-primary/10 pt-10">
+      <div class="mt-20 grid grid-cols-3 bg-surface-container-highest/20 rounded-xl p-6">
         <div>
           <span
             class="block font-mono text-[9px] text-on-surface-variant mb-2 uppercase tracking-widest"

--- a/website/src/components/landing/Navbar.astro
+++ b/website/src/components/landing/Navbar.astro
@@ -4,7 +4,7 @@ import { SITE, NAV_LINKS } from '../../data/site';
 ---
 
 <nav
-  class="fixed top-0 w-full z-100 bg-surface/40 backdrop-blur-2xl border-b border-primary/10"
+  class="fixed top-0 w-full z-100 bg-surface-container-low/60 backdrop-blur-2xl"
 >
   <div
     class="flex justify-between items-center w-full px-8 py-4 max-w-400 mx-auto"
@@ -40,7 +40,7 @@ import { SITE, NAV_LINKS } from '../../data/site';
         >
       </div>
       <a href={`${import.meta.env.BASE_URL}${SITE.waitlistUrl}`} aria-label="Join Waitlist"
-        class="bg-primary text-on-primary-fixed font-mono font-bold px-6 py-2 rounded text-[10px] tracking-widest uppercase hover:shadow-[0_0_20px_rgba(186,158,255,0.4)] transition-all"
+        class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-mono font-bold px-6 py-2 rounded-xl text-[10px] tracking-widest uppercase hover:shadow-[0_0_20px_rgba(186,158,255,0.4)] transition-all"
         >JOIN WAITLIST</a
       >
     </div>

--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -42,7 +42,7 @@ const title = "WAITLIST";
 <form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-outline-variant/30 rounded-xl overflow-hidden focus-within:border-outline-variant focus-within:shadow-[0_0_8px_var(--color-primary)] transition-all duration-500">
 <label for="waitlist-email" class="sr-only">Email address</label>
 <input id="waitlist-email" class="bg-transparent border-none focus:ring-0 text-on-surface placeholder:text-outline font-mono py-5 px-6 w-full text-lg" placeholder="email@example.com" type="email" required autocomplete="email"/>
-<button id="waitlist-submit" type="submit" class="bg-linear-to-br from-primary to-primary-dim text-on-primary font-headline font-bold px-12 py-6 text-xl hover:bg-primary-fixed transition-all flex items-center gap-2 group/btn relative overflow-hidden">
+<button id="waitlist-submit" type="submit" class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold px-12 py-6 text-xl hover:shadow-[0_0_50px_rgba(186,158,255,0.4)] transition-all flex items-center gap-2 group/btn relative overflow-hidden">
                         <span id="waitlist-button-text">JOIN NOW</span>
                         <div id="waitlist-loading" class="hidden absolute inset-0 bg-primary flex items-center justify-center">
                             <span class="material-symbols-outlined text-on-primary animate-spin">progress_activity</span>

--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -39,10 +39,10 @@ const title = "WAITLIST";
 <!-- Waitlist Module -->
 <div class="w-full max-w-lg group relative">
 <div class="absolute -inset-0.5 bg-linear-to-r from-primary to-primary-dim rounded-xl blur opacity-20 group-focus-within:opacity-50 transition duration-1000"></div>
-<form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-outline-variant/30 rounded-xl overflow-hidden focus-within:border-primary transition-all duration-500">
+<form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-outline-variant/30 rounded-xl overflow-hidden focus-within:border-outline-variant focus-within:shadow-[0_0_8px_var(--color-primary)] transition-all duration-500">
 <label for="waitlist-email" class="sr-only">Email address</label>
 <input id="waitlist-email" class="bg-transparent border-none focus:ring-0 text-on-surface placeholder:text-outline font-mono py-5 px-6 w-full text-lg" placeholder="email@example.com" type="email" required autocomplete="email"/>
-<button id="waitlist-submit" type="submit" class="bg-primary text-on-primary font-headline font-bold px-12 py-6 text-xl hover:bg-primary-fixed transition-all flex items-center gap-2 group/btn relative overflow-hidden">
+<button id="waitlist-submit" type="submit" class="bg-linear-to-br from-primary to-primary-dim text-on-primary font-headline font-bold px-12 py-6 text-xl hover:bg-primary-fixed transition-all flex items-center gap-2 group/btn relative overflow-hidden">
                         <span id="waitlist-button-text">JOIN NOW</span>
                         <div id="waitlist-loading" class="hidden absolute inset-0 bg-primary flex items-center justify-center">
                             <span class="material-symbols-outlined text-on-primary animate-spin">progress_activity</span>


### PR DESCRIPTION
This PR refines the UI components on the landing and waitlist pages to strictly adhere to the TajsOS Design System (`DESIGN.md`):

1. **Gradients over Solid Colors:** Primary buttons across the Navbar, Hero, CTA, and Waitlist form have been updated from flat colors to the `bg-linear-to-br` linear gradient for a neon, lit-from-within look.
2. **Standardized Radii:** Primary buttons now consistently use the `rounded-xl` (12dp) radius token rather than a mix of `rounded` and `rounded-2xl`.
3. **No-Line Rule:** Hard divider lines (`border-t`, `border-b`, `h-px`) were stripped from the Navbar, Footer, and InstrumentPanel. Boundaries are now achieved strictly via background color shifts to `surface-container-low` or `surface-container-highest/20`.
4. **Ghost Borders for Focus:** Waitlist input fields focus state was adjusted to remove high-contrast borders, utilizing the `outline-variant` ("Ghost Border") and an 8px primary external glow shadow.

---
*PR created automatically by Jules for task [11656133350635270312](https://jules.google.com/task/11656133350635270312) started by @tajemniktv*