### PR TITLE
fix(ui): unify card borders using ghost border design token

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AlertCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AlertCards.kt
@@ -51,7 +51,7 @@ fun AlertCard(
         modifier = modifier.fillMaxWidth(),
         color = color.copy(alpha = 0.05f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, color.copy(alpha = 0.3f)),
+        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
     ) {
         Row(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DashboardCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DashboardCards.kt
@@ -69,7 +69,7 @@ fun StickyNoteCard(
         modifier = modifier.width(200.dp),
         color = TajsOSTheme.Accent.copy(alpha = 0.1f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.Accent.copy(alpha = 0.3f)),
+        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/InsightsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/InsightsCards.kt
@@ -601,7 +601,7 @@ fun InsightPatternCard(
         shape =
             androidx.compose.foundation.shape
                 .RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = androidx.compose.foundation.BorderStroke(1.dp, color.copy(alpha = 0.2f)),
+        border = androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.GhostBorder),
     ) {
         Row(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -679,7 +679,7 @@ fun AreaHealthInsightCard(area: AreaHealthMetrics) {
         shape =
             androidx.compose.foundation.shape
                 .RoundedCornerShape(TajsOSTheme.RadiusSm),
-        border = androidx.compose.foundation.BorderStroke(1.dp, color.copy(alpha = 0.25f)),
+        border = androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.GhostBorder),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/RecoveryCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/RecoveryCards.kt
@@ -38,7 +38,7 @@ fun BasicSurvivalCard(
         modifier = modifier,
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, color.copy(alpha = 0.2f)),
+        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/SystemOverviewCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/SystemOverviewCards.kt
@@ -166,7 +166,7 @@ fun AreaHealthCard(
         modifier = modifier.width(190.dp),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, color.copy(alpha = 0.3f)),
+        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/ProtocolTrigger.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/ProtocolTrigger.kt
@@ -54,7 +54,7 @@ fun ProtocolTrigger(
         modifier = Modifier.width(120.dp),
         color = color.copy(alpha = 0.1f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, color.copy(alpha = 0.3f)),
+        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/ProjectItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/ProjectItem.kt
@@ -76,7 +76,7 @@ fun ProjectItem(
             border =
                 androidx.compose.foundation.BorderStroke(
                     1.dp,
-                    TajsOSTheme.Muted.copy(alpha = 0.2f),
+                    TajsOSTheme.GhostBorder,
                 ),
         ) {
             Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
@@ -112,7 +112,7 @@ fun ProjectItem(
                         progress = { progress },
                         modifier = Modifier.fillMaxWidth().height(2.dp),
                         color = TajsOSTheme.Primary,
-                        trackColor = TajsOSTheme.Muted.copy(alpha = 0.2f),
+                        trackColor = TajsOSTheme.GhostBorder,
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/ProjectItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/ProjectItem.kt
@@ -112,7 +112,7 @@ fun ProjectItem(
                         progress = { progress },
                         modifier = Modifier.fillMaxWidth().height(2.dp),
                         color = TajsOSTheme.Primary,
-                        trackColor = TajsOSTheme.GhostBorder,
+                        trackColor = TajsOSTheme.Border,
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/SuggestionGroup.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/SuggestionGroup.kt
@@ -69,7 +69,7 @@ fun SuggestionGroup(
                 modifier = Modifier.fillMaxWidth(),
                 color = TajsOSTheme.CardSurface,
                 shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
-                border = BorderStroke(1.dp, color.copy(alpha = 0.2f)),
+                border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
             ) {
                 Row(
                     modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
@@ -69,7 +69,7 @@ fun TaskBrief(
                         .background(if (isDone) TajsOSTheme.Primary else Color.Transparent)
                         .border(
                             1.dp,
-                            if (isDone) TajsOSTheme.Primary else TajsOSTheme.Muted,
+                            if (isDone) TajsOSTheme.Primary else TajsOSTheme.GhostBorder,
                             CircleShape,
                         ).clickable { onToggle() },
                 contentAlignment = Alignment.Center,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
@@ -366,7 +366,7 @@ private fun AreaCard(
                 ),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-            border = BorderStroke(1.dp, color.copy(alpha = 0.28f)),
+            border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
@@ -400,7 +400,7 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                 modifier = Modifier.fillMaxWidth(),
                 color = TajsOSTheme.Accent.copy(alpha = 0.1f),
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                border = BorderStroke(1.dp, TajsOSTheme.Accent.copy(alpha = 0.3f)),
+                border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
             ) {
                 Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
                     Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
@@ -452,7 +452,7 @@ private fun CommandSidebar(
                 OutlinedButton(
                     onClick = { showSweepDialog = true },
                     modifier = Modifier.fillMaxWidth(),
-                    border = BorderStroke(1.dp, TajsOSTheme.Primary.copy(alpha = 0.5f)),
+                    border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
                 ) {
                     Text("Sweep $staleTasksCount Stale Tasks", color = TajsOSTheme.Primary)
                 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -429,7 +429,7 @@ private fun renderTaskDescription(context: TaskDetailContext) {
                         Surface(
                             shape = RoundedCornerShape(999.dp),
                             color = TajsOSTheme.Primary.copy(alpha = 0.15f),
-                            border = BorderStroke(1.dp, TajsOSTheme.Primary.copy(alpha = 0.35f)),
+                            border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
                         ) {
                             Text(
                                 text = chip,
@@ -1042,7 +1042,7 @@ private fun StatusPill(state: TaskState) {
     Surface(
         shape = RoundedCornerShape(999.dp),
         color = tint.copy(alpha = 0.15f),
-        border = BorderStroke(1.dp, tint.copy(alpha = 0.35f)),
+        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
     ) {
         Text(
             text = label,
@@ -1204,7 +1204,7 @@ private fun TaskStateBadge(
     Surface(
         shape = RoundedCornerShape(999.dp),
         color = tint.copy(alpha = 0.16f),
-        border = BorderStroke(1.dp, tint.copy(alpha = 0.35f)),
+        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
     ) {
         Text(
             text = label,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/vaults/VaultsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/vaults/VaultsScreen.kt
@@ -428,7 +428,7 @@ private fun VaultHeroPrimary(modifier: Modifier = Modifier) {
         Surface(
             color = TajsOSTheme.Primary.copy(alpha = 0.14f),
             shape = RoundedCornerShape(999.dp),
-            border = BorderStroke(1.dp, TajsOSTheme.Primary.copy(alpha = 0.35f)),
+            border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
         ) {
             Text(
                 stringResource(Res.string.dash_module_ready),


### PR DESCRIPTION
This PR unifies the border styles across various card components by replacing the ad-hoc high contrast borders and varying opacity calculations with the standardized `TajsOSTheme.GhostBorder` token. This adheres to the "No-Line" rule defined in `DESIGN.md` ensuring a consistent and subtle separation between elements.

Changes include updates to:
- AlertCards, DashboardCards, InsightsCards, RecoveryCards, SystemOverviewCards
- ProjectItem, SuggestionGroup, TaskBrief
- VaultsScreen, AreasDashboardBlocks, TasksCommandView, TaskDetailBlocks, NoteDetailBlocks, ProtocolTrigger

Testing:
Ran `./gradlew :composeApp:compileKotlinJvm` and `./gradlew :shared:jvmTest` successfully.

---
*PR created automatically by Jules for task [1548928070619007545](https://jules.google.com/task/1548928070619007545) started by @tajemniktv*