### PR TITLE
docs: Add KDoc for MainViewModel

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -128,9 +128,9 @@ import kotlin.time.Clock
 /**
  * Global orchestrator for the application shell.
  *
- * MainViewModel handles shell-level state (like modes, sync status, app locks, and sidebar state).
- * It delegates feature-heavy orchestration to other scoped components but acts as the root provider
- * of core app state.
+ * Handles shell-level state (including modes, sync status, application locking, and sidebar state).
+ * It delegates feature-heavy orchestration to internal command handlers (e.g., [NodeCommands])
+ * but acts as the root provider of core app state.
  */
 @Stable
 class MainViewModel(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -125,6 +125,13 @@ import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.json.Json
 import kotlin.time.Clock
 
+/**
+ * Global orchestrator for the application shell.
+ *
+ * MainViewModel handles shell-level state (like modes, sync status, app locks, and sidebar state).
+ * It delegates feature-heavy orchestration to other scoped components but acts as the root provider
+ * of core app state.
+ */
 @Stable
 class MainViewModel(
     private val repository: AppRepository,


### PR DESCRIPTION
This PR adds class-level KDoc documentation to `MainViewModel` in order to describe its intent, contracts, and role as the global orchestrator for the application shell.

---
*PR created automatically by Jules for task [8931803554162970838](https://jules.google.com/task/8931803554162970838) started by @tajemniktv*