### PR TITLE
perf: optimize node batch inserts during imports

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -1675,7 +1675,7 @@ class AppRepository(
      * @return An [ImportReport] summarizing the counts of entities inserted.
      */
     suspend fun importBundle(bundle: ExportBundle): ImportReport {
-        nodeDao.insertNodes(bundle.nodes)
+insertNodes(bundle.nodes)
         relationDao.insertRelations(bundle.relations)
         tagDao.insertTags(bundle.tags)
         templateDao.insertTemplates(bundle.templates)
@@ -1707,7 +1707,7 @@ class AppRepository(
      * @return The number of nodes imported.
      */
     suspend fun importLegacyNodes(nodes: List<NodeEntity>): Int {
-        nodeDao.insertNodes(nodes)
+insertNodes(nodes)
         return nodes.size
     }
 }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -1665,8 +1665,17 @@ class AppRepository(
             recentEvents = getRecentLogs(limit = recentEventLimit).first(),
         )
 
+    /**
+     * Imports a comprehensive [ExportBundle] into the database.
+     *
+     * Performance optimization: Utilizes batch operations (e.g., [NodeDao.insertNodes])
+     * for all entity lists to minimize database transactions and significantly improve import speed.
+     *
+     * @param bundle The full bundle containing nodes, relations, tags, etc.
+     * @return An [ImportReport] summarizing the counts of entities inserted.
+     */
     suspend fun importBundle(bundle: ExportBundle): ImportReport {
-        bundle.nodes.forEach { nodeDao.insertNode(it) }
+        nodeDao.insertNodes(bundle.nodes)
         relationDao.insertRelations(bundle.relations)
         tagDao.insertTags(bundle.tags)
         templateDao.insertTemplates(bundle.templates)
@@ -1688,8 +1697,17 @@ class AppRepository(
         )
     }
 
+    /**
+     * Imports a list of legacy nodes into the database.
+     *
+     * Performance optimization: Uses a batch insert via [NodeDao.insertNodes] rather than
+     * iterating over individual insertions to prevent transaction overhead.
+     *
+     * @param nodes The legacy nodes to import.
+     * @return The number of nodes imported.
+     */
     suspend fun importLegacyNodes(nodes: List<NodeEntity>): Int {
-        nodes.forEach { nodeDao.insertNode(it) }
+        nodeDao.insertNodes(nodes)
         return nodes.size
     }
 }


### PR DESCRIPTION
Replaced sequential `.forEach { nodeDao.insertNode(it) }` calls with batch `nodeDao.insertNodes(nodes)` in `Repository.importBundle` and `Repository.importLegacyNodes`. This reduces the number of database transactions during import, significantly improving performance. Added KDocs to both methods detailing the performance optimization.

---
*PR created automatically by Jules for task [2907559176181664029](https://jules.google.com/task/2907559176181664029) started by @tajemniktv*