### PR TITLE
docs: Clarify missing domain queries in DomainLensQueries

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -114,8 +114,8 @@ private val healthTitleKeywords =
  * right lenses without requiring manual user curation.
  *
  * Currently, heuristic matching queries are only implemented for the `FINANCES` and `HEALTH` domains.
- * Other domains defined in `DomainKind` (e.g., `EDUCATION` and `RELATIONSHIPS`) do not yet have dedicated
- * queries in this object.
+ * `EDUCATION` and `RELATIONSHIPS` (defined in [com.tajemniktv.tajsos.domain.DomainKind])
+ * do not yet have dedicated queries in this object.
  */
 object DomainLensQueries {
     /**

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -112,6 +112,10 @@ private val healthTitleKeywords =
  * implicitly categorized into domains via keyword matching in titles, content, tags, and
  * specific maintenance/note types. This decoupling allows items to naturally surface in the
  * right lenses without requiring manual user curation.
+ *
+ * Currently, heuristic matching queries are only implemented for the `FINANCES` and `HEALTH` domains.
+ * Other domains defined in `DomainKind` (e.g., `EDUCATION` and `RELATIONSHIPS`) do not yet have dedicated
+ * queries in this object.
  */
 object DomainLensQueries {
     /**


### PR DESCRIPTION
Added KDoc to `DomainLensQueries` to clarify that while `DomainKind` defines `EDUCATION` and `RELATIONSHIPS`, currently only `FINANCES` and `HEALTH` domains have dedicated heuristic matching queries implemented. This reduces onboarding friction by making the non-obvious behavior explicit.

---
*PR created automatically by Jules for task [14403084807662066896](https://jules.google.com/task/14403084807662066896) started by @tajemniktv*