### PR TITLE
perf: use batch inserts for data imports to improve reliability

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -165,6 +165,9 @@ interface FocusSessionDao {
     @Upsert
     suspend fun insertSession(session: FocusSessionEntity): Long
 
+    @Upsert
+    suspend fun insertSessions(sessions: List<FocusSessionEntity>)
+
     @Update
     suspend fun updateSession(session: FocusSessionEntity)
 
@@ -182,6 +185,9 @@ interface TrackDao {
 
     @Upsert
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long
+
+    @Upsert
+    suspend fun insertTrackEntries(entries: List<TrackEntryEntity>)
 
     @Query("SELECT * FROM track_entries WHERE date = :date LIMIT 1")
     suspend fun getTrackEntryByDate(date: String): TrackEntryEntity?
@@ -252,6 +258,9 @@ interface TagDao {
 
     @Upsert
     suspend fun insertTag(tag: TagEntity): Long
+
+    @Upsert
+    suspend fun insertTags(tags: List<TagEntity>)
 
     @Transaction
     @Query(
@@ -663,6 +672,9 @@ interface ReviewDao {
     @Upsert
     suspend fun insertReview(review: ReviewEntity): Long
 
+    @Upsert
+    suspend fun insertReviews(reviews: List<ReviewEntity>)
+
     @Query("SELECT * FROM reviews WHERE type = :type ORDER BY completedAt DESC LIMIT 1")
     suspend fun getLastReviewByType(type: String): ReviewEntity?
 }
@@ -677,6 +689,9 @@ interface CalendarProviderDao {
 
     @Upsert
     suspend fun insertProvider(provider: CalendarProviderEntity): Long
+
+    @Upsert
+    suspend fun insertProviders(providers: List<CalendarProviderEntity>)
 
     @Update
     suspend fun updateProvider(provider: CalendarProviderEntity)

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -1666,18 +1666,18 @@ class AppRepository(
         )
 
     suspend fun importBundle(bundle: ExportBundle): ImportReport {
-        bundle.nodes.forEach { nodeDao.insertNode(it) }
-        bundle.relations.forEach { relationDao.insertRelation(it) }
-        bundle.tags.forEach { tagDao.insertTag(it) }
-        bundle.templates.forEach { templateDao.insertTemplate(it) }
-        bundle.reviews.forEach { reviewDao.insertReview(it) }
-        bundle.tracks.forEach { trackDao.insertTrackEntry(it) }
-        bundle.sessions.forEach { focusSessionDao.insertSession(it) }
-        bundle.providers.forEach { calendarProviderDao.insertProvider(it) }
+        nodeDao.insertNodes(bundle.nodes)
+        relationDao.insertRelations(bundle.relations)
+        tagDao.insertTags(bundle.tags)
+        templateDao.insertTemplates(bundle.templates)
+        reviewDao.insertReviews(bundle.reviews)
+        trackDao.insertTrackEntries(bundle.tracks)
+        focusSessionDao.insertSessions(bundle.sessions)
+        calendarProviderDao.insertProviders(bundle.providers)
         if (bundle.calendars.isNotEmpty()) {
             calendarEventDao.insertEvents(bundle.calendars)
         }
-        bundle.recentEvents.forEach { eventLogDao.insertLog(it) }
+        eventLogDao.insertLogs(bundle.recentEvents)
 
         return ImportReport(
             nodes = bundle.nodes.size,
@@ -1689,7 +1689,7 @@ class AppRepository(
     }
 
     suspend fun importLegacyNodes(nodes: List<NodeEntity>): Int {
-        nodes.forEach { nodeDao.insertNode(it) }
+        nodeDao.insertNodes(nodes)
         return nodes.size
     }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
@@ -26,6 +26,7 @@ class CalendarManagerTest {
     private val fakeNodeSnapshotDao = FakeNodeSnapshotDao()
     private val fakeReviewDao = FakeReviewDao()
     private val fakeCalendarProviderDao = object : CalendarProviderDao {
+        override suspend fun insertProviders(providers: List<CalendarProviderEntity>) { providers.forEach { insertProvider(it) } }
         val providers = mutableListOf<CalendarProviderEntity>()
         override fun getAllProviders() = kotlinx.coroutines.flow.MutableStateFlow(providers)
         override suspend fun insertProvider(provider: CalendarProviderEntity): Long {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeFocusSessionDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeFocusSessionDao.kt
@@ -12,6 +12,7 @@ class FakeFocusSessionDao : FocusSessionDao {
         return sessionsFlow.map { it.sortedByDescending { session -> session.startedAt } }
     }
 
+    override suspend fun insertSessions(sessions: List<FocusSessionEntity>) { sessions.forEach { insertSession(it) } }
     override suspend fun insertSession(session: FocusSessionEntity): Long {
         val newId = (sessions.size + 1).toLong()
         val newSession = session.copy(id = newId)

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTagDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTagDao.kt
@@ -12,6 +12,7 @@ class FakeTagDao : TagDao {
 
     override fun getAllTags(): Flow<List<TagEntity>> = tagsFlow
 
+    override suspend fun insertTags(tags: List<TagEntity>) { tags.forEach { insertTag(it) } }
     override suspend fun insertTag(tag: TagEntity): Long {
         val newId = (tags.size + 1).toLong()
         val newTag = tag.copy(id = newId)

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTrackDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTrackDao.kt
@@ -14,6 +14,7 @@ class FakeTrackDao : TrackDao {
         return entriesFlow.map { list -> list.sortedWith(compareByDescending<TrackEntryEntity> { it.date }.thenByDescending { it.createdAt }) }
     }
 
+    override suspend fun insertTrackEntries(entries: List<TrackEntryEntity>) { entries.forEach { insertTrackEntry(it) } }
     override suspend fun insertTrackEntry(entry: TrackEntryEntity): Long {
         val index = entries.indexOfFirst { it.id == entry.id }
         if (index != -1 && entry.id != 0L) {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/Fakes.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/Fakes.kt
@@ -28,6 +28,7 @@ class FakeNodeSnapshotDao : NodeSnapshotDao {
 class FakeReviewDao : ReviewDao {
     private val reviews = mutableListOf<ReviewEntity>()
     override fun getAllReviews(): Flow<List<ReviewEntity>> = MutableStateFlow(reviews.toList())
+    override suspend fun insertReviews(reviews: List<ReviewEntity>) { this.reviews.addAll(reviews) }
     override suspend fun insertReview(review: ReviewEntity): Long {
         reviews.add(review)
         return reviews.size.toLong()
@@ -38,10 +39,13 @@ class FakeReviewDao : ReviewDao {
 }
 
 class FakeCalendarProviderDao : CalendarProviderDao {
+    override suspend fun insertProviders(providers: List<CalendarProviderEntity>) { providers.forEach { insertProvider(it) } }
     override fun getAllProviders(): Flow<List<CalendarProviderEntity>> =
         MutableStateFlow(emptyList())
 
     override suspend fun insertProvider(provider: CalendarProviderEntity): Long = 0
+
+
     override suspend fun updateProvider(provider: CalendarProviderEntity) {}
     override suspend fun deleteProvider(provider: CalendarProviderEntity) {}
     override suspend fun getProviderById(id: Long): CalendarProviderEntity? = null

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/RepositoryDelegationTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/RepositoryDelegationTest.kt
@@ -89,6 +89,7 @@ class RepositoryDelegationTest {
         override fun getAllSessions(): Flow<List<FocusSessionEntity>> = flowOf(emptyList())
 
         override suspend fun insertSession(session: FocusSessionEntity): Long = 0L
+        override suspend fun insertSessions(sessions: List<FocusSessionEntity>) { sessions.forEach { insertSession(it) } }
 
         override suspend fun updateSession(session: FocusSessionEntity) {
         }
@@ -100,6 +101,7 @@ class RepositoryDelegationTest {
         override fun getAllTrackEntries(): Flow<List<TrackEntryEntity>> = flowOf(emptyList())
 
         override suspend fun insertTrackEntry(entry: TrackEntryEntity): Long = 0
+        override suspend fun insertTrackEntries(entries: List<TrackEntryEntity>) { entries.forEach { insertTrackEntry(it) } }
 
         override suspend fun getTrackEntryByDate(date: String): TrackEntryEntity? = null
 
@@ -148,6 +150,7 @@ class RepositoryDelegationTest {
         override fun getAllTags(): Flow<List<TagEntity>> = flowOf(emptyList())
 
         override suspend fun insertTag(tag: TagEntity): Long = 0L
+        override suspend fun insertTags(tags: List<TagEntity>) { tags.forEach { insertTag(it) } }
 
         override fun getTagsForNode(nodeId: Long): Flow<List<TagEntity>> = flowOf(emptyList())
 

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/MainViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/MainViewModelTest.kt
@@ -116,6 +116,7 @@ class MainViewModelTest {
 
     class StubFocusSessionDao : FocusSessionDao {
         override suspend fun insertSession(session: FocusSessionEntity): Long = 0
+        override suspend fun insertSessions(sessions: List<FocusSessionEntity>) { sessions.forEach { insertSession(it) } }
 
         override suspend fun updateSession(session: FocusSessionEntity) {
         }
@@ -129,6 +130,7 @@ class MainViewModelTest {
         override fun getAllTrackEntries(): Flow<List<TrackEntryEntity>> = flowOf(emptyList())
 
         override suspend fun insertTrackEntry(entry: TrackEntryEntity): Long = 0
+        override suspend fun insertTrackEntries(entries: List<TrackEntryEntity>) { entries.forEach { insertTrackEntry(it) } }
 
         override suspend fun getTrackEntryByDate(date: String): TrackEntryEntity? = null
 
@@ -170,6 +172,7 @@ class MainViewModelTest {
         override fun getAllTags(): Flow<List<TagEntity>> = flowOf(emptyList())
 
         override suspend fun insertTag(tag: TagEntity): Long = 0
+        override suspend fun insertTags(tags: List<TagEntity>) { tags.forEach { insertTag(it) } }
 
         override fun getTagsForNode(nodeId: Long): Flow<List<TagEntity>> = flowOf(emptyList())
 


### PR DESCRIPTION
This pull request modifies the core data repository to utilize batch inserts instead of iterative loop inserts during bulk data imports (e.g., `importBundle` and `importLegacyNodes`). 

**Key Changes:**
1.  **Added Batch `@Upsert` Methods:** Introduced new batch functions in `Daos.kt` (e.g., `insertTags`, `insertReviews`, `insertTrackEntries`, `insertSessions`, `insertProviders`) matching existing batch methods like `insertNodes` and `insertRelations`.
2.  **Updated Repository Imports:** Replaced `forEach { dao.insert(it) }` constructs in `Repository.kt` with bulk insert lists (e.g., `dao.insertTags(bundle.tags)`). 
3.  **Updated Test Fakes:** Ensured all test stubs and fake DAO implementations properly replicate the batching behaviour (using `forEach` or `addAll` inside the test fakes to preserve state).

**Impact:**
-   **Reliability & Fault Tolerance:** Improves atomic transaction safety. By passing lists to Room's `@Upsert`, operations are processed as a single database transaction, mitigating the risk of partial database writes if the app crashes midway through an import.
-   **Predictability & Performance:** Significantly speeds up the processing of large `ExportBundle` payloads by avoiding the overhead of invoking independent SQLite transactions per record.

---
*PR created automatically by Jules for task [7986634844992524525](https://jules.google.com/task/7986634844992524525) started by @tajemniktv*