### PR TITLE
fix(ui): apply No-Line rule and depth to website landing page

### DIFF
--- a/website/src/components/landing/Features.astro
+++ b/website/src/components/landing/Features.astro
@@ -40,7 +40,7 @@
         </p>
       </div>
       <div
-        class="absolute top-75 left-0 lg:left-[10%] w-full lg:w-[45%] glass-panel p-16 rounded-3xl border-secondary/20 instrument-glow z-10"
+        class="absolute top-75 left-0 lg:left-[10%] w-full lg:w-[45%] glass-panel p-16 rounded-3xl instrument-glow z-10"
       >
         <span
           class="font-mono text-secondary text-[10px] bg-secondary/10 px-3 py-1 rounded mb-8 inline-block"

--- a/website/src/components/landing/FocusMode.astro
+++ b/website/src/components/landing/FocusMode.astro
@@ -24,7 +24,7 @@
         intersection of thought and medium.
       </p>
       <div class="grid grid-cols-2 gap-12">
-        <div class="border-l-2 border-primary pl-8">
+        <div class="bg-surface-container-low p-6 rounded-2xl">
           <span
             class="font-mono text-[10px] text-primary block mb-3 uppercase tracking-widest"
             >Review_Mode</span
@@ -33,7 +33,7 @@
             Periodic reviews of projects and areas.
           </p>
         </div>
-        <div class="border-l-2 border-primary pl-8">
+        <div class="bg-surface-container-low p-6 rounded-2xl">
           <span
             class="font-mono text-[10px] text-primary block mb-3 uppercase tracking-widest"
             >Tracking_Data</span

--- a/website/src/components/landing/Hero.astro
+++ b/website/src/components/landing/Hero.astro
@@ -7,10 +7,10 @@ import { SITE } from '../../data/site';
   <div class="w-full lg:w-3/4 z-10">
     <div class="flex items-center gap-4 mb-12">
       <span
-        class="font-mono text-[10px] tracking-[0.5em] text-primary bg-primary/10 px-4 py-2 rounded border border-primary/20 uppercase"
+        class="font-mono text-[10px] tracking-[0.5em] text-primary bg-surface-container-highest px-4 py-2 rounded shadow-[0_0_15px_rgba(186,158,255,0.1)] uppercase"
         >LOCAL_FIRST</span
       >
-      <div class="h-px w-32 bg-primary/30"></div>
+
     </div>
     <h1
       class="font-headline text-[clamp(5rem,15vw,12rem)] leading-[0.8] font-bold tracking-tighter uppercase text-on-surface"
@@ -36,7 +36,7 @@ import { SITE } from '../../data/site';
           [ Join_Waitlist ]
         </a>
         <a href={`${import.meta.env.BASE_URL}architecture`}
-          class="w-fit font-mono font-bold uppercase tracking-widest text-[11px] text-on-surface-variant/60 hover:text-primary transition-colors pl-4 border-l border-outline-variant"
+          class="w-fit font-mono font-bold uppercase tracking-widest text-[11px] text-on-surface-variant/60 hover:text-primary transition-colors bg-surface-container-low px-4 py-2 rounded-lg"
         >
           Architecture
         </a>
@@ -58,7 +58,7 @@ import { SITE } from '../../data/site';
         >
         </div>
         <div
-          class="absolute bottom-8 left-8 right-8 bg-surface/80 backdrop-blur-xl p-6 rounded border border-primary/20"
+          class="absolute bottom-8 left-8 right-8 bg-surface-container-highest/90 backdrop-blur-xl p-6 rounded-xl shadow-[0_20px_40px_rgba(0,0,0,0.4)]"
         >
           <span
             class="font-mono text-[9px] text-primary block mb-3 tracking-[0.3em] uppercase"

--- a/website/src/components/landing/InstrumentPanel.astro
+++ b/website/src/components/landing/InstrumentPanel.astro
@@ -71,7 +71,7 @@
       </div>
     </div>
     <div
