### PR TITLE
fix(ui): apply 'no-line' design rules to astro website

### DIFF
--- a/website/src/pages/app.astro
+++ b/website/src/pages/app.astro
@@ -24,7 +24,7 @@ const title = "APP";
                     TajsOS offers a unified dashboard bringing your tasks, notes, projects, and areas into one cohesive environment designed for execution and insight.
                 </p>
 <div class="flex gap-4">
-<div class="px-4 py-2 bg-surface-container-high border border-outline-variant/20 rounded-lg flex items-center gap-3">
+<div class="px-4 py-2 bg-surface-container-high ring-1 ring-inset ring-outline-variant/20 border-none rounded-lg flex items-center gap-3">
 <span class="w-2 h-2 rounded-full bg-primary animate-pulse"></span>
 <span class="font-mono text-[10px] uppercase tracking-widest text-primary">UI V1.0</span>
 </div>
@@ -33,7 +33,7 @@ const title = "APP";
 </header>
 
 <section class="mb-32">
-  <div class="w-full aspect-[16/9] bg-surface-container-low rounded-2xl overflow-hidden border border-outline-variant/10 relative">
+  <div class="w-full aspect-[16/9] bg-surface-container-low rounded-2xl overflow-hidden ring-1 ring-inset ring-outline-variant/10 border-none relative">
     <img src={`${import.meta.env.BASE_URL}images/app-screenshot.png`} alt="TajsOS Dashboard" class="w-full h-full object-cover">
   </div>
 </section>

--- a/website/src/pages/architecture.astro
+++ b/website/src/pages/architecture.astro
@@ -14,7 +14,7 @@ const title = "ARCHITECTURE";
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
 
 <!-- Section 1: Header -->
-<header class="relative flex flex-col md:flex-row justify-between items-end border-b border-outline-variant/20 pb-8">
+<header class="relative flex flex-col md:flex-row justify-between items-end shadow-[inset_0_-1px_0_0_rgba(var(--color-outline-variant),0.2)] border-none pb-8">
 <div class="space-y-2">
 <div class="flex items-center space-x-3 text-primary font-mono text-sm tracking-widest uppercase">
 <span class="w-2 h-2 bg-primary rounded-full animate-pulse"></span>
@@ -33,7 +33,7 @@ const title = "ARCHITECTURE";
   </p>
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mt-8">
-    <div class="bg-surface-container-low p-6 rounded-xl border border-outline-variant/10">
+    <div class="bg-surface-container-low p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none">
       <h3 class="font-bold text-xl text-on-surface mb-2">Frontend / UI</h3>
       <ul class="list-disc pl-4 space-y-2">
         <li>Compose Multiplatform</li>
@@ -41,7 +41,7 @@ const title = "ARCHITECTURE";
       </ul>
     </div>
 
-    <div class="bg-surface-container-low p-6 rounded-xl border border-outline-variant/10">
+    <div class="bg-surface-container-low p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none">
       <h3 class="font-bold text-xl text-on-surface mb-2">Backend / Sync</h3>
       <ul class="list-disc pl-4 space-y-2">
         <li>Ktor Server</li>
@@ -49,7 +49,7 @@ const title = "ARCHITECTURE";
       </ul>
     </div>
 
-    <div class="bg-surface-container-low p-6 rounded-xl border border-outline-variant/10">
+    <div class="bg-surface-container-low p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none">
       <h3 class="font-bold text-xl text-on-surface mb-2">Database Layer</h3>
       <ul class="list-disc pl-4 space-y-2">
         <li>SQLite</li>
@@ -57,7 +57,7 @@ const title = "ARCHITECTURE";
       </ul>
     </div>
 
-    <div class="bg-surface-container-low p-6 rounded-xl border border-outline-variant/10">
+    <div class="bg-surface-container-low p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none">
       <h3 class="font-bold text-xl text-on-surface mb-2">Core Logic</h3>
       <ul class="list-disc pl-4 space-y-2">
         <li>Kotlin Multiplatform (Shared library)</li>

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -22,7 +22,7 @@ const title = "Changelog";
 <!-- Vital Graphs -->
 <div class="flex flex-col gap-4">
 <!-- CPU -->
