### PR TITLE
fix(website): resolve Astro Starlight plugin conflicts

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,10 @@ export default defineConfig({
       title: "Docs",
       description: "TajsOS Documentation",
 
+      components: {
+        MarkdownContent: './src/components/MarkdownContent.astro',
+      },
+
       sidebar: [
         {
           label: "Introduction",

--- a/website/package.json
+++ b/website/package.json
@@ -34,8 +34,6 @@
     "typescript": "^6.0.3",
     "vite": "^7.3.2"
   },
-  "devDependencies": {
-  },
   "overrides": {
     "vite": "$vite"
   }

--- a/website/src/components/MarkdownContent.astro
+++ b/website/src/components/MarkdownContent.astro
@@ -1,0 +1,11 @@
+---
+import BlogMarkdownContent from 'starlight-blog/components/MarkdownContent.astro';
+import VideosMarkdownContent from 'starlight-videos/components/MarkdownContent.astro';
+
+const props = Astro.props;
+---
+<VideosMarkdownContent {...props}>
+    <BlogMarkdownContent {...props}>
+        <slot />
+    </BlogMarkdownContent>
+</VideosMarkdownContent>

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -1,7 +1,20 @@
 import { defineCollection } from 'astro:content';
+import { z } from 'astro/zod';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
+import { blogSchema } from 'starlight-blog/schema';
+import { videosSchema } from 'starlight-videos/schemas';
 
 export const collections = {
-    docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+    docs: defineCollection({
+        loader: docsLoader(),
+        schema: docsSchema({
+            extend: (context) => {
+                return z.object({
+                    ...blogSchema(context).shape,
+                    ...videosSchema.shape
+                });
+            }
+        })
+    }),
 };


### PR DESCRIPTION
Addresses issue where Astro Starlight plugins `starlight-blog` and `starlight-videos` could not be used together. Since both try to override `MarkdownContent` and the collection schema, nesting their components and merging their zod schemas fixes the integration collision.

---
*PR created automatically by Jules for task [16012368088244983427](https://jules.google.com/task/16012368088244983427) started by @tajemniktv*