### PR TITLE
perf: Replace @Insert REPLACE with @Upsert in DAOs

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -102,13 +102,13 @@ interface NodeDao {
      * @param node The [NodeEntity] to insert.
      * @return The auto-generated or existing primary key ID of the inserted node.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertNode(node: NodeEntity): Long
 
     /**
      * Inserts multiple nodes, returning their generated or existing identifiers.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertNodes(nodes: List<NodeEntity>): List<Long>
 
     /**
@@ -133,7 +133,7 @@ interface NodeDao {
      *
      * @param pin The [TodayPinEntity] representing the pinned state.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun pinToToday(pin: TodayPinEntity)
 
     /**
@@ -180,7 +180,7 @@ interface TrackDao {
     @Query("SELECT * FROM track_entries ORDER BY date DESC, createdAt DESC")
     fun getAllTrackEntries(): Flow<List<TrackEntryEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long
 
     @Query("SELECT * FROM track_entries WHERE date = :date LIMIT 1")
@@ -201,10 +201,10 @@ interface RelationDao {
     @Query("SELECT * FROM relations WHERE fromNodeId = :nodeId OR toNodeId = :nodeId")
     fun getRelationsForNode(nodeId: Long): Flow<List<RelationEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertRelation(relation: RelationEntity)
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertRelations(relations: List<RelationEntity>)
 
     @Delete
@@ -699,13 +699,13 @@ interface CalendarEventDao {
         to: Long,
     ): Flow<List<CalendarEventEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEvents(events: List<CalendarEventEntity>)
 
     @Query("DELETE FROM calendar_events WHERE providerId = :providerId")
     suspend fun deleteEventsByProvider(providerId: Long)
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEvent(event: CalendarEventEntity): Long
 
     @Update

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -637,19 +637,21 @@ class AppRepository(
                 fromEpochDay = fromEpochDay,
                 toEpochDay = toEpochDay,
             ).map { entries -> entries.map { it.toModel() } }
-
     /**
      * Inserts a new node into the database.
+     *
+     * Handles @Upsert behaviour where it returns -1L if it's updating an existing entity instead of inserting.
      *
      * **Side effects:**
      * - Logs a "NODE_CREATED" event.
      * - Synchronizes "BELONGS_TO" relations for the node's associated project and area.
      *
      * @param node The node entity to insert.
-     * @return The auto-generated ID of the newly inserted node.
+     * @return The auto-generated ID of the newly inserted node, or the existing ID if updated.
      */
     suspend fun insertNode(node: NodeEntity): Long {
-        val id = nodeDao.insertNode(node)
+        var id = nodeDao.insertNode(node)
+        if (id == -1L) id = node.id
         logEvent("NODE_CREATED", id)
         syncBelongsToRelations(id, node.projectId, node.areaId)
         syncTypedFacetsFromNode(node.copy(id = id))
@@ -1079,7 +1081,8 @@ class AppRepository(
     fun getActiveSession(): Flow<FocusSessionEntity?> = focusSessionDao.getActiveSession()
 
     suspend fun insertSession(session: FocusSessionEntity): Long {
-        val id = focusSessionDao.insertSession(session)
+        var id = focusSessionDao.insertSession(session)
+        if (id == -1L) id = session.id
         logEvent("SESSION_STARTED", session.nodeId)
         return id
     }
@@ -1094,7 +1097,8 @@ class AppRepository(
     fun getAllTrackEntries(): Flow<List<TrackEntryEntity>> = trackDao.getAllTrackEntries()
 
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long {
-        val id = trackDao.insertTrackEntry(entry)
+        var id = trackDao.insertTrackEntry(entry)
+        if (id == -1L) id = entry.id
         logEvent("CHECKIN_CREATED")
         return id
     }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeNodeDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeNodeDao.kt
@@ -63,11 +63,18 @@ class FakeNodeDao : NodeDao {
     }
 
     override suspend fun insertNode(node: NodeEntity): Long {
-        val newId = (nodes.size + 1).toLong()
-        val newNode = node.copy(id = newId)
-        nodes.add(newNode)
-        nodesFlow.value = nodes.toList()
-        return newId
+        val index = nodes.indexOfFirst { it.id == node.id }
+        if (index != -1 && node.id != 0L) {
+            nodes[index] = node
+            nodesFlow.value = nodes.toList()
+            return -1L
+        } else {
+            val newId = if (node.id != 0L) node.id else (nodes.maxOfOrNull { it.id } ?: 0L) + 1L
+            val newNode = node.copy(id = newId)
+            nodes.add(newNode)
+            nodesFlow.value = nodes.toList()
+            return newId
+        }
     }
 
     override suspend fun insertNodes(nodes: List<NodeEntity>): List<Long> {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeRelationDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeRelationDao.kt
@@ -13,10 +13,16 @@ class FakeRelationDao : RelationDao {
     }
 
     override suspend fun insertRelation(relation: RelationEntity) {
-        val newId = (relations.size + 1).toLong()
-        val newRelation = relation.copy(id = newId)
-        relations.add(newRelation)
-        relationsFlow.value = relations.toList()
+        val index = relations.indexOfFirst { it.id == relation.id }
+        if (index != -1 && relation.id != 0L) {
+            relations[index] = relation
+            relationsFlow.value = relations.toList()
+        } else {
+            val newId = if (relation.id != 0L) relation.id else (relations.maxOfOrNull { it.id } ?: 0L) + 1L
+            val newRelation = relation.copy(id = newId)
+            relations.add(newRelation)
+            relationsFlow.value = relations.toList()
+        }
     }
 
     override suspend fun insertRelations(relations: List<RelationEntity>) {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTrackDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTrackDao.kt
@@ -15,11 +15,18 @@ class FakeTrackDao : TrackDao {
     }
 
     override suspend fun insertTrackEntry(entry: TrackEntryEntity): Long {
-        val newId = (entries.size + 1).toLong()
-        val newEntry = entry.copy(id = newId)
-        entries.add(newEntry)
-        entriesFlow.value = entries.toList()
-        return newId
+        val index = entries.indexOfFirst { it.id == entry.id }
+        if (index != -1 && entry.id != 0L) {
+            entries[index] = entry
+            entriesFlow.value = entries.toList()
+            return -1L
+        } else {
+            val newId = if (entry.id != 0L) entry.id else (entries.maxOfOrNull { it.id } ?: 0L) + 1L
+            val newEntry = entry.copy(id = newId)
+            entries.add(newEntry)
+            entriesFlow.value = entries.toList()
+            return newId
+        }
     }
 
     override suspend fun getTrackEntryByDate(date: String): TrackEntryEntity? {


### PR DESCRIPTION
- Replaced Room's `@Insert(onConflict = REPLACE)` with `@Upsert` in `Daos.kt` as it causes unnecessary deletions and re-insertions which can trigger cascading deletes, invalidate indices, and reduce database efficiency.
- Modified `AppRepository` functions like `insertNode`, `insertTrackEntry`, and `insertSession` to capture the `id`, checking if it equals `-1L` (which signals an update under `@Upsert`) and falling back to the entity's ID to prevent breakages in side effects like event logging.
- Added appropriate KDocs to `AppRepository` insertion methods documenting the updated behaviour.
- Addressed testing issues by updating `FakeNodeDao.kt`, `FakeRelationDao.kt`, and `FakeTrackDao.kt` logic to properly test for ID matches and update existing objects rather than arbitrarily appending new rows, maintaining parity with `@Upsert`.

---
*PR created automatically by Jules for task [15856960270877861245](https://jules.google.com/task/15856960270877861245) started by @tajemniktv*