### PR TITLE
🧪 test: add error path test for sidebarMode fallback

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -316,6 +317,6 @@ fun StudentNodeCard(
             Text(stringResource(Res.string.common_revisit))
         }
     }
-    androidx.compose.material3.HorizontalDivider()
+    HorizontalDivider()
 }
 

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Grzegorz Kaczmarski (TajemnikTV) 2026. All rights reserved.
+ */
+
+package com.tajemniktv.tajsos.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import app.cash.turbine.test
+import com.tajemniktv.tajsos.ui.SidebarMode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PreferencesRepositoryTest {
+
+    private class FakeDataStore : DataStore<Preferences> {
+        private val _data = MutableStateFlow(emptyPreferences())
+        override val data: Flow<Preferences> = _data
+
+        override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences {
+            val newData = transform(_data.value)
+            _data.value = newData
+            return newData
+        }
+    }
+
+    @Test
+    fun sidebarMode_defaultsToExpanded() = runTest {
+        val dataStore = FakeDataStore()
+        val repository = PreferencesRepository(dataStore)
+
+        repository.sidebarMode.test {
+            assertEquals(SidebarMode.EXPANDED, awaitItem())
+        }
+    }
+
+    @Test
+    fun sidebarMode_returnsCorrectValue() = runTest {
+        val dataStore = FakeDataStore()
+        val repository = PreferencesRepository(dataStore)
+
+        repository.sidebarMode.test {
+            assertEquals(SidebarMode.EXPANDED, awaitItem())
+
+            repository.updateSidebarMode(SidebarMode.COLLAPSED)
+            assertEquals(SidebarMode.COLLAPSED, awaitItem())
+
+            repository.updateSidebarMode(SidebarMode.HOVER_EXPAND)
+            assertEquals(SidebarMode.HOVER_EXPAND, awaitItem())
+        }
+    }
+
+    @Test
+    fun sidebarMode_fallsBackToExpanded_onInvalidValue() = runTest {
+        val dataStore = FakeDataStore()
+        val repository = PreferencesRepository(dataStore)
+        val sidebarModeKey = stringPreferencesKey("sidebar_mode")
+
+        repository.sidebarMode.test {
+            assertEquals(SidebarMode.EXPANDED, awaitItem())
+
+            dataStore.edit { prefs ->
+                prefs[sidebarModeKey] = "INVALID_VALUE"
+            }
+            assertEquals(SidebarMode.EXPANDED, awaitItem())
+        }
+    }
+
+    @Test
+    fun desktopWindowStartupMode_defaultsToRestoreLast() = runTest {
+        val dataStore = FakeDataStore()
+        val repository = PreferencesRepository(dataStore)
+
+        repository.desktopWindowStartupMode.test {
+            assertEquals(DesktopWindowStartupMode.RESTORE_LAST, awaitItem())
+        }
+    }
+
+    @Test
+    fun desktopWindowStartupMode_returnsCorrectValue() = runTest {
+        val dataStore = FakeDataStore()
+        val repository = PreferencesRepository(dataStore)
+
+        repository.desktopWindowStartupMode.test {
+            assertEquals(DesktopWindowStartupMode.RESTORE_LAST, awaitItem())
+
+            repository.updateDesktopWindowStartupMode(DesktopWindowStartupMode.ALWAYS_MAXIMIZED)
+            assertEquals(DesktopWindowStartupMode.ALWAYS_MAXIMIZED, awaitItem())
+        }
+    }
+
+    @Test
+    fun desktopWindowStartupMode_fallsBackToRestoreLast_onInvalidValue() = runTest {
+        val dataStore = FakeDataStore()
+        val repository = PreferencesRepository(dataStore)
+        val key = stringPreferencesKey("desktop_window_startup_mode")
+
+        repository.desktopWindowStartupMode.test {
+            assertEquals(DesktopWindowStartupMode.RESTORE_LAST, awaitItem())
+
+            dataStore.edit { prefs ->
+                prefs[key] = "NOT_A_MODE"
+            }
+            assertEquals(DesktopWindowStartupMode.RESTORE_LAST, awaitItem())
+        }
+    }
+}


### PR DESCRIPTION
This change improves the reliability of the codebase by adding unit tests for the `PreferencesRepository`. Specifically, it addresses a testing gap where the fallback behavior for invalid preference values (like `sidebarMode` and `desktopWindowStartupMode`) was not being verified.

**🎯 What:** Added unit tests for `PreferencesRepository` using a `FakeDataStore`.
**📊 Coverage:** 
- `sidebarMode`: missing value, valid value, and invalid value (fallback) scenarios.
- `desktopWindowStartupMode`: missing value, valid value, and invalid value (fallback) scenarios.
**✨ Result:** Increased test coverage for persistence logic and ensured that the application gracefully handles corrupted or unexpected configuration data.

---
*PR created automatically by Jules for task [6253963362046572093](https://jules.google.com/task/6253963362046572093) started by @tajemniktv*