### PR TITLE
feat(ui): implement tactile outlined text fields matching No-Line design system

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
@@ -4,6 +4,14 @@
 
 package com.tajemniktv.tajsos.ui.components
 
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -271,5 +279,82 @@ private fun TactileSliderPreview() {
                 )
             }
         }
+    }
+}
+
+
+@Composable
+fun TactileOutlinedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    containerModifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: androidx.compose.ui.text.input.VisualTransformation = androidx.compose.ui.text.input.VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    shape: Shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+    colors: TextFieldColors = OutlinedTextFieldDefaults.colors(
+        focusedContainerColor = TajsOSTheme.SurfaceLowest,
+        unfocusedContainerColor = TajsOSTheme.SurfaceLowest,
+        disabledContainerColor = TajsOSTheme.SurfaceLowest,
+        focusedBorderColor = TajsOSTheme.GhostBorder,
+        unfocusedBorderColor = Color.Transparent,
+        disabledBorderColor = Color.Transparent,
+    )
+) {
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    Box(modifier = containerModifier, propagateMinConstraints = true) {
+        if (isFocused) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .blur(8.dp)
+                    .background(
+                        TajsOSTheme.Primary.copy(alpha = 0.2f),
+                        shape
+                    )
+            )
+        }
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier,
+            enabled = enabled,
+            readOnly = readOnly,
+            textStyle = textStyle,
+            label = label,
+            placeholder = placeholder,
+            leadingIcon = leadingIcon,
+            trailingIcon = trailingIcon,
+            prefix = prefix,
+            suffix = suffix,
+            supportingText = supportingText,
+            isError = isError,
+            visualTransformation = visualTransformation,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            minLines = minLines,
+            interactionSource = interactionSource,
+            shape = shape,
+            colors = colors,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.components.cards
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -618,14 +619,14 @@ fun PersonRelationshipCard(
                     label = { Text("OPEN RELATIONSHIP") },
                 )
             }
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = socialNotes,
                 onValueChange = { socialNotes = it },
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text("Social energy notes") },
                 minLines = 2,
             )
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = relationshipContext,
                 onValueChange = { relationshipContext = it },
                 modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.components.cards
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -232,22 +233,22 @@ fun TemplateQuickActionsCard(
                 )
             }
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                OutlinedTextField(
-                    modifier = Modifier.weight(1f),
+                TactileOutlinedTextField(
+                    containerModifier = Modifier.weight(1f),
                     value = courseId,
                     onValueChange = onCourseIdChange,
                     label = { Text(stringResource(Res.string.student_course_id)) },
                     singleLine = true,
                 )
-                OutlinedTextField(
-                    modifier = Modifier.weight(1f),
+                TactileOutlinedTextField(
+                    containerModifier = Modifier.weight(1f),
                     value = semester,
                     onValueChange = onSemesterChange,
                     label = { Text(stringResource(Res.string.student_semester)) },
                     singleLine = true,
                 )
             }
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 modifier = Modifier.fillMaxWidth(),
                 value = courseName,
                 onValueChange = onCourseNameChange,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.components.layout
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -326,7 +327,7 @@ private fun HeaderBreadcrumbs(breadcrumbs: List<ScreenHeaderBreadcrumb>) {
  */
 @Composable
 fun GlobalSearchBar(modifier: Modifier = Modifier) {
-    OutlinedTextField(
+    TactileOutlinedTextField(
         value = "",
         onValueChange = {},
         readOnly = true,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.components.nodes
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -374,7 +375,7 @@ fun DecisionDetailContent(
             onDismissRequest = { showAddOptionDialog = false },
             title = { Text(stringResource(Res.string.decision_add_option_title)) },
             text = {
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = optionTitle,
                     onValueChange = { optionTitle = it },
                     label = { Text(stringResource(Res.string.decision_add_option_field)) },
@@ -431,7 +432,7 @@ fun DecisionDetailContent(
                             Text(option.title)
                         }
                     }
-                    OutlinedTextField(
+                    TactileOutlinedTextField(
                         value = outcome,
                         onValueChange = { outcome = it },
                         label = { Text(stringResource(Res.string.decision_outcome_reason)) },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardCoreBlockRenderers.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardCoreBlockRenderers.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.dashboard
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -325,7 +326,7 @@ internal fun renderTimeArchitectureBlock(context: DashboardBlockContext) {
 
 @Composable
 internal fun renderSearchBlock(context: DashboardBlockContext) {
-    OutlinedTextField(
+    TactileOutlinedTextField(
         value = "",
         onValueChange = {
             context.viewModel.updateSearchQuery(it)

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.dashboard
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -337,7 +338,7 @@ private fun RenderDashboardBlock(
         }
 
         "search_capture" -> {
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = "",
                 onValueChange = {},
                 modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/focus/FocusDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/focus/FocusDashboardBlocks.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.focus
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -308,7 +309,7 @@ internal fun FocusMainBlock(viewModel: MainViewModel) {
                     color = TajsOSTheme.Text,
                     fontWeight = FontWeight.SemiBold,
                 )
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = step,
                     onValueChange = { step = it },
                     modifier = Modifier.fillMaxWidth(),
@@ -379,7 +380,7 @@ internal fun FocusMainBlock(viewModel: MainViewModel) {
                     color = TajsOSTheme.Text,
                     fontWeight = FontWeight.SemiBold,
                 )
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = capture,
                     onValueChange = { capture = it },
                     modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesDashboardBlocks.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.notes
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -96,7 +97,7 @@ internal fun NotesMainBlock(
         )
         Spacer(modifier = Modifier.height(16.dp))
 
-        OutlinedTextField(
+        TactileOutlinedTextField(
             value = searchQuery,
             onValueChange = { searchQuery = it },
             modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.notes
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -113,10 +114,11 @@ fun NotesEditorPane(
                         color = TajsOSTheme.Muted,
                     )
                     Spacer(Modifier.height(8.dp))
-                    OutlinedTextField(
+                    TactileOutlinedTextField(
                         value = note.title,
                         onValueChange = onTitleChange,
-                        modifier = Modifier.fillMaxWidth().focusRequester(titleFocusRequester),
+                        modifier = Modifier.focusRequester(titleFocusRequester),
+                        containerModifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         textStyle = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.SemiBold),
                         placeholder = { Text("Untitled note") },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.notes
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -90,7 +91,7 @@ fun NotesListRail(
                 Spacer(Modifier.width(8.dp))
                 Text("New note")
             }
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = searchQuery,
                 onValueChange = onSearchChange,
                 modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.notes
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -213,7 +214,7 @@ fun NotesWorkspaceDetail(
                         fontWeight = FontWeight.Bold,
                     )
                 }
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = query,
                     onValueChange = { query = it },
                     modifier = Modifier.fillMaxWidth(),
@@ -322,17 +323,18 @@ fun NotesWorkspaceDetail(
                 }
 
                 if (isEditMode) {
-                    OutlinedTextField(
+                    TactileOutlinedTextField(
                         value = titleDraft,
                         onValueChange = { titleDraft = it },
                         modifier = Modifier.fillMaxWidth(),
                         label = { Text(stringResource(Res.string.detail_title)) },
                         singleLine = true,
                     )
-                    OutlinedTextField(
+                    TactileOutlinedTextField(
                         value = contentDraft,
                         onValueChange = { contentDraft = it },
-                        modifier = Modifier.fillMaxWidth().weight(1f),
+                        modifier = Modifier.fillMaxWidth(),
+                        containerModifier = Modifier.weight(1f),
                         label = { Text(stringResource(Res.string.detail_content)) },
                     )
                 } else {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/places/PlacesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/places/PlacesScreen.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.places
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -164,7 +165,7 @@ internal fun PlacesLayer(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = newPlaceTitle,
                 onValueChange = { newPlaceTitle = it },
                 modifier = Modifier.fillMaxWidth(),
@@ -212,13 +213,13 @@ internal fun PlacesLayer(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = logisticsTitle,
                 onValueChange = { logisticsTitle = it },
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text(stringResource(Res.string.places_placeholder_list_title)) },
             )
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = logisticsContent,
                 onValueChange = { logisticsContent = it },
                 modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.profile
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -320,7 +321,7 @@ private fun renderAboutModuleBlock(context: ProfileScreenContext) {
             onValueChange = { context.onEditorChange(context.editor.copy(preferredGreeting = it)) },
             label = stringResource(Res.string.profile_greeting),
         )
-        OutlinedTextField(
+        TactileOutlinedTextField(
             value = context.editor.bio,
             onValueChange = { context.onEditorChange(context.editor.copy(bio = it)) },
             label = { Text(stringResource(Res.string.profile_bio)) },
@@ -469,7 +470,7 @@ private fun ProfileField(
     isError: Boolean = false,
     supportingText: String? = null,
 ) {
-    OutlinedTextField(
+    TactileOutlinedTextField(
         value = value,
         onValueChange = onValueChange,
         label = { Text(label) },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileRoute.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.profile
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
@@ -208,25 +209,25 @@ private fun AddMedicationDialog(
                         TajsOSTheme.SpacingSm,
                     ),
             ) {
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = substance,
                     onValueChange = { substance = it },
                     label = { Text(stringResource(Res.string.med_substance)) },
                     shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 )
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = brands,
                     onValueChange = { brands = it },
                     label = { Text(stringResource(Res.string.med_brand_names)) },
                     shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 )
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = dosage,
                     onValueChange = { dosage = it },
                     label = { Text(stringResource(Res.string.med_dosage)) },
                     shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 )
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = hour,
                     onValueChange = { hour = it },
                     label = { Text(stringResource(Res.string.med_take_at)) },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/ProjectsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/ProjectsDashboardBlocks.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.projects
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -97,7 +98,7 @@ internal fun ProjectsMainBlock(
         )
         Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
 
-        OutlinedTextField(
+        TactileOutlinedTextField(
             value = searchQuery,
             onValueChange = { searchQuery = it },
             modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/protocols/ProtocolsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/protocols/ProtocolsScreen.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.protocols
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -450,7 +451,7 @@ private fun ProtocolLibrarySurface(
         }
 
     Column(verticalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingMd)) {
-        OutlinedTextField(
+        TactileOutlinedTextField(
             value = searchQuery,
             onValueChange = onSearchQueryChange,
             modifier = Modifier.fillMaxWidth(),
@@ -915,7 +916,7 @@ private fun ProtocolRunSidebar(
                 color = TajsOSTheme.Text,
                 fontWeight = FontWeight.SemiBold,
             )
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = sessionNotes,
                 onValueChange = onSessionNotesChange,
                 modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/rules/RulesDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/rules/RulesDashboardBlocks.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.rules
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -115,13 +116,13 @@ private fun renderRulesInput(context: RulesDashboardContext) {
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = context.ruleTitle,
                 onValueChange = context.onRuleTitleChange,
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text("Rule title") },
             )
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = context.ruleContent,
                 onValueChange = context.onRuleContentChange,
                 modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.settings
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -263,7 +264,7 @@ private fun renderSettingsData(context: SettingsDashboardContext) {
 
         Spacer(Modifier.height(TajsOSTheme.SpacingMd))
 
-        OutlinedTextField(
+        TactileOutlinedTextField(
             value = context.importPayload,
             onValueChange = context.onImportPayloadChange,
             modifier = Modifier.fillMaxWidth().height(180.dp),
@@ -744,25 +745,25 @@ private fun SettingsAddMedicationDialog(
             Column(
                 verticalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
             ) {
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = substance,
                     onValueChange = { substance = it },
                     label = { Text(stringResource(Res.string.med_substance)) },
                     shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 )
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = brands,
                     onValueChange = { brands = it },
                     label = { Text(stringResource(Res.string.med_brand_names)) },
                     shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 )
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = dosage,
                     onValueChange = { dosage = it },
                     label = { Text(stringResource(Res.string.med_dosage)) },
                     shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 )
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = hour,
                     onValueChange = { hour = it },
                     label = { Text(stringResource(Res.string.med_take_at)) },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.tasks
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -157,10 +158,10 @@ internal fun TasksAllView(
             horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = query,
                 onValueChange = { query = it },
-                modifier = Modifier.weight(1f),
+                containerModifier = Modifier.weight(1f),
                 placeholder = { Text(stringResource(Res.string.tasks_search_placeholder)) },
                 leadingIcon = { Icon(Icons.Default.Search, null) },
                 singleLine = true,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.tasks
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -407,7 +408,7 @@ private fun CommandSidebar(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
             )
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = quickAdd,
                 onValueChange = onQuickAddChanged,
                 modifier = Modifier.fillMaxWidth(),
@@ -426,7 +427,7 @@ private fun CommandSidebar(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
             )
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = capture,
                 onValueChange = onCaptureChanged,
                 modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.tasks.detail
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -486,10 +487,10 @@ private fun renderTaskSubtasks(context: TaskDetailContext) {
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                OutlinedTextField(
+                TactileOutlinedTextField(
                     value = newChecklistItem,
                     onValueChange = { newChecklistItem = it },
-                    modifier = Modifier.weight(1f),
+                    containerModifier = Modifier.weight(1f),
                     singleLine = true,
                     label = { Text(stringResource(Res.string.detail_tag_new_placeholder)) },
                 )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/vaults/VaultsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/vaults/VaultsScreen.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.vaults
 
+import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -297,7 +298,7 @@ internal fun VaultsLayer(
                             ).padding(22.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
-                    OutlinedTextField(
+                    TactileOutlinedTextField(
                         value = searchQuery,
                         onValueChange = { searchQuery = it },
                         modifier = Modifier.fillMaxWidth(),
@@ -721,14 +722,14 @@ private fun VaultEntryComposer(
                 style = MaterialTheme.typography.titleSmall,
                 color = TajsOSTheme.VaultTextStrong,
             )
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = entryTitle,
                 onValueChange = onEntryTitleChange,
                 modifier = Modifier.fillMaxWidth(),
                 label = { Text(stringResource(Res.string.lens_reference_entry_title)) },
                 singleLine = true,
             )
-            OutlinedTextField(
+            TactileOutlinedTextField(
                 value = entryContent,
                 onValueChange = onEntryContentChange,
                 modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## Summary
This PR implements UX/UI polish for the application's text fields to comply with the project's DESIGN.md specifications.

It adds a new reusable component, `TactileOutlinedTextField`, replacing the default `OutlinedTextField` across all relevant screens. 

### Changes
- Created `TactileOutlinedTextField` in `TactileComponents.kt` with a custom `blur` effect and recessed background.
- Split component modifiers (`modifier` vs `containerModifier`) to allow proper Jetpack Compose layout scaling (e.g. `.weight(1f)`) without sacrificing focus requests.
- Ran a systematic replacement across 22 UI files to unify input elements.

### Verification
- Tested compilation (`:composeApp:compileKotlinJvm`) and verified no regressions via tests (`:shared:jvmTest`).

---
*PR created automatically by Jules for task [6025341761829296596](https://jules.google.com/task/6025341761829296596) started by @tajemniktv*