-      class="lg:col-span-4 glass-panel instrument-glow rounded-3xl p-10 flex flex-col justify-between border-secondary/20 relative"
+      class="lg:col-span-4 glass-panel instrument-glow rounded-3xl p-10 flex flex-col justify-between relative"
     >
       <div>
         <span
@@ -80,7 +80,7 @@
         >
         <div class="space-y-6">
           <div
-            class="bg-surface-container-lowest/60 p-6 rounded-xl border-l-4 border-secondary backdrop-blur-md flex justify-between items-center"
+            class="bg-surface-container-highest p-6 rounded-xl backdrop-blur-md flex justify-between items-center shadow-[0_0_20px_rgba(192,140,247,0.15)]"
           >
             <div>
               <p
@@ -96,7 +96,7 @@
             >
           </div>
           <div
-            class="bg-surface-container-lowest/20 p-6 rounded-xl border-l-4 border-outline/20 flex justify-between items-center opacity-40"
+            class="bg-surface-container-low p-6 rounded-xl flex justify-between items-center opacity-60"
           >
             <div>
               <p
@@ -155,7 +155,7 @@
       </div>
     </div>
     <div
-      class="lg:col-span-7 glass-panel instrument-glow rounded-3xl p-12 flex flex-col md:flex-row gap-12 items-center hover:border-secondary/40 transition-all border-secondary/10"
+      class="lg:col-span-7 glass-panel instrument-glow rounded-3xl p-12 flex flex-col md:flex-row gap-12 items-center hover:bg-surface-container-highest/30 transition-all"
     >
       <div class="w-full md:w-1/2">
         <span
@@ -177,11 +177,12 @@
       >
         <div class="absolute inset-0 opacity-10">
           <div class="grid grid-cols-6 h-full w-full">
-            <div class="border-r border-secondary/30"></div>
-            <div class="border-r border-secondary/30"></div>
-            <div class="border-r border-secondary/30"></div>
-            <div class="border-r border-secondary/30"></div>
-            <div class="border-r border-secondary/30"></div>
+            <div class="bg-secondary/5"></div>
+            <div class="bg-transparent"></div>
+            <div class="bg-secondary/5"></div>
+            <div class="bg-transparent"></div>
+            <div class="bg-secondary/5"></div>
+            <div class="bg-transparent"></div>
           </div>
         </div>
         <div

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -60,10 +60,10 @@
 }
 
 @layer utilities {
-    .glass-panel {
-        background: rgba(31, 31, 36, 0.5);
-        backdrop-filter: blur(60px);
-        border: 1px solid rgba(186, 158, 255, 0.15);
+        .glass-panel {
+        background: rgba(31, 31, 36, 0.6);
+        backdrop-filter: blur(40px);
+        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
     }
     .instrument-glow {
         box-shadow: 0 0 50px rgba(186, 158, 255, 0.08), inset 0 0 30px rgba(186, 158, 255, 0.03);

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -60,8 +60,8 @@
 }
 
 @layer utilities {
-        .glass-panel {
-        background: rgba(31, 31, 36, 0.6);
+    .glass-panel {
+        background: color-mix(in srgb, var(--color-surface-container-high) 60%, transparent);
         backdrop-filter: blur(40px);
         box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
     }


### PR DESCRIPTION
This PR resolves major design system violations on the landing page of the website project by implementing the "Organic Industrialism" No-Line rule.

Key changes:
- Removed hard 1px borders from `global.css` for `.glass-panel` and added standard 40px backdrop filters with deep shadows.
- Updated `Hero.astro`, `Features.astro`, `FocusMode.astro`, and `InstrumentPanel.astro` to remove hard lines and rely on `bg-surface-container-low` through `bg-surface-container-highest` for depth separation.
- Adjusted glowing `box-shadow` depth layers to preserve spacing and hierarchy.

---
*PR created automatically by Jules for task [6898665567498528375](https://jules.google.com/task/6898665567498528375) started by @tajemniktv*