### PR TITLE
fix(ui): Enforce No-Line rule and standardize borders

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
@@ -227,7 +227,7 @@ fun TactileTextField(
                     // Obey DESIGN.md: no solid borders. Use GhostBorder.
                     .border(
                         1.dp,
-                        if (isFocused) TajsOSTheme.GhostBorder.copy(alpha = 0.5f) else Color.Transparent,
+                        if (isFocused) TajsOSTheme.GhostBorder else Color.Transparent,
                         RoundedCornerShape(TajsOSTheme.RadiusMd)
                     )
                     .padding(TajsOSTheme.SpacingMd)

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
@@ -138,7 +138,7 @@ fun OpenLoopCard(
                     )
                 }
             }
-            HorizontalDivider(color = TajsOSTheme.Border)
+            HorizontalDivider(color = TajsOSTheme.GhostBorder)
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
                 verticalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
@@ -271,7 +271,7 @@ fun MaintenanceCard(
                 }, label = { Text("DUE +7D") })
                 AssistChip(onClick = { onSetOverdue(null) }, label = { Text("CLEAR DUE") })
             }
-            HorizontalDivider(color = TajsOSTheme.Border)
+            HorizontalDivider(color = TajsOSTheme.GhostBorder)
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
                 verticalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
@@ -316,6 +316,6 @@ fun StudentNodeCard(
             Text(stringResource(Res.string.common_revisit))
         }
     }
-    androidx.compose.material3.HorizontalDivider()
+    androidx.compose.material3.HorizontalDivider(color = TajsOSTheme.GhostBorder)
 }
 

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
@@ -316,6 +316,6 @@ fun StudentNodeCard(
             Text(stringResource(Res.string.common_revisit))
         }
     }
-    androidx.compose.material3.HorizontalDivider(color = TajsOSTheme.GhostBorder)
+    HorizontalDivider(color = TajsOSTheme.GhostBorder)
 }
 

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
@@ -553,7 +553,7 @@ fun ExpandableNavSection(
                         onRootNavigate()
                     },
                 )
-                HorizontalDivider()
+                HorizontalDivider(color = TajsOSTheme.GhostBorder)
                 children.forEach { child ->
                     val isActiveChild =
                         isChildActive(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt
@@ -204,7 +204,7 @@ internal fun CalendarMainBlock(
                                 )
                             }
 
-                            HorizontalDivider(color = TajsOSTheme.Border.copy(alpha = 0.6f))
+                            HorizontalDivider(color = TajsOSTheme.GhostBorder.copy(alpha = 0.6f))
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Icon(
                                     Icons.Default.TaskAlt,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt
@@ -204,7 +204,7 @@ internal fun CalendarMainBlock(
                                 )
                             }
 
-                            HorizontalDivider(color = TajsOSTheme.GhostBorder.copy(alpha = 0.6f))
+                            HorizontalDivider(color = TajsOSTheme.GhostBorder)
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Icon(
                                     Icons.Default.TaskAlt,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -241,7 +241,7 @@ fun NotesWorkspaceDetail(
                         )
                     }
                 }
-                HorizontalDivider(color = TajsOSTheme.Border)
+                HorizontalDivider(color = TajsOSTheme.GhostBorder)
                 LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     items(filtered, key = { it.id }) { item ->
                         Surface(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -612,7 +612,7 @@ private fun AppearanceSectionCard(
             style = MaterialTheme.typography.titleMedium,
             color = TajsOSTheme.Text,
         )
-        HorizontalDivider(color = TajsOSTheme.GhostBorder.copy(alpha = 0.3f))
+        HorizontalDivider(color = TajsOSTheme.GhostBorder)
         content()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -612,7 +612,7 @@ private fun AppearanceSectionCard(
             style = MaterialTheme.typography.titleMedium,
             color = TajsOSTheme.Text,
         )
-        HorizontalDivider(color = TajsOSTheme.Border.copy(alpha = 0.3f))
+        HorizontalDivider(color = TajsOSTheme.GhostBorder.copy(alpha = 0.3f))
         content()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
@@ -245,7 +245,7 @@ internal fun TasksAllView(
                             areaById,
                             onSelect = { selectedId = it },
                         )
-                        HorizontalDivider(color = TajsOSTheme.Border)
+                        HorizontalDivider(color = TajsOSTheme.GhostBorder)
                         TaskDetails(
                             selected,
                             projectById,
@@ -301,7 +301,7 @@ private fun TaskTable(
                 color = TajsOSTheme.Muted,
             )
         }
-        HorizontalDivider(color = TajsOSTheme.Border)
+        HorizontalDivider(color = TajsOSTheme.GhostBorder)
         Column {
             tasks.forEach { task ->
                 val selected = task.id == selectedId
@@ -357,7 +357,7 @@ private fun TaskTable(
                     onClick = { onSelect(task.id) },
                     modifier = Modifier.padding(horizontal = TajsOSTheme.SpacingMd),
                 ) { Text(stringResource(Res.string.tasks_open_action)) }
-                HorizontalDivider(color = TajsOSTheme.Border)
+                HorizontalDivider(color = TajsOSTheme.GhostBorder)
             }
         }
     }
@@ -409,7 +409,7 @@ private fun TaskDetails(
                 color = TajsOSTheme.Text,
             )
         }
