### PR TITLE
🔒 [security fix] Sanitize biometric authentication error logs

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -364,7 +364,7 @@ class MainActivity : FragmentActivity() {
                 init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
             }
         } catch (e: KeyPermanentlyInvalidatedException) {
-            Log.w(TAG, "Biometric key invalidated, regenerating key: ${e.javaClass.simpleName}")
+            Log.w(TAG, "Biometric key invalidated, regenerating key")
             try {
                 val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
                 keyStore.deleteEntry(BIOMETRIC_KEY_ALIAS)

--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -364,7 +364,7 @@ class MainActivity : FragmentActivity() {
                 init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
             }
         } catch (e: KeyPermanentlyInvalidatedException) {
-            Log.w(TAG, "Biometric key invalidated, regenerating key", e)
+            Log.w(TAG, "Biometric key invalidated, regenerating key: ${e.javaClass.simpleName}")
             try {
                 val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
                 keyStore.deleteEntry(BIOMETRIC_KEY_ALIAS)
@@ -372,11 +372,11 @@ class MainActivity : FragmentActivity() {
                     init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
                 }
             } catch (regenerationException: GeneralSecurityException) {
-                Log.e(TAG, "Failed to reinitialize cipher after key regeneration", regenerationException)
+                Log.e(TAG, "Failed to reinitialize cipher after key regeneration: ${regenerationException.javaClass.simpleName}")
                 null
             }
         } catch (e: GeneralSecurityException) {
-            Log.e(TAG, "Failed to initialize biometric cipher", e)
+            Log.e(TAG, "Failed to initialize biometric cipher: ${e.javaClass.simpleName}")
             null
         }
     }
@@ -409,7 +409,7 @@ class MainActivity : FragmentActivity() {
                         val authCipher = result.cryptoObject?.cipher ?: return
                         runCatching { authCipher.doFinal("auth".toByteArray()) }
                             .onSuccess { viewModel.setAuthenticated(true) }
-                            .onFailure { Log.e(TAG, "Biometric crypto operation failed", it) }
+                            .onFailure { Log.e(TAG, "Biometric crypto operation failed: ${it.javaClass.simpleName}") }
                     }
 
                     override fun onAuthenticationError(


### PR DESCRIPTION
This PR fixes a security vulnerability where sensitive biometric authentication errors and cryptographic exceptions were being logged to Android's Logcat with full stack traces. 

🎯 **What:** Sanitized biometric-related log messages in `MainActivity.kt`.
⚠️ **Risk:** Potential exposure of internal security implementation details and cryptographic state to unauthorized parties with log access.
🛡️ **Solution:** Replaced full `Throwable` logging with `${e.javaClass.simpleName}` to provide context for debugging without leaking sensitive information.

I also attempted to verify the fix with a build, but encountered environment limitations (missing JDK 25). The changes were verified via manual inspection and code review.

---
*PR created automatically by Jules for task [4893709370484919515](https://jules.google.com/task/4893709370484919515) started by @tajemniktv*