-<div class="bg-surface-container-low p-6 rounded-xl border border-outline-variant/10 relative overflow-hidden group">
+<div class="bg-surface-container-low p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none relative overflow-hidden group">
 <div class="absolute top-0 right-0 w-32 h-32 bg-primary/5 blur-3xl rounded-full -mr-16 -mt-16"></div>
 <div class="flex justify-between items-end mb-4">
 <div>
@@ -42,7 +42,7 @@ const title = "Changelog";
 </div>
 </div>
 <!-- Neural Load -->
-<div class="bg-surface-container-low p-6 rounded-xl border border-outline-variant/10 relative overflow-hidden group">
+<div class="bg-surface-container-low p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none relative overflow-hidden group">
 <div class="flex justify-between items-end mb-4">
 <div>
 <p class="font-mono text-[10px] text-outline uppercase">Neural Synapse</p>
@@ -60,7 +60,7 @@ const title = "Changelog";
 </div>
 </div>
 <!-- Memory -->
-<div class="bg-surface-container-low p-6 rounded-xl border border-outline-variant/10">
+<div class="bg-surface-container-low p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none">
 <p class="font-mono text-[10px] text-outline uppercase mb-2">Memory Allocation</p>
 <div class="flex items-center gap-4">
 <div class="relative w-16 h-16">
@@ -81,28 +81,28 @@ const title = "Changelog";
 <div class="mt-4 flex flex-col gap-4">
 <p class="font-mono text-[10px] text-outline uppercase tracking-widest">Cognitive Services</p>
 <div class="grid grid-cols-2 gap-3">
