### PR TITLE
test: improve edge case coverage for domain lens heuristic queries

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
@@ -112,4 +112,60 @@ class DomainLensQueriesMatchesSignalTest {
         val expectedIds = listOf(1L, 2L)
         assertEquals(expectedIds, result.map { it.node.id }.sorted())
     }
+
+    @Test
+    fun financeActionItems_content_case_insensitivity() {
+        val nodeContent = createNode(1, "some task", "PAY TAX")
+        val result = DomainLensQueries.financeActionItems(listOf(nodeContent))
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun financeKnowledgeItems_includes_reference_note_if_tag_matches() {
+        val nodeReference = createNode(1, "some unrelated title", type = "note", noteType = "reference", tags = listOf("finance"))
+        val result = DomainLensQueries.financeKnowledgeItems(listOf(nodeReference))
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun financeKnowledgeItems_excludes_reference_note_without_signals() {
+        val nodeReference = createNode(1, "some unrelated title", type = "note", noteType = "reference")
+        val result = DomainLensQueries.financeKnowledgeItems(listOf(nodeReference))
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun healthKnowledgeItems_implicit_journal_without_keywords() {
+        val nodeJournal = createNode(1, "random thought", type = "note", noteType = "journal")
+        val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeJournal))
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun healthKnowledgeItems_excludes_general_note_without_signals() {
+        val nodeNote = createNode(1, "random thought", type = "note")
+        val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeNote))
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun financeActionItems_edge_empty_strings() {
+        val nodeEmpty = createNode(1, "")
+        val result = DomainLensQueries.financeActionItems(listOf(nodeEmpty))
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun healthActionItems_edge_empty_strings() {
+        val nodeEmpty = createNode(1, "")
+        val result = DomainLensQueries.healthActionItems(listOf(nodeEmpty))
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun healthKnowledgeItems_implicit_reflection_without_keywords() {
+        val nodeReflection = createNode(1, "random thought", type = "note", noteType = "reflection")
+        val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeReflection))
+        assertEquals(1, result.size)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
@@ -114,13 +114,6 @@ class DomainLensQueriesMatchesSignalTest {
     }
 
     @Test
-    fun financeActionItems_content_case_insensitivity() {
-        val nodeContent = createNode(1, "some task", "PAY TAX")
-        val result = DomainLensQueries.financeActionItems(listOf(nodeContent))
-        assertEquals(1, result.size)
-    }
-
-    @Test
     fun financeKnowledgeItems_includes_reference_note_if_tag_matches() {
         val nodeReference = createNode(1, "some unrelated title", type = "note", noteType = "reference", tags = listOf("finance"))
         val result = DomainLensQueries.financeKnowledgeItems(listOf(nodeReference))
@@ -135,37 +128,24 @@ class DomainLensQueriesMatchesSignalTest {
     }
 
     @Test
-    fun healthKnowledgeItems_implicit_journal_without_keywords() {
-        val nodeJournal = createNode(1, "random thought", type = "note", noteType = "journal")
-        val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeJournal))
-        assertEquals(1, result.size)
-    }
-
-    @Test
     fun healthKnowledgeItems_excludes_general_note_without_signals() {
         val nodeNote = createNode(1, "random thought", type = "note")
         val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeNote))
         assertEquals(0, result.size)
     }
-
     @Test
-    fun financeActionItems_edge_empty_strings() {
+    fun actionItems_edge_empty_strings() {
         val nodeEmpty = createNode(1, "")
-        val result = DomainLensQueries.financeActionItems(listOf(nodeEmpty))
-        assertEquals(0, result.size)
+        val financeResult = DomainLensQueries.financeActionItems(listOf(nodeEmpty))
+        val healthResult = DomainLensQueries.healthActionItems(listOf(nodeEmpty))
+        assertEquals(0, financeResult.size)
+        assertEquals(0, healthResult.size)
     }
-
     @Test
-    fun healthActionItems_edge_empty_strings() {
-        val nodeEmpty = createNode(1, "")
-        val result = DomainLensQueries.healthActionItems(listOf(nodeEmpty))
-        assertEquals(0, result.size)
-    }
-
-    @Test
-    fun healthKnowledgeItems_implicit_reflection_without_keywords() {
-        val nodeReflection = createNode(1, "random thought", type = "note", noteType = "reflection")
-        val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeReflection))
-        assertEquals(1, result.size)
+    fun healthKnowledgeItems_implicit_note_types_without_keywords() {
+        val nodeJournal = createNode(1, "random thought", type = "note", noteType = "journal")
+        val nodeReflection = createNode(2, "another thought", type = "note", noteType = "reflection")
+        val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeJournal, nodeReflection))
+        assertEquals(2, result.size)
     }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
