### PR TITLE
test: improve test coverage for edge cases

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParser.kt
@@ -30,11 +30,11 @@ internal sealed class IpAddress {
     data class Ipv6(val words: LongArray) : IpAddress() {
         override fun isLoopback(): Boolean = words[0] == 0L && words[1] == 0L && words[2] == 0L && words[3] == 1L
 
-        override fun isLinkLocal(): Boolean = (words[0] ushr 16) == 0xFE80L // fe80::/10
+        override fun isLinkLocal(): Boolean = (words[0] ushr 22) == 0x3FAL // fe80::/10
 
         override fun isSiteLocal(): Boolean {
             val prefix7 = (words[0] ushr 25)
-            return prefix7 == 0x7EL || prefix7 == 0x7FL // fc00::/7 => fc00 to fdff
+            return prefix7 == 0x7EL // fc00::/7 => fc00 to fdff
         }
 
         override fun equals(other: Any?): Boolean {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserEdgeTest.kt
@@ -54,6 +54,6 @@ class InetAddressParserEdgeTest {
         val ipv6A = parseIpAddress("2001:db8::1")
         val ipv6B = parseIpAddress("2001:db8:0:0:0:0:0:1")
         assertEquals(ipv6A, ipv6B)
-        assertEquals(ipv6A.hashCode(), ipv6B.hashCode())
+        assertEquals(ipv6A!!.hashCode(), ipv6B!!.hashCode())
     }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserEdgeTest.kt
@@ -1,0 +1,59 @@
+package com.tajemniktv.tajsos.calendar
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertEquals
+
+class InetAddressParserEdgeTest {
+
+    @Test
+    fun testIpv4SiteLocalEdges() {
+        // 10.x.x.x boundary
+        assertTrue(parseIpAddress("10.0.0.0")!!.isSiteLocal())
+        assertTrue(parseIpAddress("10.255.255.255")!!.isSiteLocal())
+
+        // 172.16.x.x - 172.31.x.x boundaries
+        assertTrue(parseIpAddress("172.16.0.0")!!.isSiteLocal())
+        assertTrue(parseIpAddress("172.31.255.255")!!.isSiteLocal())
+        assertFalse(parseIpAddress("172.15.255.255")!!.isSiteLocal())
+        assertFalse(parseIpAddress("172.32.0.0")!!.isSiteLocal())
+
+        // 192.168.x.x boundary
+        assertTrue(parseIpAddress("192.168.0.0")!!.isSiteLocal())
+        assertTrue(parseIpAddress("192.168.255.255")!!.isSiteLocal())
+        assertFalse(parseIpAddress("192.167.255.255")!!.isSiteLocal())
+    }
+
+    @Test
+    fun testIpv6SiteLocalEdges() {
+        // fc00::/7 (fc00:: to fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff)
+        assertTrue(parseIpAddress("fc00::")!!.isSiteLocal())
+        assertTrue(parseIpAddress("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isSiteLocal())
+
+        // Edge out of bounds
+        assertFalse(parseIpAddress("fbff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isSiteLocal())
+        assertFalse(parseIpAddress("fe00::")!!.isSiteLocal())
+    }
+
+    @Test
+    fun testIpv6LinkLocalEdges() {
+        // fe80::/10 (fe80:: to febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff)
+        assertTrue(parseIpAddress("fe80::")!!.isLinkLocal())
+        assertTrue(parseIpAddress("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isLinkLocal())
+
+        // Out of bounds
+        assertFalse(parseIpAddress("fe7f:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isLinkLocal())
+        assertFalse(parseIpAddress("fec0::")!!.isLinkLocal())
+    }
+
+    @Test
+    fun testIpv6Equality() {
+        val ipv6A = parseIpAddress("2001:db8::1")
+        val ipv6B = parseIpAddress("2001:db8:0:0:0:0:0:1")
+        assertEquals(ipv6A, ipv6B)
+        assertEquals(ipv6A.hashCode(), ipv6B.hashCode())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
@@ -5,6 +5,7 @@ import com.tajemniktv.tajsos.data.NodeWithPin
 import com.tajemniktv.tajsos.data.TagEntity
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DomainLensQueriesMatchesSignalTest {
     private fun createNode(
@@ -49,6 +50,18 @@ class DomainLensQueriesMatchesSignalTest {
     }
 
     @Test
+    fun financeActionItems_case_insensitivity() {
+        val nodeTitle = createNode(1, "MY BUDGET")
+        val nodeContent = createNode(2, "some task", "PAY TAX")
+        val nodeTag = createNode(3, "some task", tags = listOf("MONEY"))
+
+        val result = DomainLensQueries.financeActionItems(listOf(nodeTitle, nodeContent, nodeTag))
+        assertEquals(3, result.size)
+        val expectedIds = listOf(1L, 2L, 3L)
+        assertEquals(expectedIds, result.map { it.node.id }.sorted())
+    }
+
+    @Test
     fun financeKnowledgeItems_includes_reference_notes() {
         val nodeReferenceMatch = createNode(1, "some budget", type = "note", noteType = "reference")
         val nodeReferenceTagMatch = createNode(2, "some doc", type = "note", noteType = "reference", tags = listOf("finance"))
@@ -73,6 +86,18 @@ class DomainLensQueriesMatchesSignalTest {
         val result = DomainLensQueries.healthActionItems(listOf(nodeTitle, nodeContent, nodeTag, nodeMaintenance, nodeReflection, nodeNone))
         assertEquals(4, result.size)
         val expectedIds = listOf(1L, 2L, 3L, 4L)
+        assertEquals(expectedIds, result.map { it.node.id }.sorted())
+    }
+
+    @Test
+    fun healthActionItems_case_insensitivity() {
+        val nodeTitle = createNode(1, "SEE DOCTOR")
+        val nodeContent = createNode(2, "some task", "PICK UP MEDICATION")
+        val nodeTag = createNode(3, "some task", tags = listOf("MEDICAL"))
+
+        val result = DomainLensQueries.healthActionItems(listOf(nodeTitle, nodeContent, nodeTag))
+        assertEquals(3, result.size)
+        val expectedIds = listOf(1L, 2L, 3L)
         assertEquals(expectedIds, result.map { it.node.id }.sorted())
     }
 


### PR DESCRIPTION
This PR improves test coverage and test quality by focusing on meaningful edge cases and boundary inputs.

**Changes:**
1.  **Domain Lens Case Insensitivity:** The `matchesFinanceSignal` and `matchesHealthSignal` functions now have dedicated tests proving case insensitivity.
2.  **IPv6 Address Boundaries (Bug Fix & Test):** Found and fixed incorrect bit masking for `isLinkLocal` (`fe80::/10`) and `isSiteLocal` (`fc00::/7`) in `InetAddressParser`. The `fe80::/10` was mistakenly implemented as a `/16` strict equality check, and `fc00::/7` was accidentally leaking into multicast ranges. These bugs are fixed.
3.  **IPv4 and IPv6 Edge Testing:** Added `InetAddressParserEdgeTest` providing absolute boundary testing for class networks (`10.x.x.x`, `172.x.x.x`, `192.x.x.x`, `fe80::`, `fc00::`).

---
*PR created automatically by Jules for task [8173404902189081287](https://jules.google.com/task/8173404902189081287) started by @tajemniktv*