### PR TITLE
docs: Fix outdated domain metadata reference in Lens queries

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -104,7 +104,8 @@ private val healthTitleKeywords =
  * This heuristic-based approach provides a zero-configuration experience, allowing items to be surfaced
  * appropriately even if the user forgets to manually assign the domain.
  *
- * Note: These queries intentionally bypass explicit domain associations (e.g., via `ItemDomainEntity`) in favor of terminology matching to lower the friction of capturing new data.
+ * Note: These queries intentionally bypass explicit domain associations (e.g., via ItemDomainEntity)
+ * in favor of terminology matching to lower the friction of capturing new data.
  *
  * This object implements a zero-configuration classification strategy. Instead of relying on
  * explicit database associations (like a many-to-many domain relation table), items are

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -104,8 +104,7 @@ private val healthTitleKeywords =
  * This heuristic-based approach provides a zero-configuration experience, allowing items to be surfaced
  * appropriately even if the user forgets to manually assign the domain.
  *
- * Note: These queries intentionally bypass explicit domain associations (e.g., via `associatedDomains`
- * in `AreaMetadata`) in favor of terminology matching to lower the friction of capturing new data.
+ * Note: These queries intentionally bypass explicit domain associations (e.g., via `ItemDomainEntity`) in favor of terminology matching to lower the friction of capturing new data.
  *
  * This object implements a zero-configuration classification strategy. Instead of relying on
  * explicit database associations (like a many-to-many domain relation table), items are


### PR DESCRIPTION
Updates KDoc in `DomainLensQueries.kt` to accurately reflect the current data model. It replaces the outdated reference to `associatedDomains` in `AreaMetadata` with the correct `ItemDomainEntity` database association. This aligns the documentation with the actual code behavior where explicit associations are bypassed in favor of implicit matching.

---
*PR created automatically by Jules for task [12961641443734410183](https://jules.google.com/task/12961641443734410183) started by @tajemniktv*