### PR TITLE
docs: add KDoc for Domain models, Lens queries, and Dao interfaces

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -156,6 +156,9 @@ interface NodeDao {
 
 /**
  * Provides database access for managing deep work and [FocusSessionEntity] focus sessions linked to specific nodes.
+ *
+ * Flow emissions from this DAO will trigger updates across active session widgets.
+ * A session without an `endedAt` value is considered the single globally active session.
  */
 @Dao
 interface FocusSessionDao {
@@ -174,6 +177,9 @@ interface FocusSessionDao {
 
 /**
  * Provides database access for [TrackEntryEntity] time tracking logs, capturing continuous effort against system nodes.
+ *
+ * Time tracking records act as an immutable ledger. Queries should generally filter by `date` to aggregate
+ * effort or link it back to specific items.
  */
 @Dao
 interface TrackDao {
@@ -195,6 +201,10 @@ interface TrackDao {
 
 /**
  * Provides database access for resolving bi-directional [RelationEntity] graph relationships between nodes.
+ *
+ * This DAO manages the graph edges. Note that relationships must always point to existing node IDs.
+ * The `deleteBelongsToRelations` methods are specifically designed to safely unlink items
+ * without necessarily deleting the underlying nodes.
  */
 @Dao
 interface RelationDao {
@@ -244,6 +254,9 @@ interface RelationDao {
 
 /**
  * Provides database access for global classification [TagEntity] tags mapped across system nodes via [NodeTagEntity].
+ *
+ * Tags represent a many-to-many relationship with nodes. This DAO exposes queries to resolve all tags,
+ * as well as transaction-backed queries (`getTagsForNode`) that traverse the join table.
  */
 @Dao
 interface TagDao {
@@ -278,6 +291,9 @@ interface TagDao {
 
 /**
  * Provides database access for capturing immutable chronological [EventLogEntity] activity events for system nodes.
+ *
+ * Event logs are meant to act as an append-only audit trail. Updates and deletions should generally be avoided
+ * in favor of inserting new events.
  */
 @Dao
 interface EventLogDao {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -157,7 +157,7 @@ interface NodeDao {
 /**
  * Provides database access for managing deep work and [FocusSessionEntity] focus sessions linked to specific nodes.
  *
- * Flow emissions from this DAO will trigger updates across active session widgets.
+ * Flow emissions from this DAO provide real-time updates on session state changes.
  * A session without an `endedAt` value is considered the single globally active session.
  */
 @Dao
@@ -178,8 +178,8 @@ interface FocusSessionDao {
 /**
  * Provides database access for [TrackEntryEntity] time tracking logs, capturing continuous effort against system nodes.
  *
- * Time tracking records act as an immutable ledger. Queries should generally filter by `date` to aggregate
- * effort or link it back to specific items.
+ * Time tracking records represent daily status snapshots. Queries should generally filter by `date` to retrieve
+ * the state for a specific day or to analyze wellbeing trends over time.
  */
 @Dao
 interface TrackDao {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/DomainKind.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/DomainKind.kt
@@ -13,6 +13,11 @@ import kotlinx.serialization.Serializable
  * to user-defined Areas. TajsOS utilizes heuristic-based, zero-configuration logic
  * (e.g., implicit keyword matching) for categorizing domains rather than requiring
  * explicit user associations.
+ *
+ * This implicit matching (implemented in [com.tajemniktv.tajsos.domain.lens.DomainLensQueries])
+ * intentionally bypasses explicit assignments like [com.tajemniktv.tajsos.data.ItemDomainEntity]
+ * to provide a seamless user experience, ensuring items surface in appropriate lenses
+ * without requiring the user to constantly curate their metadata.
  */
 @Serializable
 enum class DomainKind {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -115,7 +115,9 @@ private val healthTitleKeywords =
  *
  * Currently, heuristic matching queries are only implemented for the `FINANCES` and `HEALTH` domains.
  * `EDUCATION` and `RELATIONSHIPS` (defined in [com.tajemniktv.tajsos.domain.DomainKind])
- * do not yet have dedicated queries in this object.
+ * do not yet have dedicated queries in this object. Adding support for them would require
+ * establishing similar heuristic marker sets (e.g., `educationTagMarkers`, `educationTitleKeywords`,
+ * `relationshipsMaintenanceTypes`) and implementing their respective projection queries.
  */
 object DomainLensQueries {
     /**


### PR DESCRIPTION
This PR introduces missing KDocs to core domain and persistence layers to improve codebase onboarding and clarify internal behaviors. 

- **DomainKind.kt & DomainLensQueries.kt**: Documented the deliberate choice to use heuristic matching (tags, titles, etc.) over explicit `ItemDomainEntity` relations for zero-configuration domain classification. Also clarified what would be needed to support currently unimplemented domains like Education and Relationships.
- **Daos.kt**: Added detailed KDoc to `FocusSessionDao`, `TrackDao`, `RelationDao`, `TagDao`, and `EventLogDao` explicitly outlining their purpose, expected usage patterns (like append-only nature of Event Logs), and data flows.

---
*PR created automatically by Jules for task [1701645899877704014](https://jules.google.com/task/1701645899877704014) started by @tajemniktv*