### PR TITLE
rel: use Upsert instead of Insert(REPLACE)

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -102,13 +102,13 @@ interface NodeDao {
      * @param node The [NodeEntity] to insert.
      * @return The auto-generated or existing primary key ID of the inserted node.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertNode(node: NodeEntity): Long
 
     /**
      * Inserts multiple nodes, returning their generated or existing identifiers.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertNodes(nodes: List<NodeEntity>): List<Long>
 
     /**
@@ -133,7 +133,7 @@ interface NodeDao {
      *
      * @param pin The [TodayPinEntity] representing the pinned state.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun pinToToday(pin: TodayPinEntity)
 
     /**
@@ -180,7 +180,7 @@ interface TrackDao {
     @Query("SELECT * FROM track_entries ORDER BY date DESC, createdAt DESC")
     fun getAllTrackEntries(): Flow<List<TrackEntryEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long
 
     @Query("SELECT * FROM track_entries WHERE date = :date LIMIT 1")
@@ -201,10 +201,10 @@ interface RelationDao {
     @Query("SELECT * FROM relations WHERE fromNodeId = :nodeId OR toNodeId = :nodeId")
     fun getRelationsForNode(nodeId: Long): Flow<List<RelationEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertRelation(relation: RelationEntity)
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertRelations(relations: List<RelationEntity>)
 
     @Delete
@@ -699,13 +699,13 @@ interface CalendarEventDao {
         to: Long,
     ): Flow<List<CalendarEventEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEvents(events: List<CalendarEventEntity>)
 
     @Query("DELETE FROM calendar_events WHERE providerId = :providerId")
     suspend fun deleteEventsByProvider(providerId: Long)
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEvent(event: CalendarEventEntity): Long
 
     @Update

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -649,7 +649,8 @@ class AppRepository(
      * @return The auto-generated ID of the newly inserted node.
      */
     suspend fun insertNode(node: NodeEntity): Long {
-        val id = nodeDao.insertNode(node)
+        var id = nodeDao.insertNode(node)
+        if (id == -1L) id = node.id
         logEvent("NODE_CREATED", id)
         syncBelongsToRelations(id, node.projectId, node.areaId)
         syncTypedFacetsFromNode(node.copy(id = id))
@@ -1094,7 +1095,8 @@ class AppRepository(
     fun getAllTrackEntries(): Flow<List<TrackEntryEntity>> = trackDao.getAllTrackEntries()
 
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long {
-        val id = trackDao.insertTrackEntry(entry)
+        var id = trackDao.insertTrackEntry(entry)
+        if (id == -1L) id = entry.id
         logEvent("CHECKIN_CREATED")
         return id
     }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeNodeDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeNodeDao.kt
@@ -63,7 +63,13 @@ class FakeNodeDao : NodeDao {
     }
 
     override suspend fun insertNode(node: NodeEntity): Long {
-        val newId = (nodes.size + 1).toLong()
+        val index = nodes.indexOfFirst { it.id == node.id }
+        if (index != -1 && node.id != 0L) {
+            nodes[index] = node
+            nodesFlow.value = nodes.toList()
+            return -1L
+        }
+        val newId = if (node.id != 0L) node.id else (nodes.maxOfOrNull { it.id } ?: 0L) + 1L
         val newNode = node.copy(id = newId)
         nodes.add(newNode)
         nodesFlow.value = nodes.toList()

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeRelationDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeRelationDao.kt
@@ -13,7 +13,13 @@ class FakeRelationDao : RelationDao {
     }
 
     override suspend fun insertRelation(relation: RelationEntity) {
-        val newId = (relations.size + 1).toLong()
+        val index = relations.indexOfFirst { it.id == relation.id }
+        if (index != -1 && relation.id != 0L) {
+            relations[index] = relation
+            relationsFlow.value = relations.toList()
+            return
+        }
+        val newId = if (relation.id != 0L) relation.id else (relations.maxOfOrNull { it.id } ?: 0L) + 1L
         val newRelation = relation.copy(id = newId)
         relations.add(newRelation)
         relationsFlow.value = relations.toList()

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTrackDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTrackDao.kt
@@ -15,7 +15,13 @@ class FakeTrackDao : TrackDao {
     }
 
     override suspend fun insertTrackEntry(entry: TrackEntryEntity): Long {
-        val newId = (entries.size + 1).toLong()
+        val index = entries.indexOfFirst { it.id == entry.id }
+        if (index != -1 && entry.id != 0L) {
+            entries[index] = entry
+            entriesFlow.value = entries.toList()
+            return -1L
+        }
+        val newId = if (entry.id != 0L) entry.id else (entries.maxOfOrNull { it.id } ?: 0L) + 1L
         val newEntry = entry.copy(id = newId)
         entries.add(newEntry)
         entriesFlow.value = entries.toList()


### PR DESCRIPTION
Replaced `@Insert(onConflict = REPLACE)` with `@Upsert` in Room DAOs to enhance reliability. Update Fakes and logic to properly handle returned IDs when `-1` is given back.

---
*PR created automatically by Jules for task [3780869159489519537](https://jules.google.com/task/3780869159489519537) started by @tajemniktv*