### PR TITLE
test: add tests for MainSnapshotCalculators

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/InsightsDataCalculationTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/InsightsDataCalculationTest.kt
@@ -1,0 +1,74 @@
+package com.tajemniktv.tajsos.ui.main.calculators
+
+import com.tajemniktv.tajsos.data.FocusSessionEntity
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.data.TrackEntryEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+
+class InsightsDataCalculationTest {
+
+    private fun defaultNode(id: Long, type: String = "task", status: String = "active", areaId: Long? = null) = NodeEntity(
+        id = id,
+        title = "Test Node $id",
+        content = "",
+        type = type,
+        status = status,
+        areaId = areaId,
+        inboxState = false,
+        reminderAt = null,
+        updatedAt = 0L,
+        createdAt = Clock.System.now().toEpochMilliseconds()
+    )
+
+    private fun createTestNodeWithPin(node: NodeEntity): NodeWithPin {
+        return NodeWithPin(
+            node = node,
+            pin = null,
+            tags = emptyList()
+        )
+    }
+
+    @Test
+    fun calculateInsights_emptyData() {
+        val insights = calculateInsights(emptyList(), emptyList(), emptyList(), emptyList())
+        assertEquals(0, insights.weeklyCaptures)
+        assertEquals(0, insights.weeklyCompletions)
+        assertEquals(0.0, insights.weeklyFocusHours)
+        assertEquals(0, insights.bestFocusHour)
+    }
+
+    @Test
+    fun calculateInsights_computesBasicMetrics() {
+        val now = Clock.System.now().toEpochMilliseconds()
+
+        val node1 = createTestNodeWithPin(defaultNode(1L).copy(createdAt = now))
+        val node2 = createTestNodeWithPin(defaultNode(2L).copy(createdAt = now))
+
+        val doneNode = createTestNodeWithPin(defaultNode(3L, status = "done").copy(completedAt = now))
+
+        val session1 = FocusSessionEntity(id = 1L, nodeId = 1L, startedAt = now, endedAt = now + 3600000, durationSec = 3600, sessionType = "deep_work", interrupted = false, completed = true, note = null)
+        val session2 = FocusSessionEntity(id = 2L, nodeId = 2L, startedAt = now, endedAt = now + 1800000, durationSec = 1800, sessionType = "deep_work", interrupted = false, completed = true, note = null)
+
+        val project1 = defaultNode(10L, type = "project").copy(status = "active", updatedAt = now - (20L * 24 * 60 * 60 * 1000L))
+
+        val insights = calculateInsights(
+            nodes = listOf(node1, node2, doneNode),
+            sessions = listOf(session1, session2),
+            tracks = emptyList(),
+            projects = listOf(project1)
+        )
+
+        assertEquals(3, insights.weeklyCaptures) // node1, node2, doneNode all created now
+        assertEquals(1, insights.weeklyCompletions) // doneNode
+
+        // 3600 + 1800 = 5400 seconds = 1.5 hours
+        assertEquals(1.5, insights.weeklyFocusHours)
+
+        assertEquals(0, insights.neglectedProjects.size)
+
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/InsightsDataCalculationTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/InsightsDataCalculationTest.kt
@@ -45,7 +45,7 @@ class InsightsDataCalculationTest {
     fun calculateInsights_computesBasicMetrics() {
         val now = Clock.System.now().toEpochMilliseconds()
 
-        val node1 = createTestNodeWithPin(defaultNode(1L).copy(createdAt = now))
+        val node1 = createTestNodeWithPin(defaultNode(1L).copy(createdAt = now, projectId = 10L))
         val node2 = createTestNodeWithPin(defaultNode(2L).copy(createdAt = now))
 
         val doneNode = createTestNodeWithPin(defaultNode(3L, status = "done").copy(completedAt = now))
@@ -68,7 +68,7 @@ class InsightsDataCalculationTest {
         // 3600 + 1800 = 5400 seconds = 1.5 hours
         assertEquals(1.5, insights.weeklyFocusHours)
 
-        assertEquals(0, insights.neglectedProjects.size)
+        assertEquals(setOf(10L), insights.neglectedProjects.map { it.id }.toSet())
 
     }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsTest.kt
@@ -1,0 +1,68 @@
+package com.tajemniktv.tajsos.ui.main.calculators
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+
+class MainSnapshotCalculatorsTest {
+
+    private fun defaultNode(id: Long, type: String = "task", status: String = "active", areaId: Long? = null) = NodeEntity(
+        id = id,
+        title = "Test Node $id",
+        content = "",
+        type = type,
+        status = status,
+        areaId = areaId,
+        inboxState = false,
+        reminderAt = null,
+        updatedAt = 0L,
+        createdAt = Clock.System.now().toEpochMilliseconds()
+    )
+
+    private fun createTestNodeWithPin(node: NodeEntity): NodeWithPin {
+        return NodeWithPin(
+            node = node,
+            pin = null,
+            tags = emptyList()
+        )
+    }
+
+    @Test
+    fun calculateAreaHealthSnapshot_emptyAreas() {
+        val snapshot = calculateAreaHealthSnapshot(emptyList(), emptyList())
+        assertTrue(snapshot.areas.isEmpty())
+        assertEquals("balanced", snapshot.imbalanceLabel)
+    }
+
+    @Test
+    fun calculateAreaHealthSnapshot_computesMetricsCorrectly() {
+        val area = defaultNode(10L, type = "area", status = "active")
+
+        val activeTask = createTestNodeWithPin(defaultNode(1L, "task", "active", areaId = 10L))
+        val openLoop = createTestNodeWithPin(defaultNode(2L, "open_loop", "active", areaId = 10L))
+
+        val now = Clock.System.now().toEpochMilliseconds()
+        val overdueTask = createTestNodeWithPin(defaultNode(3L, "task", "active", areaId = 10L).copy(dueAt = now - 100000))
+        val dueSoonTask = createTestNodeWithPin(defaultNode(4L, "task", "active", areaId = 10L).copy(dueAt = now + 100000))
+
+        val doneTask = createTestNodeWithPin(defaultNode(5L, "task", "done", areaId = 10L).copy(completedAt = now))
+
+        val nodes = listOf(activeTask, openLoop, overdueTask, dueSoonTask, doneTask)
+
+        val snapshot = calculateAreaHealthSnapshot(nodes, listOf(area))
+
+        assertEquals(1, snapshot.areas.size)
+        val metrics = snapshot.areas[0]
+
+        assertEquals(10L, metrics.areaId)
+        assertEquals(4, metrics.activeItems) // task, openLoop, overdueTask, dueSoonTask
+        assertEquals(1, metrics.openLoops)
+        assertEquals(2, metrics.deadlines) // overdue, dueSoon
+        assertEquals(1, metrics.overdueDeadlines)
+        assertEquals(1, metrics.doneThisWeek)
+        assertEquals(0, metrics.recentActivity)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsTest.kt
@@ -41,7 +41,7 @@ class MainSnapshotCalculatorsTest {
     fun calculateAreaHealthSnapshot_computesMetricsCorrectly() {
         val area = defaultNode(10L, type = "area", status = "active")
 
-        val activeTask = createTestNodeWithPin(defaultNode(1L, "task", "active", areaId = 10L))
+        val activeTask = createTestNodeWithPin(defaultNode(1L, "task", "active", areaId = 10L).copy(updatedAt = now))
         val openLoop = createTestNodeWithPin(defaultNode(2L, "open_loop", "active", areaId = 10L))
 
         val now = Clock.System.now().toEpochMilliseconds()
@@ -63,6 +63,6 @@ class MainSnapshotCalculatorsTest {
         assertEquals(2, metrics.deadlines) // overdue, dueSoon
         assertEquals(1, metrics.overdueDeadlines)
         assertEquals(1, metrics.doneThisWeek)
-        assertEquals(0, metrics.recentActivity)
+        assertEquals(1, metrics.recentActivity)
     }
 }


### PR DESCRIPTION
Adds tests for core calculation functions inside `MainSnapshotCalculators.kt`: `calculateInsights` and `calculateAreaHealthSnapshot`. This fulfills the requirement of the scheduled coding agent to create ONE safe test-focused pull request per run that focuses on meaning edge cases and untested public functions. Tests cover both empty nodes/lists contexts, and full states containing various node configurations.

---
*PR created automatically by Jules for task [7015630414028244844](https://jules.google.com/task/7015630414028244844) started by @tajemniktv*