### PR TITLE
fix(ui): remove solid borders and enforce organic industrialism in components

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
@@ -224,9 +224,10 @@ fun TactileTextField(
                     .fillMaxWidth()
                     .heightIn(min = 120.dp)
                     .background(TajsOSTheme.SurfaceLowest, RoundedCornerShape(TajsOSTheme.RadiusMd))
+                    // Obey DESIGN.md: no solid borders. Use GhostBorder.
                     .border(
                         1.dp,
-                        if (isFocused) TajsOSTheme.GhostBorder else TajsOSTheme.SurfaceLow,
+                        if (isFocused) TajsOSTheme.GhostBorder else Color.Transparent,
                         RoundedCornerShape(TajsOSTheme.RadiusMd)
                     )
                     .padding(TajsOSTheme.SpacingMd)

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
@@ -227,7 +227,7 @@ fun TactileTextField(
                     // Obey DESIGN.md: no solid borders. Use GhostBorder.
                     .border(
                         1.dp,
-                        if (isFocused) TajsOSTheme.GhostBorder else Color.Transparent,
+                        if (isFocused) TajsOSTheme.GhostBorder.copy(alpha = 0.5f) else Color.Transparent,
                         RoundedCornerShape(TajsOSTheme.RadiusMd)
                     )
                     .padding(TajsOSTheme.SpacingMd)

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AreaCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AreaCards.kt
@@ -33,7 +33,6 @@ fun AreaHealthOverviewCard(
         shape =
             androidx.compose.foundation.shape
                 .RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DashboardCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DashboardCards.kt
@@ -413,7 +413,6 @@ fun VaultCard(
         modifier = modifier,
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Icon(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
@@ -39,7 +39,6 @@ fun OptionCard(
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.Background,
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         shape = RoundedCornerShape(2.dp),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingSm)) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/GeneralCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/GeneralCards.kt
@@ -51,7 +51,6 @@ fun InfoCard(
         modifier = modifier.glassChrome(shape = RoundedCornerShape(TajsOSTheme.RadiusMd), material = GlassMaterial.REGULAR),
         color = glassContainerColor(TajsOSTheme.Surface),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Row(
@@ -96,7 +95,6 @@ fun StatusCard(
         modifier = modifier.fillMaxWidth().glassChrome(shape = RoundedCornerShape(TajsOSTheme.RadiusMd), material = GlassMaterial.REGULAR),
         color = glassContainerColor(TajsOSTheme.Surface),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(
@@ -134,7 +132,6 @@ fun LinkedNodeItem(
         modifier = modifier.fillMaxWidth().glassChrome(shape = RoundedCornerShape(TajsOSTheme.RadiusMd), material = GlassMaterial.REGULAR),
         color = glassContainerColor(TajsOSTheme.Surface),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Row(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -189,7 +186,6 @@ fun ConnectionCard(
         modifier = modifier.fillMaxWidth().glassChrome(shape = RoundedCornerShape(TajsOSTheme.RadiusMd), material = GlassMaterial.THIN),
         color = glassContainerColor(Color.Transparent),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.5f)),
     ) {
         Row(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/InsightsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/InsightsCards.kt
@@ -635,7 +635,6 @@ fun AreaHealthSystemCard(
         shape =
             androidx.compose.foundation.shape
                 .RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/ModuleCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/ModuleCard.kt
@@ -70,7 +70,6 @@ fun ModuleCard(
         ),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         color = glassContainerColor(TajsOSTheme.Surface),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.5f)),
         shadowElevation = 2.dp,
     ) {
         Column(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
@@ -307,7 +307,6 @@ fun ProtocolCard(
         shape =
             androidx.compose.foundation.shape
                 .RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
@@ -31,7 +31,7 @@ fun DashCard(
         modifier = modifier,
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
+        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
         content = content,
     )
 }
@@ -47,7 +47,7 @@ fun TactileCard(
             modifier
                 .fillMaxWidth()
                 .background(TajsOSTheme.CardSurface, RoundedCornerShape(TajsOSTheme.RadiusMd))
-                .border(1.dp, TajsOSTheme.CardStroke, RoundedCornerShape(TajsOSTheme.RadiusMd))
+                .border(1.dp, TajsOSTheme.GhostBorder, RoundedCornerShape(TajsOSTheme.RadiusMd))
                 .then(
                     if (onClick != null) {
                         Modifier.mouseClickable(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/SelectorDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/SelectorDialog.kt
@@ -113,7 +113,6 @@ fun <T> SelectorDialog(
                     Surface(
                         color = Color.Black.copy(alpha = 0.5f),
                         shape = RoundedCornerShape(4.dp),
-                        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
                     ) {
                         Text(
                             "STATUS: READY",

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
@@ -88,7 +88,6 @@ fun DashHeader(
             Surface(
                 color = Color.Black.copy(alpha = 0.5f),
                 shape = CircleShape,
-                border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
             ) {
                 Row(
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/HeaderComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/HeaderComponents.kt
@@ -66,7 +66,6 @@ fun SystemOnlineStatus(tintColor: Color) {
     Surface(
         color = Color.Black.copy(alpha = 0.5f),
         shape = CircleShape,
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
@@ -109,7 +108,6 @@ fun DesktopSearchSurface() {
     Surface(
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/StateAwareActionsGrid.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/StateAwareActionsGrid.kt
@@ -78,7 +78,6 @@ fun StateAwareActionsGrid(
                 modifier = Modifier.weight(1f),
                 color = TajsOSTheme.CardSurface,
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
             ) {
                 Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
                     Icon(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -232,7 +232,6 @@ fun DecisionDetailContent(
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
                     color = TajsOSTheme.Background,
-                    border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
                     shape = RoundedCornerShape(2.dp),
                 ) {
                     Row(
@@ -355,7 +354,6 @@ fun DecisionDetailContent(
                 onClick = { viewModel.convertDecisionToTask(node.id) },
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(2.dp),
-                border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
             ) {
                 Text(stringResource(Res.string.decision_convert_task), color = TajsOSTheme.Text)
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/OperationsScreenCommon.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/OperationsScreenCommon.kt
@@ -82,7 +82,6 @@ internal fun GroupedOpenLoopSection(
         shape =
             androidx.compose.foundation.shape
                 .RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/capacity/CapacityDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/capacity/CapacityDashboardBlocks.kt
@@ -75,7 +75,6 @@ internal fun CapacityLayer(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
@@ -391,7 +391,6 @@ private fun RenderDashboardBlock(
                 modifier = Modifier.fillMaxWidth(),
                 color = TajsOSTheme.CardSurface,
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
             ) {
                 Column(Modifier.padding(20.dp)) {
                     Text(
@@ -427,7 +426,6 @@ private fun RenderDashboardBlock(
                 modifier = Modifier.fillMaxWidth(),
                 color = TajsOSTheme.CardSurface.copy(alpha = 0.5f),
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
             ) {
                 Row(
                     modifier = Modifier.padding(12.dp).fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
@@ -73,7 +73,6 @@ internal fun renderFinanceHeaderBlock(context: FinanceDashboardContext) {
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface.copy(alpha = 0.6f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -133,7 +132,6 @@ internal fun renderFinanceMetricsBlock(context: FinanceDashboardContext) {
         Surface(
             modifier = Modifier.weight(1f),
             color = TajsOSTheme.CardSurface.copy(alpha = 0.65f),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         ) {
             Column(
@@ -169,7 +167,6 @@ internal fun renderFinanceMetricsBlock(context: FinanceDashboardContext) {
         Surface(
             modifier = Modifier.weight(1f),
             color = TajsOSTheme.CardSurface.copy(alpha = 0.65f),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         ) {
             Column(
@@ -201,7 +198,6 @@ internal fun renderFinanceActivityBlock(context: FinanceDashboardContext) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface.copy(alpha = 0.7f),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     ) {
         Column(
@@ -264,7 +260,6 @@ internal fun renderFinanceInsightsBlock(context: FinanceDashboardContext) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface.copy(alpha = 0.7f),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     ) {
         Column(
@@ -289,7 +284,6 @@ internal fun renderFinanceInsightsBlock(context: FinanceDashboardContext) {
                     modifier = Modifier.fillMaxWidth(),
                     color = TajsOSTheme.Background.copy(alpha = 0.35f),
                     shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
-                    border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.7f)),
                 ) {
                     Text(
                         item,
@@ -320,7 +314,6 @@ internal fun renderFinanceVaultBlock(context: FinanceDashboardContext) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface.copy(alpha = 0.7f),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     ) {
         Column(
@@ -366,7 +359,6 @@ internal fun renderFinanceQueueControlsBlock(context: FinanceDashboardContext) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface.copy(alpha = 0.7f),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     ) {
         Column(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/focus/FocusDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/focus/FocusDashboardBlocks.kt
@@ -193,7 +193,6 @@ internal fun FocusMainBlock(viewModel: MainViewModel) {
         Surface(
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(16.dp),
@@ -299,7 +298,6 @@ internal fun FocusMainBlock(viewModel: MainViewModel) {
         Surface(
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(16.dp),
@@ -371,7 +369,6 @@ internal fun FocusMainBlock(viewModel: MainViewModel) {
         Surface(
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(16.dp),
@@ -418,7 +415,6 @@ internal fun FocusMainBlock(viewModel: MainViewModel) {
         Surface(
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(16.dp),
@@ -475,7 +471,6 @@ private fun FocusListCard(
     Surface(
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(16.dp),
@@ -528,7 +523,6 @@ private fun FocusListCard(
                             OutlinedButton(
                                 onClick = { onPick(task) },
                                 shape = RoundedCornerShape(999.dp),
-                                border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
                                 colors =
                                     ButtonDefaults.outlinedButtonColors(
                                         containerColor = TajsOSTheme.CardSurface,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/graph/GraphDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/graph/GraphDashboardBlocks.kt
@@ -99,7 +99,6 @@ internal fun GraphMainBlock(
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Card(
                 colors = CardDefaults.cardColors(containerColor = TajsOSTheme.SurfaceLow),
-                border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
             ) {
                 Text(
                     text = stringResource(Res.string.graph_no_data),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/health/HealthDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/health/HealthDashboardBlocks.kt
@@ -63,7 +63,6 @@ internal fun HealthMainBlock(
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -119,7 +118,6 @@ internal fun HealthMainBlock(
                     modifier = Modifier.fillMaxWidth(),
                     color = TajsOSTheme.CardSurface,
                     shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
-                    border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
                     onClick = { onEditNode(item.node.node.id) },
                 ) {
                     Column(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/identity/IdentityDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/identity/IdentityDashboardBlocks.kt
@@ -92,7 +92,6 @@ private fun renderIdentitySignature(context: IdentityDashboardContext) {
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -152,7 +151,6 @@ private fun renderIdentitySignature(context: IdentityDashboardContext) {
                 modifier = Modifier.fillMaxWidth(),
                 color = TajsOSTheme.CardSurface,
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
             ) {
                 Column(
                     modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -192,7 +190,6 @@ private fun renderIdentitySignature(context: IdentityDashboardContext) {
                     modifier = Modifier.fillMaxWidth(),
                     color = TajsOSTheme.CardSurface,
                     shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                    border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
                 ) {
                     Column(
                         modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -244,7 +241,6 @@ private fun renderIdentityDistinction(context: IdentityDashboardContext) {
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -300,7 +296,6 @@ private fun renderIdentityDirection(context: IdentityDashboardContext) {
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -345,7 +340,6 @@ private fun renderIdentityCoreShift(context: IdentityDashboardContext) {
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
@@ -289,7 +289,6 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
                 Row(
@@ -453,7 +452,6 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
                 Row(
@@ -533,7 +531,6 @@ private fun renderNoteContextGraph(context: NoteDetailContext) {
         modifier = Modifier.fillMaxWidth(),
         color = Color.Black.copy(alpha = 0.3f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.5f)),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingLg)) {
             Row(
@@ -569,7 +566,6 @@ private fun renderNoteContextGraph(context: NoteDetailContext) {
                 Surface(
                     color = TajsOSTheme.CardSurface,
                     shape = CircleShape,
-                    border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
                 ) {
                     Text(
                         "${tags.size} Tags",
@@ -638,7 +634,6 @@ private fun renderNoteCadence(context: NoteDetailContext) {
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Row(
                 modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -693,7 +688,6 @@ private fun renderNoteAwarePlanning(context: NoteDetailContext) {
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -808,7 +802,6 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(
@@ -906,7 +899,6 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
                 Row(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/openloops/OpenLoopsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/openloops/OpenLoopsScreen.kt
@@ -130,7 +130,6 @@ internal fun OpenLoopsLayer(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/places/PlacesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/places/PlacesScreen.kt
@@ -128,7 +128,6 @@ internal fun PlacesLayer(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -161,7 +160,6 @@ internal fun PlacesLayer(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -210,7 +208,6 @@ internal fun PlacesLayer(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -346,7 +343,6 @@ internal fun PlacesLayer(
                 modifier = Modifier.fillMaxWidth(),
                 color = TajsOSTheme.CardSurface,
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
             ) {
                 Column(
                     modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/protocols/ProtocolsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/protocols/ProtocolsScreen.kt
@@ -257,7 +257,6 @@ internal fun ProtocolsLayer(
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.SurfaceLowest,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.6f)),
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingSm),
@@ -340,7 +339,6 @@ private fun ProtocolsHeader(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier =
@@ -404,7 +402,6 @@ private fun HeaderStatChip(
 ) {
     Surface(
         color = TajsOSTheme.SurfaceHighest.copy(alpha = 0.9f),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.45f)),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     ) {
         Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
@@ -476,7 +473,6 @@ private fun ProtocolLibrarySurface(
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 color = TajsOSTheme.CardSurface,
-                border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             ) {
                 Text(
@@ -513,7 +509,6 @@ private fun ProtocolLibraryCard(
         modifier = Modifier.width(360.dp),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd),
@@ -600,7 +595,6 @@ private fun ProtocolRunSurface(
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd),
@@ -769,7 +763,6 @@ private fun ProtocolRunMainPanel(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingLg),
@@ -815,7 +808,6 @@ private fun ProtocolRunMainPanel(
                 modifier = Modifier.fillMaxWidth(),
                 color = TajsOSTheme.SurfaceLowest,
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.7f)),
             ) {
                 Column(
                     modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd),
@@ -910,7 +902,6 @@ private fun ProtocolRunSidebar(
         modifier = modifier,
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd),
@@ -939,7 +930,6 @@ private fun ProtocolRunSidebar(
                 Surface(
                     color = TajsOSTheme.SurfaceHighest.copy(alpha = 0.8f),
                     shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                    border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.5f)),
                 ) {
                     Text(
                         text = stringResource(Res.string.protocol_up_next, upNext),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/relationships/RelationshipsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/relationships/RelationshipsScreen.kt
@@ -101,7 +101,6 @@ internal fun PeopleLayer(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/rules/RulesDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/rules/RulesDashboardBlocks.kt
@@ -65,7 +65,6 @@ private fun renderRulesStats(context: RulesDashboardContext) {
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -111,7 +110,6 @@ private fun renderRulesInput(context: RulesDashboardContext) {
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
@@ -206,7 +206,6 @@ internal fun TasksAllView(
                         modifier = Modifier.weight(2f),
                         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                         color = TajsOSTheme.CardSurface,
-                        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
                     ) {
                         TaskTable(
                             sorted,
@@ -220,7 +219,6 @@ internal fun TasksAllView(
                         modifier = Modifier.weight(1f),
                         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                         color = TajsOSTheme.CardSurface,
-                        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
                     ) {
                         TaskDetails(
                             selected,
@@ -238,7 +236,6 @@ internal fun TasksAllView(
                 Surface(
                     shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                     color = TajsOSTheme.CardSurface,
-                    border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
                 ) {
                     Column(modifier = Modifier.fillMaxWidth()) {
                         TaskTable(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksArchiveView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksArchiveView.kt
@@ -67,7 +67,6 @@ internal fun TasksArchiveView(
         Surface(
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             color = TajsOSTheme.CardSurface,
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column {
                 archivedTasks.forEach { task ->

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
@@ -256,7 +256,6 @@ private fun PriorityTaskCard(
     Surface(
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         color = TajsOSTheme.CardSurface,
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd),
@@ -337,7 +336,6 @@ private fun QueueList(
     Surface(
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         color = TajsOSTheme.CardSurface,
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column {
             tasks.forEach { task ->
@@ -399,7 +397,6 @@ private fun CommandSidebar(
         modifier = modifier,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         color = TajsOSTheme.CardSurface,
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksInboxView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksInboxView.kt
@@ -72,7 +72,6 @@ internal fun TasksInboxView(
         Surface(
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             color = TajsOSTheme.CardSurface,
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd),
@@ -135,7 +134,6 @@ internal fun TasksInboxView(
         Surface(
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             color = TajsOSTheme.CardSurface,
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksTodayView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksTodayView.kt
@@ -134,7 +134,6 @@ private fun TodaySection(
     Surface(
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         color = TajsOSTheme.CardSurface,
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -300,7 +300,6 @@ private fun HeaderTitleEditor(
     Surface(
         shape = RoundedCornerShape(10.dp),
         color = TajsOSTheme.SurfaceHighest,
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.25f)),
     ) {
         BasicTextField(
             value = value,
@@ -390,7 +389,6 @@ private fun renderTaskDescription(context: TaskDetailContext) {
                 Surface(
                     shape = RoundedCornerShape(10.dp),
                     color = TajsOSTheme.SurfaceHighest,
-                    border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.22f)),
                 ) {
                     BasicTextField(
                         value = context.draftDescription,
@@ -578,7 +576,6 @@ private fun SubtaskRow(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(10.dp),
         color = background,
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.18f)),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
@@ -141,7 +141,6 @@ private fun renderTimeMap(context: TimeArchitectureDashboardContext) {
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.SurfaceLow,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.18f)),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -310,7 +309,6 @@ private fun TimeArchitectureCadenceCard(
         modifier = modifier,
         color = TajsOSTheme.SurfaceLow,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.15f)),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -359,7 +357,6 @@ private fun TimeArchitectureAnchorsCard(
         modifier = modifier,
         color = TajsOSTheme.SurfaceLow,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-        border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.15f)),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -410,7 +407,6 @@ private fun renderTimeProjectPhases(context: TimeArchitectureDashboardContext) {
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.SurfaceLow,
             shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.15f)),
         ) {
             Column(
                 modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -474,7 +470,6 @@ private fun renderTimeHorizonQueue(context: TimeArchitectureDashboardContext) {
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.SurfaceLow,
             shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
-            border = BorderStroke(1.dp, TajsOSTheme.CardStroke.copy(alpha = 0.15f)),
         ) {
             Column(
                 modifier = Modifier.padding(TajsOSTheme.SpacingMd),


### PR DESCRIPTION
This PR systematically removes solid, 100% opaque borders (`TajsOSTheme.CardStroke`) across a vast majority of the application's surface and card components, opting instead for either no borders or subtle `GhostBorder`s where appropriate. This creates a much cleaner, more modern interface, directly fulfilling the goal of "UX polish" and adhering to the "No-Line" rule defined in `DESIGN.md`. All changes are cosmetic and fully contained in the Jetpack Compose UI layer.

---
*PR created automatically by Jules for task [816472903691455461](https://jules.google.com/task/816472903691455461) started by @tajemniktv*