-        HorizontalDivider(color = TajsOSTheme.Border)
+        HorizontalDivider(color = TajsOSTheme.GhostBorder)
         DetailRow(
             stringResource(Res.string.tasks_detail_status),
             (task.taskStateOrNull() ?: TaskState.ACTIVE).storageKey,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksArchiveView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksArchiveView.kt
@@ -107,7 +107,7 @@ internal fun TasksArchiveView(
                             }
                         }
                     }
-                    HorizontalDivider(color = TajsOSTheme.Border)
+                    HorizontalDivider(color = TajsOSTheme.GhostBorder)
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
@@ -370,7 +370,7 @@ private fun QueueList(
                         IconButton(onClick = { onDone(task) }) { Icon(Icons.Default.Check, null) }
                     }
                 }
-                HorizontalDivider(color = TajsOSTheme.Border)
+                HorizontalDivider(color = TajsOSTheme.GhostBorder)
             }
         }
     }
@@ -420,7 +420,7 @@ private fun CommandSidebar(
                     ),
                 )
             }
-            HorizontalDivider(color = TajsOSTheme.Border)
+            HorizontalDivider(color = TajsOSTheme.GhostBorder)
             Text(
                 stringResource(Res.string.tasks_quick_capture_title),
                 style = MaterialTheme.typography.titleMedium,
@@ -437,7 +437,7 @@ private fun CommandSidebar(
                     stringResource(Res.string.tasks_quick_capture_action),
                 )
             }
-            HorizontalDivider(color = TajsOSTheme.Border)
+            HorizontalDivider(color = TajsOSTheme.GhostBorder)
             Text(
                 stringResource(Res.string.tasks_context_title),
                 style = MaterialTheme.typography.titleMedium,
@@ -448,7 +448,7 @@ private fun CommandSidebar(
             ContextRow(stringResource(Res.string.tasks_context_due_soon), dueSoonCount)
 
             if (staleTasksCount > 0) {
-                HorizontalDivider(color = TajsOSTheme.Border)
+                HorizontalDivider(color = TajsOSTheme.GhostBorder)
                 OutlinedButton(
                     onClick = { showSweepDialog = true },
                     modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksInboxView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksInboxView.kt
@@ -125,7 +125,7 @@ internal fun TasksInboxView(
                                 }
                             }
                         }
-                        HorizontalDivider(color = TajsOSTheme.Border)
+                        HorizontalDivider(color = TajsOSTheme.GhostBorder)
                     }
                 }
             }
@@ -195,7 +195,7 @@ internal fun TasksInboxView(
                                 }
                             }
                         }
-                        HorizontalDivider(color = TajsOSTheme.Border)
+                        HorizontalDivider(color = TajsOSTheme.GhostBorder)
                     }
                 }
             }


### PR DESCRIPTION
This PR addresses the "No-Line" rule and the focus on "Tonal Layering" mentioned in `DESIGN.md`.

*   **Replaced `TajsOSTheme.Border` with `TajsOSTheme.GhostBorder`** across all `HorizontalDivider` instances. The design document explicitly forbids high-contrast borders and prefers `outline-variant` (which maps to `GhostBorder`) if a boundary is necessary.
*   **Updated Tactile TextField Focus State**: Ensured that the focused state of input fields uses a subtle 1px `GhostBorder` rather than a solid or `alpha = 0.5f` border.

This improves the overall polish and brings the app closer to the intended "Organic Industrialism" and "Glassmorphism" aesthetic without inventing new behaviors.

---
*PR created automatically by Jules for task [3578061144211417008](https://jules.google.com/task/3578061144211417008) started by @tajemniktv*