### PR TITLE
fix: prevent stack trace leakage when unparcelling extras

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -492,10 +492,10 @@ class MainActivity : FragmentActivity() {
                 getParcelableExtra(name) as? T
             }
         } catch (e: BadParcelableException) {
-            Log.e(TAG, "Failed to read parcelable extra: $name", e)
+            Log.e(TAG, "Failed to read parcelable extra: $name: ${e.javaClass.simpleName}")
             null
         } catch (e: ParcelFormatException) {
-            Log.e(TAG, "Failed to read parcelable extra (bad parcel format): $name", e)
+            Log.e(TAG, "Failed to read parcelable extra (bad parcel format): $name: ${e.javaClass.simpleName}")
             null
         }
 
@@ -511,10 +511,10 @@ class MainActivity : FragmentActivity() {
                 getParcelableArrayListExtra<T>(name)
             }
         } catch (e: BadParcelableException) {
-            Log.e(TAG, "Failed to read parcelable array list extra: $name", e)
+            Log.e(TAG, "Failed to read parcelable array list extra: $name: ${e.javaClass.simpleName}")
             null
         } catch (e: ParcelFormatException) {
-            Log.e(TAG, "Failed to read parcelable array list extra (bad parcel format): $name", e)
+            Log.e(TAG, "Failed to read parcelable array list extra (bad parcel format): $name: ${e.javaClass.simpleName}")
             null
         }
 }


### PR DESCRIPTION
Identified an Information Exposure vulnerability (CWE-532/CWE-209) where exceptions thrown during Android Intent unparcelling were logging their full stack trace to the system Logcat.

This change sanitizes the `Log.e` calls in `MainActivity.getSafeParcelableExtra` and `MainActivity.getSafeParcelableArrayListExtra` by replacing the `Throwable` parameter with `${e.javaClass.simpleName}`. 

This ensures that only the type of error is logged for debugging purposes without risking the exposure of internal application state or execution paths to malicious actors monitoring the device logs.

---
*PR created automatically by Jules for task [9943728676950738705](https://jules.google.com/task/9943728676950738705) started by @tajemniktv*