-<div class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2">
+<div class="bg-surface-container-highest p-3 rounded-lg ring-1 ring-inset ring-outline-variant/5 border-none flex flex-col gap-2">
 <div class="flex justify-between items-start">
 <span class="material-symbols-outlined text-xs text-primary">hub</span>
 <div class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse shadow-[0_0_5px_#ba9eff]"></div>
 </div>
 <span class="font-mono text-[9px] uppercase tracking-tighter">Sync_Node</span>
 </div>
-<div class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2">
+<div class="bg-surface-container-highest p-3 rounded-lg ring-1 ring-inset ring-outline-variant/5 border-none flex flex-col gap-2">
 <div class="flex justify-between items-start">
 <span class="material-symbols-outlined text-xs text-zinc-500">memory</span>
 <div class="w-1.5 h-1.5 rounded-full bg-zinc-700"></div>
 </div>
 <span class="font-mono text-[9px] uppercase tracking-tighter text-zinc-500">Core_Idle</span>
 </div>
-<div class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2">
+<div class="bg-surface-container-highest p-3 rounded-lg ring-1 ring-inset ring-outline-variant/5 border-none flex flex-col gap-2">
 <div class="flex justify-between items-start">
 <span class="material-symbols-outlined text-xs text-primary">security</span>
 <div class="w-1.5 h-1.5 rounded-full bg-primary shadow-[0_0_5px_#ba9eff]"></div>
 </div>
 <span class="font-mono text-[9px] uppercase tracking-tighter">Vault_Enc</span>
 </div>
-<div class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2">
+<div class="bg-surface-container-highest p-3 rounded-lg ring-1 ring-inset ring-outline-variant/5 border-none flex flex-col gap-2">
 <div class="flex justify-between items-start">
 <span class="material-symbols-outlined text-xs text-tertiary">warning</span>
 <div class="w-1.5 h-1.5 rounded-full bg-tertiary"></div>
@@ -114,9 +114,9 @@ const title = "Changelog";
 </aside>
 <!-- Main Center: Terminal Live Activity -->
 <section class="col-span-9 flex flex-col gap-4">
-<div class="bg-surface-container-lowest border border-outline-variant/10 rounded-xl flex flex-col h-[750px] overflow-hidden terminal-glow shadow-2xl">
+<div class="bg-surface-container-lowest ring-1 ring-inset ring-outline-variant/10 border-none rounded-xl flex flex-col h-[750px] overflow-hidden terminal-glow shadow-2xl">
 <!-- Terminal Header -->
-<div class="bg-surface-container-high px-6 py-3 flex justify-between items-center border-b border-outline-variant/5">
+<div class="bg-surface-container-high px-6 py-3 flex justify-between items-center shadow-[inset_0_-1px_0_0_rgba(var(--color-outline-variant),0.05)] border-none">
 <div class="flex items-center gap-4">
 <div class="flex gap-1.5">
 <div class="w-2.5 h-2.5 rounded-full bg-error/20 border border-error/40"></div>
@@ -127,7 +127,7 @@ const title = "Changelog";
 </div>
 <div class="flex items-center gap-4">
 <span class="font-mono text-[10px] text-zinc-600">STABLE_RELEASE_V4.02</span>
-<div class="flex bg-surface-container-lowest rounded overflow-hidden border border-outline-variant/20">
+<div class="flex bg-surface-container-lowest rounded overflow-hidden ring-1 ring-inset ring-outline-variant/20 border-none">
 <button class="px-3 py-1 bg-primary text-on-primary text-[10px] font-mono">LIVE</button>
 <button class="px-3 py-1 text-zinc-500 text-[10px] font-mono hover:text-white">HISTORY</button>
 </div>
@@ -201,7 +201,7 @@ const title = "Changelog";
 </div>
 </div>
 <!-- Footer Console Input -->
-<div class="bg-surface-container-low px-8 py-4 border-t border-outline-variant/10 flex items-center gap-4">
+<div class="bg-surface-container-low px-8 py-4 shadow-[inset_0_1px_0_0_rgba(var(--color-outline-variant),0.1)] border-none flex items-center gap-4">
 <span class="text-primary font-mono text-sm">tajsos@root:~ $</span>
 <input class="bg-transparent border-none focus:ring-0 w-full text-white font-mono placeholder:text-zinc-700" placeholder="Execute command..." type="text"/>
 <div class="flex gap-3">
@@ -212,8 +212,8 @@ const title = "Changelog";
 </div>
 <!-- Bottom Cards Row -->
 <div class="grid grid-cols-3 gap-6">
-<div class="bg-surface-container-low p-6 rounded-xl border border-outline-variant/10 flex items-center gap-4 group hover:border-primary/20 transition-all">
-<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary border border-outline-variant/10 group-hover:shadow-[0_0_15px_rgba(186,158,255,0.2)]">
+<div class="bg-surface-container-low p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none flex items-center gap-4 group hover:border-primary/20 transition-all">
+<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary ring-1 ring-inset ring-outline-variant/10 border-none group-hover:shadow-[0_0_15px_rgba(186,158,255,0.2)]">
 <span class="material-symbols-outlined">analytics</span>
 </div>
 <div>
@@ -221,8 +221,8 @@ const title = "Changelog";
 <p class="text-xs text-outline font-mono uppercase tracking-tighter">Analyze patterns</p>
 </div>
 </div>
-<div class="bg-surface-container-low p-6 rounded-xl border border-outline-variant/10 flex items-center gap-4 group hover:border-primary/20 transition-all">
-<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-secondary border border-outline-variant/10 group-hover:shadow-[0_0_15px_rgba(192,140,247,0.2)]">
+<div class="bg-surface-container-low p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none flex items-center gap-4 group hover:border-primary/20 transition-all">
+<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-secondary ring-1 ring-inset ring-outline-variant/10 border-none group-hover:shadow-[0_0_15px_rgba(192,140,247,0.2)]">
 <span class="material-symbols-outlined">dns</span>
 </div>
 <div>
@@ -230,8 +230,8 @@ const title = "Changelog";
 <p class="text-xs text-outline font-mono uppercase tracking-tighter">12 Active Clusters</p>
 </div>
 </div>
-<div class="bg-surface-container-low p-6 rounded-xl border border-outline-variant/10 flex items-center gap-4 group hover:border-primary/20 transition-all">
-<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-tertiary border border-outline-variant/10 group-hover:shadow-[0_0_15px_rgba(255,151,181,0.2)]">
+<div class="bg-surface-container-low p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none flex items-center gap-4 group hover:border-primary/20 transition-all">
+<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-tertiary ring-1 ring-inset ring-outline-variant/10 border-none group-hover:shadow-[0_0_15px_rgba(255,151,181,0.2)]">
 <span class="material-symbols-outlined">security</span>
 </div>
 <div>

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -25,7 +25,7 @@ const title = "FEATURES";
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-32">
       {FEATURES.map((feature) => (
-        <div class="bg-surface-container-low p-8 rounded-xl border border-outline-variant/10 hover:border-primary/30 transition-all group">
+        <div class="bg-surface-container-low p-8 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none hover:border-primary/30 transition-all group">
           <span class="material-symbols-outlined text-4xl text-primary mb-6" style="font-variation-settings: 'FILL' 1;">
             {feature.icon}
           </span>

--- a/website/src/pages/philosophy.astro
+++ b/website/src/pages/philosophy.astro
@@ -54,11 +54,11 @@ const title = "PHILOSOPHY";
 <h2 class="font-headline text-5xl font-bold tracking-tight">Local Persistence</h2>
 </div>
 <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-<div class="p-8 bg-surface-container-low rounded-xl border border-outline-variant/10">
+<div class="p-8 bg-surface-container-low rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none">
 <h3 class="font-headline text-xl font-bold mb-4 text-on-surface">Offline by Default</h3>
 <p class="text-on-surface-variant text-sm leading-relaxed">Your data lives on your device first. No internet connection is required to capture a thought or execute a task. Sync is an enhancement, not a requirement.</p>
 </div>
-<div class="p-8 bg-surface-container-low rounded-xl border border-outline-variant/10">
+<div class="p-8 bg-surface-container-low rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none">
 <h3 class="font-headline text-xl font-bold mb-4 text-on-surface">Typed Companion Tables</h3>
 <p class="text-on-surface-variant text-sm leading-relaxed">We use a NodeEntity spine with specific facet tables (TaskFacet, NoteFacet) to keep the database schema clean and typed, avoiding massive nullable rows.</p>
 </div>

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -33,7 +33,7 @@ const title = "PRIVACY";
 <!-- Bento Grid Policy Sections -->
 <section class="grid grid-cols-1 md:grid-cols-12 gap-6 mb-32">
 <!-- Data Encryption Large Card -->
-<div class="md:col-span-8 glass-panel rounded-xl p-8 border border-outline-variant/10 relative overflow-hidden group">
+<div class="md:col-span-8 glass-panel rounded-xl p-8 ring-1 ring-inset ring-outline-variant/10 border-none relative overflow-hidden group">
 <div class="absolute top-0 right-0 p-4 font-mono text-[10px] text-primary/40 uppercase tracking-tighter">Cipher: 0x8F22A</div>
 <div class="mb-12">
 <span class="material-symbols-outlined text-primary text-4xl mb-6" data-icon="lock" style="font-variation-settings: 'FILL' 1;">lock</span>
@@ -43,11 +43,11 @@ const title = "PRIVACY";
                     </p>
 </div>
 <div class="flex flex-wrap gap-4 mt-auto">
-<div class="bg-surface-container-highest px-4 py-2 rounded-lg border border-outline-variant/20 flex items-center gap-3">
+<div class="bg-surface-container-highest px-4 py-2 rounded-lg ring-1 ring-inset ring-outline-variant/20 border-none flex items-center gap-3">
 <div class="w-2 h-2 rounded-full bg-primary animate-pulse"></div>
 <span class="font-mono text-xs uppercase">ENCRYPTION: ACTIVE</span>
 </div>
-<div class="bg-surface-container-highest px-4 py-2 rounded-lg border border-outline-variant/20">
+<div class="bg-surface-container-highest px-4 py-2 rounded-lg ring-1 ring-inset ring-outline-variant/20 border-none">
 <span class="font-mono text-xs uppercase text-on-surface-variant">Standard: FIPS 140-2</span>
 </div>
 </div>
@@ -73,9 +73,9 @@ const title = "PRIVACY";
 </div>
 </div>
 <!-- Zero-Knowledge Sync -->
-<div class="md:col-span-6 bg-surface-container-low rounded-xl p-8 border border-outline-variant/10 group hover:border-primary/30 transition-colors">
+<div class="md:col-span-6 bg-surface-container-low rounded-xl p-8 ring-1 ring-inset ring-outline-variant/10 border-none group hover:border-primary/30 transition-colors">
 <div class="flex items-start justify-between mb-8">
-<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary border border-outline-variant/20">
+<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary ring-1 ring-inset ring-outline-variant/20 border-none">
 <span class="material-symbols-outlined" data-icon="sync_saved_locally">sync_saved_locally</span>
 </div>
 <span class="font-mono text-[10px] text-on-surface-variant">SYNC_ID: 1024-ALPHA</span>
@@ -89,7 +89,7 @@ const title = "PRIVACY";
 </button>
 </div>
 <!-- Retention Policy -->
-<div class="md:col-span-6 glass-panel rounded-xl p-8 border border-outline-variant/10 overflow-hidden relative">
+<div class="md:col-span-6 glass-panel rounded-xl p-8 ring-1 ring-inset ring-outline-variant/10 border-none overflow-hidden relative">
 <div class="flex items-start gap-6">
 <div class="flex-1">
 <h3 class="font-headline text-2xl font-bold mb-3">Retention Policy</h3>
@@ -115,8 +115,8 @@ const title = "PRIVACY";
 </section>
 <!-- Technical Metadata Overlay Section -->
 <section class="mb-32">
-<div class="bg-surface-container-lowest border border-outline-variant/20 rounded-xl overflow-hidden">
-<div class="bg-surface-container-high px-6 py-3 flex items-center justify-between border-b border-outline-variant/20">
+<div class="bg-surface-container-lowest ring-1 ring-inset ring-outline-variant/20 border-none rounded-xl overflow-hidden">
+<div class="bg-surface-container-high px-6 py-3 flex items-center justify-between shadow-[inset_0_-1px_0_0_rgba(var(--color-outline-variant),0.2)] border-none">
 <div class="flex gap-2">
 <div class="w-2.5 h-2.5 rounded-full bg-error/40"></div>
 <div class="w-2.5 h-2.5 rounded-full bg-primary/40"></div>
@@ -154,13 +154,13 @@ const title = "PRIVACY";
 </div>
 </section>
 <!-- CTA / Footer Transition Section -->
-<section class="text-center py-20 border-t border-outline-variant/10">
+<section class="text-center py-20 shadow-[inset_0_1px_0_0_rgba(var(--color-outline-variant),0.1)] border-none">
 <h2 class="font-headline text-5xl font-bold mb-8">Ready to reclaim your <span class="text-primary">digital ghost?</span></h2>
 <div class="flex flex-col sm:flex-row justify-center gap-6">
 <button class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold py-4 px-10 rounded-lg hover:scale-105 transition-transform duration-300 flex items-center gap-3 mx-auto sm:mx-0">
                     INITIALIZE INTERFACE <span class="material-symbols-outlined" data-icon="bolt">bolt</span>
 </button>
-<button class="bg-surface-container-highest text-on-surface font-headline font-bold py-4 px-10 rounded-lg border border-outline-variant/30 hover:bg-surface-container-high transition-colors mx-auto sm:mx-0">
+<button class="bg-surface-container-highest text-on-surface font-headline font-bold py-4 px-10 rounded-lg ring-1 ring-inset ring-outline-variant/30 border-none hover:bg-surface-container-high transition-colors mx-auto sm:mx-0">
                     READ THE WHITE PAPER
                 </button>
 </div>

--- a/website/src/pages/security.astro
+++ b/website/src/pages/security.astro
@@ -125,7 +125,7 @@ const title = "SECURITY";
 </div>
 <div class="lg:col-span-8">
 <div class="glass-panel rounded-2xl overflow-hidden">
-<div class="bg-surface-container-highest/50 px-6 py-4 flex justify-between items-center border-b border-outline-variant/10">
+<div class="bg-surface-container-highest/50 px-6 py-4 flex justify-between items-center shadow-[inset_0_-1px_0_0_rgba(var(--color-outline-variant),0.1)] border-none">
 <div class="flex gap-2">
 <div class="w-2 h-2 rounded-full bg-error"></div>
 <div class="w-2 h-2 rounded-full bg-primary/40"></div>

--- a/website/src/pages/status.astro
+++ b/website/src/pages/status.astro
@@ -16,7 +16,7 @@ const title = "SYSTEM STATUS";
 <!-- Header Status Indicator -->
 <header class="flex flex-col md:flex-row justify-between items-start md:items-end gap-6">
 <div class="space-y-2">
-<div class="flex items-center gap-3 px-4 py-1.5 bg-surface-container-low rounded-full border border-outline-variant/10 w-fit">
+<div class="flex items-center gap-3 px-4 py-1.5 bg-surface-container-low rounded-full ring-1 ring-inset ring-outline-variant/10 border-none w-fit">
 <span class="relative flex h-3 w-3">
 <span class="status-pulse absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
 <span class="relative inline-flex rounded-full h-3 w-3 bg-emerald-500"></span>
@@ -34,7 +34,7 @@ const title = "SYSTEM STATUS";
 </header>
 <!-- Hero: Uptime Stats -->
 <section class="grid grid-cols-1 md:grid-cols-3 gap-6">
-<div class="md:col-span-2 glass-panel p-10 rounded-xl border border-outline-variant/10 relative overflow-hidden group">
+<div class="md:col-span-2 glass-panel p-10 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none relative overflow-hidden group">
 <div class="absolute -right-20 -top-20 w-64 h-64 bg-primary/5 rounded-full blur-[80px] group-hover:bg-primary/10 transition-colors"></div>
 <p class="font-mono text-xs text-on-surface-variant uppercase tracking-[0.3em] mb-4">Cumulative System Uptime</p>
 <div class="flex items-baseline gap-4">
@@ -51,13 +51,13 @@ const title = "SYSTEM STATUS";
 </div>
 <p class="mt-4 font-mono text-[10px] text-on-surface-variant/60">Service reliability measured over the last 90 days.</p>
 </div>
-<div class="bg-surface-container-highest p-10 rounded-xl border border-outline-variant/10 flex flex-col justify-between">
+<div class="bg-surface-container-highest p-10 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none flex flex-col justify-between">
 <div>
 <span class="material-symbols-outlined text-primary mb-4" style="font-variation-settings: 'FILL' 1;">analytics</span>
 <p class="font-mono text-xs text-on-surface-variant uppercase tracking-widest">Active Requests</p>
 <p class="text-4xl font-headline font-bold mt-2">1.2M <span class="text-sm font-normal text-on-surface-variant/60">/sec</span></p>
 </div>
-<div class="pt-8 border-t border-outline-variant/10">
+<div class="pt-8 shadow-[inset_0_1px_0_0_rgba(var(--color-outline-variant),0.1)] border-none">
 <p class="font-mono text-xs text-on-surface-variant uppercase tracking-widest">Global Latency</p>
 <p class="text-4xl font-headline font-bold mt-2 text-secondary">24<span class="text-sm font-normal text-on-surface-variant/60">ms</span></p>
 </div>
@@ -213,7 +213,7 @@ const title = "SYSTEM STATUS";
 <section class="space-y-6">
 <h2 class="font-headline font-bold text-2xl tracking-tight">Incident History</h2>
 <div class="bg-surface-container-lowest rounded-xl overflow-hidden">
-<div class="bg-surface-container-high px-6 py-3 flex items-center justify-between border-b border-outline-variant/10">
+<div class="bg-surface-container-high px-6 py-3 flex items-center justify-between shadow-[inset_0_-1px_0_0_rgba(var(--color-outline-variant),0.1)] border-none">
 <span class="font-mono text-xs uppercase tracking-widest text-on-surface-variant">Changelog // May 2024</span>
 <span class="font-mono text-xs text-emerald-400">STATUS: NOMINAL</span>
 </div>

--- a/website/src/pages/terms.astro
+++ b/website/src/pages/terms.astro
@@ -50,7 +50,7 @@ const title = "TERMS";
 <!-- Sidebar Nav -->
 <aside class="hidden lg:block col-span-3 sticky top-32 h-fit">
 
-<div class="mt-24 p-6 bg-surface-container-low rounded-xl border border-outline-variant/30">
+<div class="mt-24 p-6 bg-surface-container-low rounded-xl ring-1 ring-inset ring-outline-variant/30 border-none">
 <span class="material-symbols-outlined text-primary mb-4" style="font-variation-settings: 'FILL' 1;">info</span>
 <h4 class="font-headline text-xs font-bold uppercase tracking-widest mb-2">Network Advisory</h4>
 <p class="text-xs text-on-surface-variant leading-relaxed">
@@ -91,7 +91,7 @@ const title = "TERMS";
 <span class="font-mono text-4xl text-primary-dim opacity-50">02.</span>
 <h2 class="font-headline text-5xl font-bold tracking-tight">Security &amp; Encryption</h2>
 </div>
-<div class="bg-surface-container-low p-10 rounded-2xl space-y-8 border border-outline-variant/30">
+<div class="bg-surface-container-low p-10 rounded-2xl space-y-8 ring-1 ring-inset ring-outline-variant/30 border-none">
 <div class="grid md:grid-cols-2 gap-12">
 <div class="space-y-4">
 <h3 class="font-headline text-xl font-bold text-on-surface uppercase tracking-tight">2.1 Zero-Knowledge Proofs</h3>
@@ -106,7 +106,7 @@ const title = "TERMS";
                                 </p>
 </div>
 </div>
-<div class="mt-8 pt-8 border-t border-outline-variant/20 flex items-center justify-between">
+<div class="mt-8 pt-8 shadow-[inset_0_1px_0_0_rgba(var(--color-outline-variant),0.2)] border-none flex items-center justify-between">
 <div class="flex items-center gap-3">
 <span class="material-symbols-outlined text-primary">verified_user</span>
 <span class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest">Quantum_Resistance_Applied</span>
@@ -156,13 +156,13 @@ const title = "TERMS";
 </div>
 </section>
 <!-- CTA Actions -->
-<div class="pt-20 border-t border-outline-variant/30 flex flex-col md:flex-row items-center justify-between gap-8">
+<div class="pt-20 shadow-[inset_0_1px_0_0_rgba(var(--color-outline-variant),0.3)] border-none flex flex-col md:flex-row items-center justify-between gap-8">
 <div class="flex flex-col gap-2">
 <p class="font-headline font-bold text-2xl">Confirm Synchronization</p>
 <p class="text-sm text-on-surface-variant">By proceeding, you bind your node to these protocols.</p>
 </div>
 <div class="flex items-center gap-4 w-full md:w-auto">
-<button class="flex-1 md:flex-none px-8 py-4 bg-surface-container-highest text-on-surface font-label text-sm font-bold rounded-xl border border-outline-variant/30 hover:bg-surface-variant transition-all">
+<button class="flex-1 md:flex-none px-8 py-4 bg-surface-container-highest text-on-surface font-label text-sm font-bold rounded-xl ring-1 ring-inset ring-outline-variant/30 border-none hover:bg-surface-variant transition-all">
                             Download Whitepaper
                         </button>
 <button class="flex-1 md:flex-none px-12 py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary font-label text-sm font-bold rounded-xl shadow-[0_0_20px_rgba(186,158,255,0.4)] active:scale-95 transition-all">

--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -22,7 +22,7 @@ const title = "WAITLIST";
 <!-- Hero Content -->
 <div class="relative z-10 w-full max-w-5xl flex flex-col items-center text-center">
 <!-- Technical Indicator -->
-<div class="mb-8 flex items-center gap-3 bg-surface-container-low/50 px-4 py-1.5 rounded-full border border-outline-variant/20 neo-blur">
+<div class="mb-8 flex items-center gap-3 bg-surface-container-low/50 px-4 py-1.5 rounded-full ring-1 ring-inset ring-outline-variant/20 border-none neo-blur">
 <span class="flex h-2 w-2 relative">
 <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75"></span>
 <span class="relative inline-flex rounded-full h-2 w-2 bg-primary"></span>
@@ -39,7 +39,7 @@ const title = "WAITLIST";
 <!-- Waitlist Module -->
 <div class="w-full max-w-lg group relative">
 <div class="absolute -inset-0.5 bg-linear-to-r from-primary to-primary-dim rounded-xl blur opacity-20 group-focus-within:opacity-50 transition duration-1000"></div>
-<form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-outline-variant/30 rounded-xl overflow-hidden focus-within:border-outline-variant focus-within:shadow-[0_0_8px_var(--color-primary)] transition-all duration-500">
+<form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest ring-1 ring-inset ring-outline-variant/30 border-none rounded-xl overflow-hidden focus-within:border-outline-variant focus-within:shadow-[0_0_8px_var(--color-primary)] transition-all duration-500">
 <label for="waitlist-email" class="sr-only">Email address</label>
 <input id="waitlist-email" class="bg-transparent border-none focus:ring-0 text-on-surface placeholder:text-outline font-mono py-5 px-6 w-full text-lg" placeholder="email@example.com" type="email" required autocomplete="email"/>
 <button id="waitlist-submit" type="submit" class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold px-12 py-6 text-xl hover:shadow-[0_0_50px_rgba(186,158,255,0.4)] transition-all flex items-center gap-2 group/btn relative overflow-hidden">
@@ -61,21 +61,21 @@ const title = "WAITLIST";
 </div>
 <!-- Status Panels - Bento Style -->
 <div class="mt-24 grid grid-cols-1 md:grid-cols-3 gap-4 w-full max-w-4xl">
-<div class="bg-surface-container-low/40 neo-blur p-6 rounded-xl border border-outline-variant/10 flex flex-col items-start gap-4">
+<div class="bg-surface-container-low/40 neo-blur p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none flex flex-col items-start gap-4">
 <span class="material-symbols-outlined text-primary-dim" data-icon="waves">waves</span>
 <div class="text-left">
 <div class="font-label text-[10px] tracking-widest text-outline uppercase mb-1">Sync_Status</div>
 <div class="font-mono text-xl text-on-surface">Local First</div>
 </div>
 </div>
-<div class="bg-surface-container-low/40 neo-blur p-6 rounded-xl border border-outline-variant/10 flex flex-col items-start gap-4">
+<div class="bg-surface-container-low/40 neo-blur p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none flex flex-col items-start gap-4">
 <span class="material-symbols-outlined text-primary-dim" data-icon="cloud_done">cloud_done</span>
 <div class="text-left">
 <div class="font-label text-[10px] tracking-widest text-outline uppercase mb-1">App_Size</div>
 <div class="font-mono text-xl text-primary">Lightweight</div>
 </div>
 </div>
-<div class="bg-surface-container-low/40 neo-blur p-6 rounded-xl border border-outline-variant/10 flex flex-col items-start gap-4">
+<div class="bg-surface-container-low/40 neo-blur p-6 rounded-xl ring-1 ring-inset ring-outline-variant/10 border-none flex flex-col items-start gap-4">
 <span class="material-symbols-outlined text-primary-dim" data-icon="encrypted">encrypted</span>
 <div class="text-left">
 <div class="font-label text-[10px] tracking-widest text-outline uppercase mb-1">Database</div>


### PR DESCRIPTION
This PR applies the "No-Line" design rule to the Astro website components in `website/src`. 

Changes:
- Extracted and modified all high-contrast Tailwind borders.
- Replaced general borders (`border border-outline-variant/10`) with inset rings (`ring-1 ring-inset ring-outline-variant/10 border-none`).
- Replaced directional borders (`border-t`, `border-b`) with inset shadows (`shadow-[inset_0_1px_0_0_rgba(var(--color-outline-variant),0.1)]`) to avoid padding and vertical layout regressions.
- Specifically reverted modifications on `<tr>` elements and left-bordered (`border-l`) elements to preserve structural integrity based on feedback.

---
*PR created automatically by Jules for task [5056079916198613781](https://jules.google.com/task/5056079916198613781) started by @tajemniktv*