### PR TITLE
docs: improve KDoc for core data, preferences, and domain lens queries

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
@@ -18,7 +18,9 @@ import kotlin.time.Duration.Companion.days
  *
  * It uses a local-first design strategy by pulling external events into the shared data layer via
  * [CalendarProviderEntity] and [CalendarEventEntity]. Synchronization works by deduplicating and merging remote events
- * with local representations, preserving primary keys and local metadata.
+ * with local representations, preserving primary keys and local metadata. This ensures that the app
+ * relies exclusively on the local Room database for rapid UI rendering, decoupling feature correctness
+ * from live network availability.
  *
  * @param repository The central data repository providing database operations for calendar objects.
  * @param httpClient The configured HTTP client to perform external API queries.

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
@@ -18,7 +18,7 @@ import kotlin.time.Duration.Companion.days
  *
  * It uses a local-first design strategy by pulling external events into the shared data layer via
  * [CalendarProviderEntity] and [CalendarEventEntity]. Synchronization works by deduplicating and merging remote events
- * with local representations, preserving primary keys and local metadata. This ensures that the app
+ * with local representations. This ensures that the app
  * relies exclusively on the local Room database for rapid UI rendering, decoupling feature correctness
  * from live network availability.
  *

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarProvider.kt
@@ -10,6 +10,10 @@ import kotlin.time.Instant
 
 /**
  * Represents a generic calendar provider capable of fetching and synchronizing events.
+ *
+ * Implementations are responsible for parsing remote data into the common [CalendarEventEntity] format,
+ * handling specific connectivity protocols (e.g., HTTP for iCal), and respecting the provided
+ * date ranges.
  */
 interface CalendarProvider {
     /**

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
@@ -99,7 +99,7 @@ data class AreaMetadata(
  *
  * It silently ignores parsing errors or unknown keys (via [nodeMetadataJson] configuration),
  * returning null if the payload is malformed or empty. This ensures that corrupt metadata
- * does not crash the UI.
+ * does not crash the UI. This design prevents a single broken node from taking down the entire list view.
  */
 fun NodeEntity.metadataEnvelopeOrNull(): NodeMetadataEnvelope? =
     metadataJson?.takeIf { it.isNotBlank() }?.let {
@@ -113,6 +113,7 @@ fun NodeEntity.metadataEnvelopeOrNull(): NodeMetadataEnvelope? =
  * to reflect the provided [envelope].
  *
  * If [envelope] is null, the resulting JSON string will be null (clearing the metadata).
+ * Uses the pre-configured [nodeMetadataJson] to serialize the structure.
  */
 fun NodeEntity.withMetadataEnvelope(envelope: NodeMetadataEnvelope?): NodeEntity =
     copy(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -29,6 +29,13 @@ enum class DesktopWindowStartupMode {
 
 /**
  * PreferencesRepository handles all of TajsOS's configuration data.
+ *
+ * It manages application-wide settings such as UI preferences (theme, sidebar mode),
+ * operational state (active mode id, active packs), and desktop-specific geometry
+ * using the multiplatform [DataStore] library.
+ *
+ * All properties are exposed as [Flow] streams that emit the current value,
+ * and automatically handle [IOException]s by emitting [emptyPreferences] as a fallback.
  */
 class PreferencesRepository(
     private val dataStore: DataStore<Preferences>,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -101,9 +101,11 @@ private val healthTitleKeywords =
  *
  * Domains (such as finance or health) are categorized implicitly by checking for hardcoded
  * string markers within node tags, titles, content, `maintenanceType`, and `noteType` fields.
+ * This heuristic-based approach provides a zero-configuration experience, allowing items to be surfaced
+ * appropriately even if the user forgets to manually assign the domain.
  *
- * Note: These queries intentionally bypass explicit domain associations (e.g., via associatedDomains in metadata) in favor of terminology matching. This ensures a zero-configuration
- * experience where items are surfaced appropriately even if the user forgets to manually assign the domain.
+ * Note: These queries intentionally bypass explicit domain associations (e.g., via `associatedDomains`
+ * in `AreaMetadata`) in favor of terminology matching to lower the friction of capturing new data.
  */
 object DomainLensQueries {
     /**


### PR DESCRIPTION
This PR targets the documentation improvement goal for scheduled runs. It introduces descriptive KDoc to multiple core interfaces, functions, and repositories (`PreferencesRepository`, `CalendarProvider`, `CalendarManager`, `NodeMetadata`, and `DomainLensQueries`).

The documentation specifically clarifies:
- The fallback behavior of datastores during `IOException`s.
- The local-first architectural contract for calendar sync.
- The metadata parsing resilience against UI crashes.
- The zero-configuration, string-matching strategy used in domain categorization.

No executable logic was altered. Tests passed successfully.

---
*PR created automatically by Jules for task [15640558015202264907](https://jules.google.com/task/15640558015202264907) started by @tajemniktv*