### PR TITLE
fix: pin GitHub actions to commit SHAs in scorecards.yml

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,24 +22,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
         with:
           sarif_file: results.sarif
 
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: scorecard-sarif-${{ github.run_id }}
           path: results.sarif


### PR DESCRIPTION
This PR pins the GitHub Actions used in `scorecards.yml` to their corresponding commit SHAs. This mitigates the risk of supply-chain attacks if an action's mutable version tag (e.g., `v4`, `v6`) is compromised, and explicitly satisfies the OpenSSF Scorecard `Pinned-Dependencies` rule.

---
*PR created automatically by Jules for task [18237010136344503692](https://jules.google.com/task/18237010136344503692) started by @tajemniktv*