### PR TITLE
fix: Implement DataStore corruption handlers

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/tajemniktv/tajsos/main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tajemniktv/tajsos/main.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.window.application
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.emptyPreferences
 import com.tajemniktv.tajsos.data.DesktopWindowStartupMode
 import com.tajemniktv.tajsos.data.PreferencesRepository
 import com.tajemniktv.tajsos.data.createDatabase
@@ -44,6 +46,7 @@ fun main() =
         // Simple DataStore setup for Desktop
         val dataStore =
             PreferenceDataStoreFactory.create(
+                corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
                 produceFile = { File(System.getProperty("user.home"), "tajsos.preferences_pb") },
             )
 

--- a/composeApp/src/jvmMain/kotlin/com/tajemniktv/tajsos/main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tajemniktv/tajsos/main.kt
@@ -64,16 +64,7 @@ fun main() =
             rememberWindowState(
                 position = persistedWindowPlacement.toWindowPosition(),
                 size = persistedWindowPlacement.toWindowSize(),
-                placement =
-                    when (desktopWindowStartupMode) {
-                        DesktopWindowStartupMode.ALWAYS_MAXIMIZED -> WindowPlacement.Maximized
-                        DesktopWindowStartupMode.RESTORE_LAST ->
-                            if (persistedWindowPlacement.isMaximized) {
-                                WindowPlacement.Maximized
-                            } else {
-                                WindowPlacement.Floating
-                            }
-                    },
+                placement = resolveWindowPlacement(desktopWindowStartupMode, persistedWindowPlacement.isMaximized),
             )
         val viewModel =
             sharedModule.createViewModel(
@@ -170,5 +161,24 @@ private fun Dp.toPersistedDpOrNull(): Int? {
         null
     } else {
         rawValue.toInt()
+    }
+}
+
+
+/**
+ * Resolves [WindowPlacement] based on startup mode and persistence.
+ */
+private fun resolveWindowPlacement(
+    startupMode: DesktopWindowStartupMode,
+    isMaximized: Boolean,
+): WindowPlacement {
+    return when (startupMode) {
+        DesktopWindowStartupMode.ALWAYS_MAXIMIZED -> WindowPlacement.Maximized
+        DesktopWindowStartupMode.RESTORE_LAST ->
+            if (isMaximized) {
+                WindowPlacement.Maximized
+            } else {
+                WindowPlacement.Floating
+            }
     }
 }

--- a/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/data/DataStore.kt
+++ b/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/data/DataStore.kt
@@ -9,7 +9,7 @@ import androidx.datastore.preferences.core.emptyPreferences
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
     name = "settings",
-    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() }
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
 )
 
 fun createDataStore(context: Context): DataStore<Preferences> {

--- a/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/data/DataStore.kt
+++ b/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/data/DataStore.kt
@@ -4,8 +4,13 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.emptyPreferences
 
-private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "settings",
+    corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() }
+)
 
 fun createDataStore(context: Context): DataStore<Preferences> {
     return context.dataStore

--- a/shared/src/jvmTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryDesktopWindowPlacementTest.kt
+++ b/shared/src/jvmTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryDesktopWindowPlacementTest.kt
@@ -4,6 +4,8 @@
 
 package com.tajemniktv.tajsos.data
 
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -82,6 +84,7 @@ class PreferencesRepositoryDesktopWindowPlacementTest {
 
     private fun createTestDataStore() =
         PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
             produceFile = {
                 Files.createTempFile("tajsos-prefs-test", ".preferences_pb").toFile().apply {
                     deleteOnExit()


### PR DESCRIPTION
Added `ReplaceFileCorruptionHandler` to `DataStore` creation across all platform initializers (Android, JVM, JVM Tests) to prevent app crashes when the data store file becomes corrupted, as per datastore best practices.

---
*PR created automatically by Jules for task [10035141584383634149](https://jules.google.com/task/10035141584383634149) started by @tajemniktv*