### PR TITLE
fix(desktop): move data and preference files to standard OS app data directories

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/tajemniktv/tajsos/main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tajemniktv/tajsos/main.kt
@@ -22,6 +22,8 @@ import androidx.datastore.preferences.core.emptyPreferences
 import com.tajemniktv.tajsos.data.DesktopWindowStartupMode
 import com.tajemniktv.tajsos.data.PreferencesRepository
 import com.tajemniktv.tajsos.data.createDatabase
+import com.tajemniktv.tajsos.utils.AppDirs
+
 import com.tajemniktv.tajsos.di.SharedModule
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
@@ -47,7 +49,7 @@ fun main() =
         val dataStore =
             PreferenceDataStoreFactory.create(
                 corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
-                produceFile = { File(System.getProperty("user.home"), "tajsos.preferences_pb") },
+                produceFile = { File(AppDirs.getAppDataDir(), "tajsos.preferences_pb") },
             )
 
         val sharedModule = SharedModule(database, dataStore)

--- a/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
+++ b/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
@@ -7,9 +7,10 @@ package com.tajemniktv.tajsos.data
 import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import java.io.File
+import com.tajemniktv.tajsos.utils.AppDirs
 
 fun createDatabase(): AppDatabase {
-    val dbFile = File(System.getProperty("user.home"), "tajsos.db")
+    val dbFile = File(AppDirs.getAppDataDir(), "tajsos.db")
     return Room
         .databaseBuilder<AppDatabase>(
             name = dbFile.absolutePath,

--- a/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/utils/AppDirs.kt
+++ b/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/utils/AppDirs.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Grzegorz Kaczmarski (TajemnikTV) 2026. All rights reserved.
+ */
+
+package com.tajemniktv.tajsos.utils
+
+import java.io.File
+
+object AppDirs {
+    fun getAppDataDir(): File {
+        val os = System.getProperty("os.name").lowercase()
+        val userHome = System.getProperty("user.home")
+
+        val appDataPath = when {
+            os.contains("win") -> {
+                System.getenv("APPDATA") ?: "$userHome\\AppData\\Roaming"
+            }
+            os.contains("mac") -> {
+                "$userHome/Library/Application Support"
+            }
+            else -> { // Linux and others
+                val xdgDataHome = System.getenv("XDG_DATA_HOME")
+                if (!xdgDataHome.isNullOrEmpty()) {
+                    xdgDataHome
+                } else {
+                    "$userHome/.local/share"
+                }
+            }
+        }
+
+        val appDir = File(appDataPath, "TajsOS")
+        if (!appDir.exists()) {
+            appDir.mkdirs()
+        }
+        return appDir
+    }
+}


### PR DESCRIPTION
This reliability-focused pull request moves the storage locations of the Desktop application's database (`tajsos.db`) and preferences file (`tajsos.preferences_pb`) from the root of the user's home directory (`~`) to standard OS-specific application data directories (e.g., `%APPDATA%` on Windows, `~/Library/Application Support` on macOS, and `$XDG_DATA_HOME` or `~/.local/share` on Linux).

**Benefits:**
- **Reliability:** Prevents application state loss resulting from users accidentally deleting or modifying files in their cluttered root directory.
- **Predictability:** Complies with standard filesystem conventions across Windows, Linux, and macOS platforms.
- **Cleanliness:** Avoids polluting the user's home directory.

---
*PR created automatically by Jules for task [13620905595399196318](https://jules.google.com/task/13620905595399196318) started by @tajemniktv*