### PR TITLE
perf: optimize database imports using batch DAO operations

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -165,6 +165,12 @@ interface FocusSessionDao {
     @Upsert
     suspend fun insertSession(session: FocusSessionEntity): Long
 
+    /**
+     * Inserts a list of focus sessions efficiently using a single transaction.
+     */
+    @Upsert
+    suspend fun insertSessions(sessions: List<FocusSessionEntity>)
+
     @Update
     suspend fun updateSession(session: FocusSessionEntity)
 
@@ -182,6 +188,12 @@ interface TrackDao {
 
     @Upsert
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long
+
+    /**
+     * Inserts a list of track entries efficiently using a single transaction.
+     */
+    @Upsert
+    suspend fun insertTrackEntries(entries: List<TrackEntryEntity>)
 
     @Query("SELECT * FROM track_entries WHERE date = :date LIMIT 1")
     suspend fun getTrackEntryByDate(date: String): TrackEntryEntity?
@@ -252,6 +264,12 @@ interface TagDao {
 
     @Upsert
     suspend fun insertTag(tag: TagEntity): Long
+
+    /**
+     * Inserts a list of tags efficiently using a single transaction.
+     */
+    @Upsert
+    suspend fun insertTags(tags: List<TagEntity>)
 
     @Transaction
     @Query(
@@ -663,6 +681,12 @@ interface ReviewDao {
     @Upsert
     suspend fun insertReview(review: ReviewEntity): Long
 
+    /**
+     * Inserts a list of reviews efficiently using a single transaction.
+     */
+    @Upsert
+    suspend fun insertReviews(reviews: List<ReviewEntity>)
+
     @Query("SELECT * FROM reviews WHERE type = :type ORDER BY completedAt DESC LIMIT 1")
     suspend fun getLastReviewByType(type: String): ReviewEntity?
 }
@@ -677,6 +701,12 @@ interface CalendarProviderDao {
 
     @Upsert
     suspend fun insertProvider(provider: CalendarProviderEntity): Long
+
+    /**
+     * Inserts a list of calendar providers efficiently using a single transaction.
+     */
+    @Upsert
+    suspend fun insertProviders(providers: List<CalendarProviderEntity>)
 
     @Update
     suspend fun updateProvider(provider: CalendarProviderEntity)

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -1666,18 +1666,36 @@ class AppRepository(
         )
 
     suspend fun importBundle(bundle: ExportBundle): ImportReport {
-        bundle.nodes.forEach { nodeDao.insertNode(it) }
-        bundle.relations.forEach { relationDao.insertRelation(it) }
-        bundle.tags.forEach { tagDao.insertTag(it) }
-        bundle.templates.forEach { templateDao.insertTemplate(it) }
-        bundle.reviews.forEach { reviewDao.insertReview(it) }
-        bundle.tracks.forEach { trackDao.insertTrackEntry(it) }
-        bundle.sessions.forEach { focusSessionDao.insertSession(it) }
-        bundle.providers.forEach { calendarProviderDao.insertProvider(it) }
+        if (bundle.nodes.isNotEmpty()) {
+            nodeDao.insertNodes(bundle.nodes)
+        }
+        if (bundle.relations.isNotEmpty()) {
+            relationDao.insertRelations(bundle.relations)
+        }
+        if (bundle.tags.isNotEmpty()) {
+            tagDao.insertTags(bundle.tags)
+        }
+        if (bundle.templates.isNotEmpty()) {
+            templateDao.insertTemplates(bundle.templates)
+        }
+        if (bundle.reviews.isNotEmpty()) {
+            reviewDao.insertReviews(bundle.reviews)
+        }
+        if (bundle.tracks.isNotEmpty()) {
+            trackDao.insertTrackEntries(bundle.tracks)
+        }
+        if (bundle.sessions.isNotEmpty()) {
+            focusSessionDao.insertSessions(bundle.sessions)
+        }
+        if (bundle.providers.isNotEmpty()) {
+            calendarProviderDao.insertProviders(bundle.providers)
+        }
         if (bundle.calendars.isNotEmpty()) {
             calendarEventDao.insertEvents(bundle.calendars)
         }
-        bundle.recentEvents.forEach { eventLogDao.insertLog(it) }
+        if (bundle.recentEvents.isNotEmpty()) {
+            eventLogDao.insertLogs(bundle.recentEvents)
+        }
 
         return ImportReport(
             nodes = bundle.nodes.size,
@@ -1689,7 +1707,9 @@ class AppRepository(
     }
 
     suspend fun importLegacyNodes(nodes: List<NodeEntity>): Int {
-        nodes.forEach { nodeDao.insertNode(it) }
+        if (nodes.isNotEmpty()) {
+            nodeDao.insertNodes(nodes)
+        }
         return nodes.size
     }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
@@ -33,6 +33,10 @@ class CalendarManagerTest {
             providers.add(provider.copy(id = id))
             return id
         }
+
+        override suspend fun insertProviders(providers: List<CalendarProviderEntity>) {
+            providers.forEach { insertProvider(it) }
+        }
         override suspend fun updateProvider(provider: CalendarProviderEntity) {
             val idx = providers.indexOfFirst { it.id == provider.id }
             if (idx != -1) providers[idx] = provider

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeFocusSessionDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeFocusSessionDao.kt
@@ -20,6 +20,10 @@ class FakeFocusSessionDao : FocusSessionDao {
         return newId
     }
 
+    override suspend fun insertSessions(sessions: List<FocusSessionEntity>) {
+        sessions.forEach { insertSession(it) }
+    }
+
     override suspend fun updateSession(session: FocusSessionEntity) {
         val index = sessions.indexOfFirst { it.id == session.id }
         if (index != -1) {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTagDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTagDao.kt
@@ -20,6 +20,10 @@ class FakeTagDao : TagDao {
         return newId
     }
 
+    override suspend fun insertTags(tags: List<TagEntity>) {
+        tags.forEach { insertTag(it) }
+    }
+
     override fun getTagsForNode(nodeId: Long): Flow<List<TagEntity>> {
         return nodeTagsFlow.map { links ->
             val tagIdsForNode = links.filter { it.nodeId == nodeId }.map { it.tagId }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTrackDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeTrackDao.kt
@@ -29,6 +29,10 @@ class FakeTrackDao : TrackDao {
         }
     }
 
+    override suspend fun insertTrackEntries(entries: List<TrackEntryEntity>) {
+        entries.forEach { insertTrackEntry(it) }
+    }
+
     override suspend fun getTrackEntryByDate(date: String): TrackEntryEntity? {
         return entriesFlow.value.find { it.date == date }
     }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/Fakes.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/Fakes.kt
@@ -33,6 +33,10 @@ class FakeReviewDao : ReviewDao {
         return reviews.size.toLong()
     }
 
+    override suspend fun insertReviews(reviews: List<ReviewEntity>) {
+        reviews.forEach { insertReview(it) }
+    }
+
     override suspend fun getLastReviewByType(type: String): ReviewEntity? =
         reviews.filter { it.type == type }.maxByOrNull { it.completedAt }
 }
@@ -42,6 +46,10 @@ class FakeCalendarProviderDao : CalendarProviderDao {
         MutableStateFlow(emptyList())
 
     override suspend fun insertProvider(provider: CalendarProviderEntity): Long = 0
+
+    override suspend fun insertProviders(providers: List<CalendarProviderEntity>) {
+        providers.forEach { insertProvider(it) }
+    }
     override suspend fun updateProvider(provider: CalendarProviderEntity) {}
     override suspend fun deleteProvider(provider: CalendarProviderEntity) {}
     override suspend fun getProviderById(id: Long): CalendarProviderEntity? = null

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/RepositoryDelegationTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/RepositoryDelegationTest.kt
@@ -88,7 +88,11 @@ class RepositoryDelegationTest {
     private class FakeFocusSessionDao : FocusSessionDao {
         override fun getAllSessions(): Flow<List<FocusSessionEntity>> = flowOf(emptyList())
 
-        override suspend fun insertSession(session: FocusSessionEntity): Long = 0L
+        override suspend fun insertSession(session: FocusSessionEntity): Long = 0
+
+        override suspend fun insertSessions(sessions: List<FocusSessionEntity>) {
+            sessions.forEach { insertSession(it) }
+        }
 
         override suspend fun updateSession(session: FocusSessionEntity) {
         }
@@ -100,6 +104,10 @@ class RepositoryDelegationTest {
         override fun getAllTrackEntries(): Flow<List<TrackEntryEntity>> = flowOf(emptyList())
 
         override suspend fun insertTrackEntry(entry: TrackEntryEntity): Long = 0
+
+        override suspend fun insertTrackEntries(entries: List<TrackEntryEntity>) {
+            entries.forEach { insertTrackEntry(it) }
+        }
 
         override suspend fun getTrackEntryByDate(date: String): TrackEntryEntity? = null
 
@@ -147,7 +155,11 @@ class RepositoryDelegationTest {
     private class FakeTagDao : TagDao {
         override fun getAllTags(): Flow<List<TagEntity>> = flowOf(emptyList())
 
-        override suspend fun insertTag(tag: TagEntity): Long = 0L
+        override suspend fun insertTag(tag: TagEntity): Long = 0
+
+        override suspend fun insertTags(tags: List<TagEntity>) {
+            tags.forEach { insertTag(it) }
+        }
 
         override fun getTagsForNode(nodeId: Long): Flow<List<TagEntity>> = flowOf(emptyList())
 

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/MainViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/MainViewModelTest.kt
@@ -117,6 +117,10 @@ class MainViewModelTest {
     class StubFocusSessionDao : FocusSessionDao {
         override suspend fun insertSession(session: FocusSessionEntity): Long = 0
 
+        override suspend fun insertSessions(sessions: List<FocusSessionEntity>) {
+            sessions.forEach { insertSession(it) }
+        }
+
         override suspend fun updateSession(session: FocusSessionEntity) {
         }
 
@@ -129,6 +133,10 @@ class MainViewModelTest {
         override fun getAllTrackEntries(): Flow<List<TrackEntryEntity>> = flowOf(emptyList())
 
         override suspend fun insertTrackEntry(entry: TrackEntryEntity): Long = 0
+
+        override suspend fun insertTrackEntries(entries: List<TrackEntryEntity>) {
+            entries.forEach { insertTrackEntry(it) }
+        }
 
         override suspend fun getTrackEntryByDate(date: String): TrackEntryEntity? = null
 
@@ -170,6 +178,10 @@ class MainViewModelTest {
         override fun getAllTags(): Flow<List<TagEntity>> = flowOf(emptyList())
 
         override suspend fun insertTag(tag: TagEntity): Long = 0
+
+        override suspend fun insertTags(tags: List<TagEntity>) {
+            tags.forEach { insertTag(it) }
+        }
 
         override fun getTagsForNode(nodeId: Long): Flow<List<TagEntity>> = flowOf(emptyList())
 


### PR DESCRIPTION
- Added explicit `@Upsert` methods with `List<Entity>` types to `Daos.kt` to allow batch inserts for tags, track entries, focus sessions, calendar providers, and reviews.
- Modified `AppRepository.kt` to use the new and existing batch insert methods (`insertNodes`, `insertRelations`, `insertTags`, etc.) instead of executing sequential `forEach` single inserts.
- Updated all test Fakes to properly implement the newly added methods by forwarding the lists to their internal arrays.
- Added standard KDocs to the new batch operations.

---
*PR created automatically by Jules for task [2132046577132371851](https://jules.google.com/task/2132046577132371851) started by @tajemniktv*