### PR TITLE
docs: Add KDocs for domain heuristics and inbox flow

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -351,6 +351,7 @@ class AppRepository(
 
     /**
      * Stores a raw capture entry before it becomes a typed life object.
+     * Raw captures sit in an unprocessed state until semantic triage turns them into actionable items.
      *
      * @return The auto-generated inbox entry identifier.
      */
@@ -398,6 +399,11 @@ class AppRepository(
      *
      * The first non-blank line of the raw text becomes the new item's title, and remaining lines become the body content.
      * This establishes the entry point for turning fleeting thoughts into durable nodes (tasks, notes, projects).
+     *
+     * **State and Data Flow Transitions:**
+     * - The un-triaged raw capture transitions from `processedAt = null` to having a concrete processing timestamp.
+     * - A new typed node is generated based on the inferred or user-selected [ItemKind].
+     * - The original raw entry retains a reference (`triagedItemId`) to the newly spawned node, completing the pipeline.
      *
      * **Side effects:**
      * - Inserts the newly created typed item into the nodes table and synchronizes its associated facets, domains, and schedules.

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/DomainKind.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/DomainKind.kt
@@ -10,7 +10,9 @@ import kotlinx.serialization.Serializable
  * Built-in, first-class LifeOS domains.
  *
  * Domains are product-level lenses over shared system data and are not equivalent
- * to user-defined Areas.
+ * to user-defined Areas. TajsOS utilizes heuristic-based, zero-configuration logic
+ * (e.g., implicit keyword matching) for categorizing domains rather than requiring
+ * explicit user associations.
  */
 @Serializable
 enum class DomainKind {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -248,7 +248,8 @@ object DomainLensQueries {
      *
      * Note: This intentionally bypasses explicit `ItemDomainEntity` database associations
      * to provide a zero-configuration experience, ensuring finance items are surfaced even
-     * if the user forgets to manually assign the finance domain.
+     * if the user forgets to manually assign the finance domain. This heuristic-based logic
+     * relies on implicit keyword matching to decouple domain categorization from explicit user action.
      */
     private fun matchesFinanceSignal(node: NodeWithPin): Boolean {
         val title = node.node.title.lowercase()
@@ -272,7 +273,8 @@ object DomainLensQueries {
      *
      * Note: This intentionally bypasses explicit `ItemDomainEntity` database associations
      * to provide a zero-configuration experience, ensuring health items are surfaced even
-     * if the user forgets to manually assign the health domain.
+     * if the user forgets to manually assign the health domain. This heuristic-based logic
+     * relies on implicit keyword matching to decouple domain categorization from explicit user action.
      */
     private fun matchesHealthSignal(node: NodeWithPin): Boolean {
         val title = node.node.title.lowercase()


### PR DESCRIPTION
This PR improves the documentation of the local-first heuristics and the un-triaged inbox state flow.

- **DomainKind & DomainLensQueries:** Explicitly documented the heuristic-based, zero-configuration logic that relies on implicit keyword matching, decoupling domain categorization from manual user action.
- **Repository Inbox Flow:** Documented the state and data flow transitions between capturing a raw inbox entry (`captureInboxEntry`) and converting it into an actionable life object (`triageInboxEntry`).

These documentation updates reduce onboarding friction by clarifying intent and non-obvious behavior without altering any architecture.

---
*PR created automatically by Jules for task [2171392514895190482](https://jules.google.com/task/2171392514895190482) started by @tajemniktv*