### PR TITLE
perf: optimize sweepStaleTasks using batch updateNodes

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -93,8 +93,12 @@ interface NodeDao {
      * @param id The node's primary key.
      * @return The matching NodeEntity, or `null` if no node with the given id exists.
      */
+
     @Query("SELECT * FROM nodes WHERE id = :id")
     suspend fun getNodeById(id: Long): NodeEntity?
+
+    @Query("SELECT * FROM nodes WHERE id IN (:ids)")
+    suspend fun getNodesByIds(ids: List<Long>): List<NodeEntity>
 
     /**
      * Inserts a new node into the database or replaces an existing one if a conflict occurs.
@@ -116,8 +120,17 @@ interface NodeDao {
      *
      * @param node The [NodeEntity] containing the updated values. Its [NodeEntity.id] must match an existing row.
      */
+
     @Update
     suspend fun updateNode(node: NodeEntity)
+
+    /**
+     * Updates multiple existing nodes in the database.
+     *
+     * @param nodes The list of [NodeEntity] containing the updated values. Their [NodeEntity.id]s must match existing rows.
+     */
+    @Update
+    suspend fun updateNodes(nodes: List<NodeEntity>)
 
     /**
      * Deletes a node from the database.

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -696,10 +696,33 @@ class AppRepository(
      */
 
 
+
     suspend fun updateNode(node: NodeEntity) {
         val oldNode = nodeDao.getNodeById(node.id) ?: return
         nodeDao.updateNode(node)
+        executeNodeSideEffects(oldNode, node)
+    }
 
+    /**
+     * Updates multiple existing nodes in the database in a batch operation.
+     * Side-effects (like logging, facet syncing, etc.) are executed for each node.
+     *
+     * @param nodes The updated node entities to save.
+     */
+    suspend fun updateNodes(nodes: List<NodeEntity>) {
+        if (nodes.isEmpty()) return
+
+        val oldNodesMap = nodeDao.getNodesByIds(nodes.map { it.id }).associateBy { it.id }
+
+        nodeDao.updateNodes(nodes)
+
+        nodes.forEach { node ->
+            val oldNode = oldNodesMap[node.id] ?: return@forEach
+            executeNodeSideEffects(oldNode, node)
+        }
+    }
+
+    private suspend fun executeNodeSideEffects(oldNode: NodeEntity, node: NodeEntity) {
         if (oldNode.status != node.status) {
             when (node.status)
             {
@@ -726,51 +749,6 @@ class AppRepository(
             dueAt = node.dueAt,
             recurrenceRule = node.recurringInterval,
         )
-    }
-
-    /**
-     * Updates multiple existing nodes in the database in a batch operation.
-     * Side-effects (like logging, facet syncing, etc.) are executed for each node.
-     *
-     * @param nodes The updated node entities to save.
-     */
-    suspend fun updateNodes(nodes: List<NodeEntity>) {
-        if (nodes.isEmpty()) return
-
-        val oldNodesMap = nodeDao.getNodesByIds(nodes.map { it.id }).associateBy { it.id }
-
-        nodeDao.updateNodes(nodes)
-
-        nodes.forEach { node ->
-            val oldNode = oldNodesMap[node.id] ?: return@forEach
-
-            if (oldNode.status != node.status) {
-                when (node.status)
-                {
-                    "done" -> logEvent("NODE_COMPLETED", node.id)
-                    "archived" -> logEvent("NODE_ARCHIVED", node.id)
-                }
-            }
-
-            if (oldNode.isFrozen != node.isFrozen) {
-                logEvent(if (node.isFrozen) "NODE_FROZEN" else "NODE_UNFROZEN", node.id)
-            }
-
-            if (oldNode.projectId != node.projectId || oldNode.areaId != node.areaId) {
-                syncBelongsToRelations(node.id, node.projectId, node.areaId)
-            }
-
-            syncTypedFacetsFromNode(node)
-            syncDomainsFromNodeMetadata(node)
-            syncDocumentFromNode(node)
-            syncScheduleEntriesForNode(
-                nodeId = node.id,
-                reminderAt = node.reminderAt,
-                startAt = node.startAt,
-                dueAt = node.dueAt,
-                recurrenceRule = node.recurringInterval,
-            )
-        }
     }
 
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -694,6 +694,8 @@ class AppRepository(
      *
      * @param node The updated node entity to save.
      */
+
+
     suspend fun updateNode(node: NodeEntity) {
         val oldNode = nodeDao.getNodeById(node.id) ?: return
         nodeDao.updateNode(node)
@@ -725,6 +727,52 @@ class AppRepository(
             recurrenceRule = node.recurringInterval,
         )
     }
+
+    /**
+     * Updates multiple existing nodes in the database in a batch operation.
+     * Side-effects (like logging, facet syncing, etc.) are executed for each node.
+     *
+     * @param nodes The updated node entities to save.
+     */
+    suspend fun updateNodes(nodes: List<NodeEntity>) {
+        if (nodes.isEmpty()) return
+
+        val oldNodesMap = nodeDao.getNodesByIds(nodes.map { it.id }).associateBy { it.id }
+
+        nodeDao.updateNodes(nodes)
+
+        nodes.forEach { node ->
+            val oldNode = oldNodesMap[node.id] ?: return@forEach
+
+            if (oldNode.status != node.status) {
+                when (node.status)
+                {
+                    "done" -> logEvent("NODE_COMPLETED", node.id)
+                    "archived" -> logEvent("NODE_ARCHIVED", node.id)
+                }
+            }
+
+            if (oldNode.isFrozen != node.isFrozen) {
+                logEvent(if (node.isFrozen) "NODE_FROZEN" else "NODE_UNFROZEN", node.id)
+            }
+
+            if (oldNode.projectId != node.projectId || oldNode.areaId != node.areaId) {
+                syncBelongsToRelations(node.id, node.projectId, node.areaId)
+            }
+
+            syncTypedFacetsFromNode(node)
+            syncDomainsFromNodeMetadata(node)
+            syncDocumentFromNode(node)
+            syncScheduleEntriesForNode(
+                nodeId = node.id,
+                reminderAt = node.reminderAt,
+                startAt = node.startAt,
+                dueAt = node.dueAt,
+                recurrenceRule = node.recurringInterval,
+            )
+        }
+    }
+
 
     private suspend fun syncBelongsToRelations(
         nodeId: Long,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
@@ -44,23 +44,26 @@ class NodeCommands(
     private val defaultNextStepLabel: () -> String = { "Next step" },
     private val defaultUntitledLabel: () -> String = { "Untitled" },
 ) {
+
     fun sweepStaleTasks(cutoffDays: Int = 3) {
         scope.launch {
             val now = Clock.System.now()
             val nodes = currentAllNodes()
             val staleTasks = calculateStaleTasks(nodes, now, cutoffDays)
 
-            staleTasks.forEach { node ->
-                repository.updateNode(
+            if (staleTasks.isNotEmpty()) {
+                val updatedNodes = staleTasks.map { node ->
                     node.copy(
                         status = TaskState.SOMEDAY.storageKey,
                         postponeCount = node.postponeCount + 1,
                         updatedAt = Clock.System.now().toEpochMilliseconds(),
-                    ),
-                )
+                    )
+                }
+                repository.updateNodes(updatedNodes)
             }
         }
     }
+
 
     fun addNode(
         title: String,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
@@ -56,7 +56,7 @@ class NodeCommands(
                     node.copy(
                         status = TaskState.SOMEDAY.storageKey,
                         postponeCount = node.postponeCount + 1,
-                        updatedAt = Clock.System.now().toEpochMilliseconds(),
+                        updatedAt = now.toEpochMilliseconds(),
                     )
                 }
                 repository.updateNodes(updatedNodes)

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeNodeDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeNodeDao.kt
@@ -58,8 +58,13 @@ class FakeNodeDao : NodeDao {
         return nodesFlow.map { it.filter { node -> node.areaId == areaId && node.type == "project" && node.status != "archived" } }
     }
 
+
     override suspend fun getNodeById(id: Long): NodeEntity? {
         return nodes.find { it.id == id }
+    }
+
+    override suspend fun getNodesByIds(ids: List<Long>): List<NodeEntity> {
+        return nodes.filter { it.id in ids }
     }
 
     override suspend fun insertNode(node: NodeEntity): Long {
@@ -81,10 +86,25 @@ class FakeNodeDao : NodeDao {
         return nodes.map { insertNode(it) }
     }
 
+
     override suspend fun updateNode(node: NodeEntity) {
         val index = nodes.indexOfFirst { it.id == node.id }
         if (index != -1) {
             nodes[index] = node
+            nodesFlow.value = nodes.toList()
+        }
+    }
+
+    override suspend fun updateNodes(updatedNodes: List<NodeEntity>) {
+        var changed = false
+        updatedNodes.forEach { node ->
+            val index = nodes.indexOfFirst { it.id == node.id }
+            if (index != -1) {
+                nodes[index] = node
+                changed = true
+            }
+        }
+        if (changed) {
             nodesFlow.value = nodes.toList()
         }
     }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/RepositoryDelegationTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/RepositoryDelegationTest.kt
@@ -64,7 +64,9 @@ class RepositoryDelegationTest {
 
         override fun getNodesByArea(areaId: Long): Flow<List<NodeEntity>> = flowOf(emptyList())
 
+
         override suspend fun getNodeById(id: Long): NodeEntity? = null
+        override suspend fun getNodesByIds(ids: List<Long>): List<NodeEntity> = emptyList()
 
         override suspend fun insertNode(node: NodeEntity): Long = 0L
 
@@ -73,8 +75,10 @@ class RepositoryDelegationTest {
         override suspend fun updateNode(node: NodeEntity) {
         }
 
+
         override suspend fun deleteNode(node: NodeEntity) {
         }
+        override suspend fun updateNodes(nodes: List<NodeEntity>) {}
 
         override suspend fun pinToToday(pin: TodayPinEntity) {
         }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/MainViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/MainViewModelTest.kt
@@ -85,7 +85,9 @@ class MainViewModelTest {
 
         override fun getNodesByProject(projectId: Long): Flow<List<NodeEntity>> = flowOf(emptyList())
 
+
         override suspend fun getNodeById(id: Long): NodeEntity? = null
+        override suspend fun getNodesByIds(ids: List<Long>): List<NodeEntity> = emptyList()
 
         override suspend fun insertNode(node: NodeEntity): Long = 0
 
@@ -94,8 +96,10 @@ class MainViewModelTest {
         override suspend fun updateNode(node: NodeEntity) {
         }
 
+
         override suspend fun deleteNode(node: NodeEntity) {
         }
+        override suspend fun updateNodes(nodes: List<NodeEntity>) {}
 
         override suspend fun pinToToday(pin: TodayPinEntity) {
         }


### PR DESCRIPTION
This PR optimizes the `sweepStaleTasks` function by processing node updates in a batch rather than executing individual database queries for each stale task. 

It introduces a new `updateNodes` batch method to the `NodeDao` and a corresponding method in `AppRepository`. The repository implementation explicitly fetches the old state of the updated nodes and ensures that critical side-effects, such as event logging, facet syncing, and relationship updates, are preserved and correctly triggered during the batch processing. This significantly reduces database overhead while maintaining full data integrity and application behavior. All tests have been updated to support the new batch retrieval and update signatures and pass successfully.

---
*PR created automatically by Jules for task [7339502476059856374](https://jules.google.com/task/7339502476059856374) started by @tajemniktv*