### PR TITLE
🧹 chore: remove unused imports and cleanup Platform.ios.kt

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeProtocolDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeProtocolDao.kt
@@ -2,7 +2,6 @@ package com.tajemniktv.tajsos.data
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.update
 
 class FakeProtocolDao : ProtocolDao {
     private val historyList = mutableListOf<ProtocolHistoryEntity>()

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/ProtocolCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/ProtocolCommandsTest.kt
@@ -24,7 +24,6 @@ import com.tajemniktv.tajsos.data.FakeTrackDao
 import com.tajemniktv.tajsos.data.FakeUserDao
 import com.tajemniktv.tajsos.data.NodeEntity
 import com.tajemniktv.tajsos.data.NodeWithPin
-import com.tajemniktv.tajsos.data.TagEntity
 import com.tajemniktv.tajsos.ui.main.state.PlaybookTemplate
 import com.tajemniktv.tajsos.ui.main.state.TransitionProtocolTemplate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -33,7 +32,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/shared/src/iosMain/kotlin/com/tajemniktv/tajsos/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/com/tajemniktv/tajsos/Platform.ios.kt
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) Grzegorz Kaczmarski (TajemnikTV) 2026. All rights reserved.
  */
 
@@ -6,7 +6,7 @@ package com.tajemniktv.tajsos
 
 import platform.UIKit.UIDevice
 
-class IOSPlatform: Platform {
+class IOSPlatform : Platform {
     override val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
 }
 


### PR DESCRIPTION
🎯 **What:** This PR improves code hygiene by removing unused imports and cleaning up file encoding and formatting in the `shared` module.

💡 **Why:** 
- Unused imports clutter the codebase and can lead to minor compiler overhead or confusion.
- The Byte Order Mark (BOM) in `Platform.ios.kt` was likely causing automated tools to misinterpret the file content (flagging the used `UIDevice` import as unused).
- Correcting formatting ensures consistency with Kotlin coding standards.

✅ **Verification:** 
- Manually verified that the removed imports (`kotlinx.coroutines.flow.update`, `com.tajemniktv.tajsos.data.TagEntity`, `kotlin.test.assertNotNull`) are not referenced in the code using `grep`.
- Confirmed `UIDevice` is still used in `Platform.ios.kt`, so its import was preserved to prevent a build break.
- Verified BOM removal using `cat -A`.

✨ **Result:** A cleaner, more standard-compliant codebase with fewer compiler warnings and better tool compatibility.

---
*PR created automatically by Jules for task [314749805378621016](https://jules.google.com/task/314749805378621016) started by @tajemniktv*