### PR TITLE
fix(ui): remove solid card borders and adjust surface colors per design system

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
@@ -31,7 +31,6 @@ fun DashCard(
         modifier = modifier,
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
         content = content,
     )
 }
@@ -47,7 +46,7 @@ fun TactileCard(
             modifier
                 .fillMaxWidth()
                 .background(TajsOSTheme.CardSurface, RoundedCornerShape(TajsOSTheme.RadiusMd))
-                .border(1.dp, TajsOSTheme.GhostBorder, RoundedCornerShape(TajsOSTheme.RadiusMd))
+
                 .then(
                     if (onClick != null) {
                         Modifier.mouseClickable(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/theme/Theme.kt
@@ -108,10 +108,10 @@ object TajsOSTheme {
     val ScreenCanvas: Color get() = currentColors.surfaceLowest
 
     /** Surface color for standard cards. */
-    val CardSurface: Color get() = currentColors.surface
+    val CardSurface: Color get() = currentColors.surfaceLow
 
     /** Surface color for nested cards. */
-    val CardNestedSurface: Color get() = currentColors.surfaceLow
+    val CardNestedSurface: Color get() = currentColors.surfaceHighest
 
     /** Stroke color for cards. */
     val CardStroke: Color get() = currentColors.ghostBorder.copy(alpha = 0.55f)


### PR DESCRIPTION
Removes 1px solid borders from PrimitiveCards and adjusts CardSurface colors to align with the 'No-Line' and 'Surface Hierarchy' rules defined in DESIGN.md.

---
*PR created automatically by Jules for task [2444834048199620560](https://jules.google.com/task/2444834048199620560) started by @tajemniktv*