@@ -39,28 +39,24 @@ class DomainLensQueriesMatchesSignalTest {
         assertEquals(expectedIds.sorted(), result.map { it.node.id }.sorted())
     }
     @Test
-    fun financeActionItems_includes_all_signals() {
+    fun financeActionItems_signals_and_case_insensitivity() {
+        // Signals
         val nodeTitle = createNode(1, "my budget is tight")
         val nodeContent = createNode(2, "some task", "need to pay tax")
         val nodeTag = createNode(3, "some task", tags = listOf("money"))
         val nodeMaintenance = createNode(4, "some task", maintenanceType = "bill")
-        // this is note, so it shouldn't be included in action items
         val nodeReference = createNode(5, "some budget", type = "note", noteType = "reference")
         val nodeNone = createNode(6, "unrelated")
 
-        val result = DomainLensQueries.financeActionItems(listOf(nodeTitle, nodeContent, nodeTag, nodeMaintenance, nodeReference, nodeNone))
-        assertDomainQueryResult(listOf(1L, 2L, 3L, 4L), result)
+        // Case insensitivity
+        val nodeTitleCase = createNode(7, "MY BUDGET")
+        val nodeContentCase = createNode(8, "some task", "PAY TAX")
+        val nodeTagCase = createNode(9, "some task", tags = listOf("MONEY"))
+
+        val result = DomainLensQueries.financeActionItems(listOf(nodeTitle, nodeContent, nodeTag, nodeMaintenance, nodeReference, nodeNone, nodeTitleCase, nodeContentCase, nodeTagCase))
+        assertDomainQueryResult(listOf(1L, 2L, 3L, 4L, 7L, 8L, 9L), result)
     }
 
-    @Test
-    fun financeActionItems_case_insensitivity() {
-        val nodeTitle = createNode(1, "MY BUDGET")
-        val nodeContent = createNode(2, "some task", "PAY TAX")
-        val nodeTag = createNode(3, "some task", tags = listOf("MONEY"))
-
-        val result = DomainLensQueries.financeActionItems(listOf(nodeTitle, nodeContent, nodeTag))
-        assertDomainQueryResult(listOf(1L, 2L, 3L), result)
-    }
 
     @Test
     fun financeKnowledgeItems_includes_reference_notes() {
@@ -71,30 +67,25 @@ class DomainLensQueriesMatchesSignalTest {
         val result = DomainLensQueries.financeKnowledgeItems(listOf(nodeReferenceMatch, nodeReferenceTagMatch, nodeReferenceNoMatch))
         assertDomainQueryResult(listOf(1L, 2L), result)
     }
-
     @Test
-    fun healthActionItems_includes_all_signals() {
+    fun healthActionItems_signals_and_case_insensitivity() {
+        // Signals
         val nodeTitle = createNode(1, "see doctor")
         val nodeContent = createNode(2, "some task", "pick up medication")
         val nodeTag = createNode(3, "some task", tags = listOf("medical"))
         val nodeMaintenance = createNode(4, "some task", maintenanceType = "appointment")
-        // this is note, so it shouldn't be included in action items
         val nodeReflection = createNode(5, "feeling better", type = "note", noteType = "reflection")
         val nodeNone = createNode(6, "unrelated")
 
-        val result = DomainLensQueries.healthActionItems(listOf(nodeTitle, nodeContent, nodeTag, nodeMaintenance, nodeReflection, nodeNone))
-        assertDomainQueryResult(listOf(1L, 2L, 3L, 4L), result)
+        // Case insensitivity
+        val nodeTitleCase = createNode(7, "SEE DOCTOR")
+        val nodeContentCase = createNode(8, "some task", "PICK UP MEDICATION")
+        val nodeTagCase = createNode(9, "some task", tags = listOf("MEDICAL"))
+
+        val result = DomainLensQueries.healthActionItems(listOf(nodeTitle, nodeContent, nodeTag, nodeMaintenance, nodeReflection, nodeNone, nodeTitleCase, nodeContentCase, nodeTagCase))
+        assertDomainQueryResult(listOf(1L, 2L, 3L, 4L, 7L, 8L, 9L), result)
     }
 
-    @Test
-    fun healthActionItems_case_insensitivity() {
-        val nodeTitle = createNode(1, "SEE DOCTOR")
-        val nodeContent = createNode(2, "some task", "PICK UP MEDICATION")
-        val nodeTag = createNode(3, "some task", tags = listOf("MEDICAL"))
-
-        val result = DomainLensQueries.healthActionItems(listOf(nodeTitle, nodeContent, nodeTag))
-        assertDomainQueryResult(listOf(1L, 2L, 3L), result)
-    }
 
     @Test
     fun healthKnowledgeItems_includes_health_notes() {
@@ -112,20 +103,18 @@ class DomainLensQueriesMatchesSignalTest {
         val result = DomainLensQueries.financeKnowledgeItems(listOf(nodeReference))
         assertEquals(1, result.size)
     }
-
     @Test
-    fun financeKnowledgeItems_excludes_reference_note_without_signals() {
+    fun knowledgeItems_excludes_notes_without_signals() {
         val nodeReference = createNode(1, "some unrelated title", type = "note", noteType = "reference")
-        val result = DomainLensQueries.financeKnowledgeItems(listOf(nodeReference))
-        assertEquals(0, result.size)
+        val nodeNote = createNode(2, "random thought", type = "note")
+
+        val financeResult = DomainLensQueries.financeKnowledgeItems(listOf(nodeReference))
+        val healthResult = DomainLensQueries.healthKnowledgeItems(listOf(nodeNote))
+
+        assertEquals(0, financeResult.size)
+        assertEquals(0, healthResult.size)
     }
 
-    @Test
-    fun healthKnowledgeItems_excludes_general_note_without_signals() {
-        val nodeNote = createNode(1, "random thought", type = "note")
-        val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeNote))
-        assertEquals(0, result.size)
-    }
     @Test
     fun actionItems_edge_empty_strings() {
         val nodeEmpty = createNode(1, "")

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
@@ -96,38 +96,34 @@ class DomainLensQueriesMatchesSignalTest {
         val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeReflection, nodeJournal, nodeOtherNote))
         assertDomainQueryResult(listOf(1L, 2L), result)
     }
+    @Test
+    fun knowledgeItems_implicit_and_tag_matches() {
+        val nodeFinanceRef = createNode(1, "some unrelated title", type = "note", noteType = "reference", tags = listOf("finance"))
+        val nodeJournal = createNode(2, "random thought", type = "note", noteType = "journal")
+        val nodeReflection = createNode(3, "another thought", type = "note", noteType = "reflection")
+
+        val financeResult = DomainLensQueries.financeKnowledgeItems(listOf(nodeFinanceRef))
+        val healthResult = DomainLensQueries.healthKnowledgeItems(listOf(nodeJournal, nodeReflection))
+
+        assertEquals(1, financeResult.size)
+        assertEquals(2, healthResult.size)
+    }
 
     @Test
-    fun financeKnowledgeItems_includes_reference_note_if_tag_matches() {
-        val nodeReference = createNode(1, "some unrelated title", type = "note", noteType = "reference", tags = listOf("finance"))
-        val result = DomainLensQueries.financeKnowledgeItems(listOf(nodeReference))
-        assertEquals(1, result.size)
-    }
-    @Test
-    fun knowledgeItems_excludes_notes_without_signals() {
+    fun edge_cases_and_exclusions() {
         val nodeReference = createNode(1, "some unrelated title", type = "note", noteType = "reference")
         val nodeNote = createNode(2, "random thought", type = "note")
+        val nodeEmpty = createNode(3, "")
 
-        val financeResult = DomainLensQueries.financeKnowledgeItems(listOf(nodeReference))
-        val healthResult = DomainLensQueries.healthKnowledgeItems(listOf(nodeNote))
+        val financeKnowledge = DomainLensQueries.financeKnowledgeItems(listOf(nodeReference))
+        val healthKnowledge = DomainLensQueries.healthKnowledgeItems(listOf(nodeNote))
+        val financeAction = DomainLensQueries.financeActionItems(listOf(nodeEmpty))
+        val healthAction = DomainLensQueries.healthActionItems(listOf(nodeEmpty))
 
-        assertEquals(0, financeResult.size)
-        assertEquals(0, healthResult.size)
+        assertEquals(0, financeKnowledge.size)
+        assertEquals(0, healthKnowledge.size)
+        assertEquals(0, financeAction.size)
+        assertEquals(0, healthAction.size)
     }
 
-    @Test
-    fun actionItems_edge_empty_strings() {
-        val nodeEmpty = createNode(1, "")
-        val financeResult = DomainLensQueries.financeActionItems(listOf(nodeEmpty))
-        val healthResult = DomainLensQueries.healthActionItems(listOf(nodeEmpty))
-        assertEquals(0, financeResult.size)
-        assertEquals(0, healthResult.size)
-    }
-    @Test
-    fun healthKnowledgeItems_implicit_note_types_without_keywords() {
-        val nodeJournal = createNode(1, "random thought", type = "note", noteType = "journal")
-        val nodeReflection = createNode(2, "another thought", type = "note", noteType = "reflection")
-        val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeJournal, nodeReflection))
-        assertEquals(2, result.size)
-    }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
@@ -33,6 +33,11 @@ class DomainLensQueriesMatchesSignalTest {
         )
     }
 
