### PR TITLE
rel: Use @Upsert instead of @Insert(onConflict = REPLACE) in Room DAOs

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -102,13 +102,13 @@ interface NodeDao {
      * @param node The [NodeEntity] to insert.
      * @return The auto-generated or existing primary key ID of the inserted node.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertNode(node: NodeEntity): Long
 
     /**
      * Inserts multiple nodes, returning their generated or existing identifiers.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertNodes(nodes: List<NodeEntity>): List<Long>
 
     /**
@@ -133,7 +133,7 @@ interface NodeDao {
      *
      * @param pin The [TodayPinEntity] representing the pinned state.
      */
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun pinToToday(pin: TodayPinEntity)
 
     /**
@@ -180,7 +180,7 @@ interface TrackDao {
     @Query("SELECT * FROM track_entries ORDER BY date DESC, createdAt DESC")
     fun getAllTrackEntries(): Flow<List<TrackEntryEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long
 
     @Query("SELECT * FROM track_entries WHERE date = :date LIMIT 1")
@@ -201,10 +201,10 @@ interface RelationDao {
     @Query("SELECT * FROM relations WHERE fromNodeId = :nodeId OR toNodeId = :nodeId")
     fun getRelationsForNode(nodeId: Long): Flow<List<RelationEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertRelation(relation: RelationEntity)
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertRelations(relations: List<RelationEntity>)
 
     @Delete
@@ -699,13 +699,13 @@ interface CalendarEventDao {
         to: Long,
     ): Flow<List<CalendarEventEntity>>
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEvents(events: List<CalendarEventEntity>)
 
     @Query("DELETE FROM calendar_events WHERE providerId = :providerId")
     suspend fun deleteEventsByProvider(providerId: Long)
 
-    @androidx.room.Insert(onConflict = androidx.room.OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertEvent(event: CalendarEventEntity): Long
 
     @Update

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -598,7 +598,11 @@ class AppRepository(
     // Calendar
     fun getAllCalendarProviders() = calendarProviderDao.getAllProviders()
 
-    suspend fun insertCalendarProvider(provider: CalendarProviderEntity) = calendarProviderDao.insertProvider(provider)
+    suspend fun insertCalendarProvider(provider: CalendarProviderEntity): Long {
+        var id = calendarProviderDao.insertProvider(provider)
+        if (id == -1L) id = provider.id
+        return id
+    }
 
     suspend fun updateCalendarProvider(provider: CalendarProviderEntity) = calendarProviderDao.updateProvider(provider)
 
@@ -649,7 +653,8 @@ class AppRepository(
      * @return The auto-generated ID of the newly inserted node.
      */
     suspend fun insertNode(node: NodeEntity): Long {
-        val id = nodeDao.insertNode(node)
+        var id = nodeDao.insertNode(node)
+        if (id == -1L) id = node.id
         logEvent("NODE_CREATED", id)
         syncBelongsToRelations(id, node.projectId, node.areaId)
         syncTypedFacetsFromNode(node.copy(id = id))
@@ -1079,7 +1084,8 @@ class AppRepository(
     fun getActiveSession(): Flow<FocusSessionEntity?> = focusSessionDao.getActiveSession()
 
     suspend fun insertSession(session: FocusSessionEntity): Long {
-        val id = focusSessionDao.insertSession(session)
+        var id = focusSessionDao.insertSession(session)
+        if (id == -1L) id = session.id
         logEvent("SESSION_STARTED", session.nodeId)
         return id
     }
@@ -1094,7 +1100,8 @@ class AppRepository(
     fun getAllTrackEntries(): Flow<List<TrackEntryEntity>> = trackDao.getAllTrackEntries()
 
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long {
-        val id = trackDao.insertTrackEntry(entry)
+        var id = trackDao.insertTrackEntry(entry)
+        if (id == -1L) id = entry.id
         logEvent("CHECKIN_CREATED")
         return id
     }
@@ -1123,7 +1130,11 @@ class AppRepository(
 
     fun getTagsForNode(nodeId: Long) = tagDao.getTagsForNode(nodeId)
 
-    suspend fun insertTag(tag: TagEntity) = tagDao.insertTag(tag)
+    suspend fun insertTag(tag: TagEntity): Long {
+        var id = tagDao.insertTag(tag)
+        if (id == -1L) id = tag.id
+        return id
+    }
 
     suspend fun attachTagToNode(
         nodeId: Long,
@@ -1373,14 +1384,22 @@ class AppRepository(
     // Reviews
     fun getAllReviews() = reviewDao.getAllReviews()
 
-    suspend fun insertReview(review: ReviewEntity) = reviewDao.insertReview(review)
+    suspend fun insertReview(review: ReviewEntity): Long {
+        var id = reviewDao.insertReview(review)
+        if (id == -1L) id = review.id
+        return id
+    }
 
     suspend fun getLastReviewByType(type: String) = reviewDao.getLastReviewByType(type)
 
     // Operating Modes
     fun getAllModes() = modeDao.getAllModes()
 
-    suspend fun insertMode(mode: ModeEntity) = modeDao.insertMode(mode)
+    suspend fun insertMode(mode: ModeEntity): Long {
+        var id = modeDao.insertMode(mode)
+        if (id == -1L) id = mode.id
+        return id
+    }
 
     suspend fun updateMode(mode: ModeEntity) = modeDao.updateMode(mode)
 
@@ -1398,7 +1417,11 @@ class AppRepository(
 
     fun getAllModeUsageLogs() = modeDao.getAllUsageLogs()
 
-    suspend fun insertModeUsageLog(log: ModeUsageLogEntity) = modeDao.insertUsageLog(log)
+    suspend fun insertModeUsageLog(log: ModeUsageLogEntity): Long {
+        var id = modeDao.insertUsageLog(log)
+        if (id == -1L) id = log.id
+        return id
+    }
 
     suspend fun deactivateModeUsageLog(
         id: Long,
@@ -1420,7 +1443,11 @@ class AppRepository(
     // Protocols
     fun getAllProtocolHistory() = protocolDao.getAllProtocolHistory()
 
-    suspend fun insertProtocolHistory(history: ProtocolHistoryEntity) = protocolDao.insertProtocolHistory(history)
+    suspend fun insertProtocolHistory(history: ProtocolHistoryEntity): Long {
+        var id = protocolDao.insertProtocolHistory(history)
+        if (id == -1L) id = history.id
+        return id
+    }
 
     // Decisions
 
@@ -1510,7 +1537,8 @@ class AppRepository(
                 content = "Derived from decision: ${node.decisionOutcome ?: node.content}",
                 areaId = node.areaId,
             )
-        val projectId = nodeDao.insertNode(newProject)
+        var projectId = nodeDao.insertNode(newProject)
+        if (projectId == -1L) projectId = newProject.id
 
         insertRelation(
             RelationEntity(
@@ -1543,7 +1571,8 @@ class AppRepository(
                 areaId = node.areaId,
                 projectId = node.projectId,
             )
-        val taskId = nodeDao.insertNode(newTask)
+        var taskId = nodeDao.insertNode(newTask)
+        if (taskId == -1L) taskId = newTask.id
 
         insertRelation(
             RelationEntity(
@@ -1558,7 +1587,11 @@ class AppRepository(
 
     fun getOptionsForDecision(nodeId: Long) = decisionDao.getOptionsForDecision(nodeId)
 
-    suspend fun insertDecisionOption(option: DecisionOptionEntity) = decisionDao.insertDecisionOption(option)
+    suspend fun insertDecisionOption(option: DecisionOptionEntity): Long {
+        var id = decisionDao.insertDecisionOption(option)
+        if (id == -1L) id = option.id
+        return id
+    }
 
     suspend fun updateDecisionOption(option: DecisionOptionEntity) = decisionDao.updateDecisionOption(option)
 
@@ -1588,7 +1621,11 @@ class AppRepository(
 
     fun getAllMedications(): Flow<List<MedicationEntity>> = medicationDao.getAllMedications()
 
-    suspend fun insertMedication(medication: MedicationEntity): Long = medicationDao.insertMedication(medication)
+    suspend fun insertMedication(medication: MedicationEntity): Long {
+        var id = medicationDao.insertMedication(medication)
+        if (id == -1L) id = medication.id
+        return id
+    }
 
     suspend fun updateMedication(medication: MedicationEntity) = medicationDao.updateMedication(medication)
 

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeFocusSessionDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeFocusSessionDao.kt
@@ -13,9 +13,9 @@ class FakeFocusSessionDao : FocusSessionDao {
     }
 
     override suspend fun insertSession(session: FocusSessionEntity): Long {
-        val newId = (sessions.size + 1).toLong()
+        val newId = if (session.id != 0L) session.id else (sessions.maxOfOrNull { it.id } ?: 0L) + 1L
         val newSession = session.copy(id = newId)
-        sessions.add(newSession)
+        sessions.removeAll { it.id == newId }; sessions.add(newSession)
         sessionsFlow.value = sessions.toList()
         return newId
     }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeNodeDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeNodeDao.kt
@@ -63,9 +63,9 @@ class FakeNodeDao : NodeDao {
     }
 
     override suspend fun insertNode(node: NodeEntity): Long {
-        val newId = (nodes.size + 1).toLong()
+        val newId = if (node.id != 0L) node.id else (nodes.maxOfOrNull { it.id } ?: 0L) + 1L
         val newNode = node.copy(id = newId)
-        nodes.add(newNode)
+        nodes.removeAll { it.id == newId }; nodes.add(newNode)
         nodesFlow.value = nodes.toList()
         return newId
     }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTagDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTagDao.kt
@@ -13,9 +13,9 @@ class FakeTagDao : TagDao {
     override fun getAllTags(): Flow<List<TagEntity>> = tagsFlow
 
     override suspend fun insertTag(tag: TagEntity): Long {
-        val newId = (tags.size + 1).toLong()
+        val newId = if (tag.id != 0L) tag.id else (tags.maxOfOrNull { it.id } ?: 0L) + 1L
         val newTag = tag.copy(id = newId)
-        tags.add(newTag)
+        tags.removeAll { it.id == newId }; tags.add(newTag)
         tagsFlow.value = tags.toList()
         return newId
     }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTrackDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTrackDao.kt
@@ -15,9 +15,9 @@ class FakeTrackDao : TrackDao {
     }
 
     override suspend fun insertTrackEntry(entry: TrackEntryEntity): Long {
-        val newId = (entries.size + 1).toLong()
+        val newId = if (entry.id != 0L) entry.id else (entries.maxOfOrNull { it.id } ?: 0L) + 1L
         val newEntry = entry.copy(id = newId)
-        entries.add(newEntry)
+        entries.removeAll { it.id == newId }; entries.add(newEntry)
         entriesFlow.value = entries.toList()
         return newId
     }


### PR DESCRIPTION
Replaces `@Insert(onConflict = OnConflictStrategy.REPLACE)` with `@Upsert` across `Daos.kt` to avoid computationally expensive delete-and-reinsert cycles and prevent unintended ON DELETE CASCADE foreign key triggers. 
Updates `AppRepository` to handle the `-1L` return value correctly when `@Upsert` updates an existing entity.
Also updates Fake DAOs in `commonTest` to accurately simulate the new upsert logic behavior.

---
*PR created automatically by Jules for task [16265279819809583265](https://jules.google.com/task/16265279819809583265) started by @tajemniktv*