### PR TITLE
fix(ui): use GhostBorder for focused text fields

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -342,7 +342,7 @@ fun GlobalSearchBar(modifier: Modifier = Modifier) {
                 unfocusedContainerColor = glassContainerColor(TajsOSTheme.SurfaceHigh.copy(alpha = 0.5f)),
                 focusedContainerColor = glassContainerColor(TajsOSTheme.SurfaceHighest.copy(alpha = 0.7f)),
                 unfocusedBorderColor = Color.Transparent,
-                focusedBorderColor = TajsOSTheme.Primary.copy(alpha = 0.5f),
+                focusedBorderColor = TajsOSTheme.GhostBorder,
             ),
         placeholder = {
             Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardCoreBlockRenderers.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardCoreBlockRenderers.kt
@@ -349,7 +349,7 @@ internal fun renderSearchBlock(context: DashboardBlockContext) {
         colors =
             OutlinedTextFieldDefaults.colors(
                 unfocusedBorderColor = TajsOSTheme.Border,
-                focusedBorderColor = TajsOSTheme.Primary,
+                focusedBorderColor = TajsOSTheme.GhostBorder,
                 unfocusedContainerColor = TajsOSTheme.Surface,
                 focusedContainerColor = TajsOSTheme.Surface,
             ),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/focus/FocusDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/focus/FocusDashboardBlocks.kt
@@ -314,7 +314,7 @@ internal fun FocusMainBlock(viewModel: MainViewModel) {
                     modifier = Modifier.fillMaxWidth(),
                     colors =
                         OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = TajsOSTheme.Primary,
+                            focusedBorderColor = TajsOSTheme.GhostBorder,
                             unfocusedBorderColor = TajsOSTheme.Border,
                         ),
                 )
@@ -386,7 +386,7 @@ internal fun FocusMainBlock(viewModel: MainViewModel) {
                     placeholder = { Text(stringResource(Res.string.focus_capture_hint)) },
                     colors =
                         OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = TajsOSTheme.Primary,
+                            focusedBorderColor = TajsOSTheme.GhostBorder,
                             unfocusedBorderColor = TajsOSTheme.Border,
                         ),
                 )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
@@ -492,7 +492,7 @@ private fun profileFieldColors() =
         unfocusedTextColor = TajsOSTheme.Text,
         focusedContainerColor = TajsOSTheme.SurfaceLowest.copy(alpha = 0.95f),
         unfocusedContainerColor = TajsOSTheme.SurfaceLowest.copy(alpha = 0.92f),
-        focusedBorderColor = TajsOSTheme.Primary.copy(alpha = 0.8f),
+        focusedBorderColor = TajsOSTheme.GhostBorder,
         unfocusedBorderColor = TajsOSTheme.GhostBorder.copy(alpha = 0.25f),
         cursorColor = TajsOSTheme.Primary,
         focusedLabelColor = TajsOSTheme.Primary,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -273,7 +273,7 @@ private fun renderSettingsData(context: SettingsDashboardContext) {
             colors =
                 OutlinedTextFieldDefaults.colors(
                     unfocusedBorderColor = TajsOSTheme.Border,
-                    focusedBorderColor = TajsOSTheme.Primary,
+                    focusedBorderColor = TajsOSTheme.GhostBorder,
                 ),
         )
 


### PR DESCRIPTION
Replaced high-contrast `TajsOSTheme.Primary` focused borders in `OutlinedTextFieldDefaults.colors` with `TajsOSTheme.GhostBorder` to comply with the 'No-Line' design rule and avoid visually jarring focus states.

---
*PR created automatically by Jules for task [4043233387197105719](https://jules.google.com/task/4043233387197105719) started by @tajemniktv*