+
+    private fun assertDomainQueryResult(expectedIds: List<Long>, result: List<NodeWithPin>) {
+        assertEquals(expectedIds.size, result.size)
+        assertEquals(expectedIds.sorted(), result.map { it.node.id }.sorted())
+    }
     @Test
     fun financeActionItems_includes_all_signals() {
         val nodeTitle = createNode(1, "my budget is tight")
@@ -44,9 +49,7 @@ class DomainLensQueriesMatchesSignalTest {
         val nodeNone = createNode(6, "unrelated")
 
         val result = DomainLensQueries.financeActionItems(listOf(nodeTitle, nodeContent, nodeTag, nodeMaintenance, nodeReference, nodeNone))
-        assertEquals(4, result.size)
-        val expectedIds = listOf(1L, 2L, 3L, 4L)
-        assertEquals(expectedIds, result.map { it.node.id }.sorted())
+        assertDomainQueryResult(listOf(1L, 2L, 3L, 4L), result)
     }
 
     @Test
@@ -56,9 +59,7 @@ class DomainLensQueriesMatchesSignalTest {
         val nodeTag = createNode(3, "some task", tags = listOf("MONEY"))
 
         val result = DomainLensQueries.financeActionItems(listOf(nodeTitle, nodeContent, nodeTag))
-        assertEquals(3, result.size)
-        val expectedIds = listOf(1L, 2L, 3L)
-        assertEquals(expectedIds, result.map { it.node.id }.sorted())
+        assertDomainQueryResult(listOf(1L, 2L, 3L), result)
     }
 
     @Test
@@ -68,9 +69,7 @@ class DomainLensQueriesMatchesSignalTest {
         val nodeReferenceNoMatch = createNode(3, "some doc", type = "note", noteType = "reference")
 
         val result = DomainLensQueries.financeKnowledgeItems(listOf(nodeReferenceMatch, nodeReferenceTagMatch, nodeReferenceNoMatch))
-        assertEquals(2, result.size)
-        val expectedIds = listOf(1L, 2L)
-        assertEquals(expectedIds, result.map { it.node.id }.sorted())
+        assertDomainQueryResult(listOf(1L, 2L), result)
     }
 
     @Test
@@ -84,9 +83,7 @@ class DomainLensQueriesMatchesSignalTest {
         val nodeNone = createNode(6, "unrelated")
 
         val result = DomainLensQueries.healthActionItems(listOf(nodeTitle, nodeContent, nodeTag, nodeMaintenance, nodeReflection, nodeNone))
-        assertEquals(4, result.size)
-        val expectedIds = listOf(1L, 2L, 3L, 4L)
-        assertEquals(expectedIds, result.map { it.node.id }.sorted())
+        assertDomainQueryResult(listOf(1L, 2L, 3L, 4L), result)
     }
 
     @Test
@@ -96,9 +93,7 @@ class DomainLensQueriesMatchesSignalTest {
         val nodeTag = createNode(3, "some task", tags = listOf("MEDICAL"))
 
         val result = DomainLensQueries.healthActionItems(listOf(nodeTitle, nodeContent, nodeTag))
-        assertEquals(3, result.size)
-        val expectedIds = listOf(1L, 2L, 3L)
-        assertEquals(expectedIds, result.map { it.node.id }.sorted())
+        assertDomainQueryResult(listOf(1L, 2L, 3L), result)
     }
 
     @Test
@@ -108,9 +103,7 @@ class DomainLensQueriesMatchesSignalTest {
         val nodeOtherNote = createNode(3, "some text", type = "note")
 
         val result = DomainLensQueries.healthKnowledgeItems(listOf(nodeReflection, nodeJournal, nodeOtherNote))
-        assertEquals(2, result.size)
-        val expectedIds = listOf(1L, 2L)
-        assertEquals(expectedIds, result.map { it.node.id }.sorted())
+        assertDomainQueryResult(listOf(1L, 2L), result)
     }
 
     @Test


### PR DESCRIPTION
Added test cases for implicit reflection notes matching, empty strings handling, content matching case-insensitivities, and ensuring reference notes without keywords are excluded correctly in `DomainLensQueriesMatchesSignalTest.kt`.

---
*PR created automatically by Jules for task [9508373552804137649](https://jules.google.com/task/9508373552804137649) started by @tajemniktv*