### PR TITLE
perf: Batch DAO operations instead of forEach

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -508,6 +508,12 @@ interface ItemDomainDao {
     @Upsert
     suspend fun upsertDomain(domain: ItemDomainEntity)
 
+    /**
+     * Upserts a list of item domains. Useful for batch updating domain metadata for a node.
+     */
+    @Upsert
+    suspend fun upsertDomains(domains: List<ItemDomainEntity>)
+
     @Query("DELETE FROM item_domains WHERE itemId = :itemId AND domainKey = :domainKey")
     suspend fun deleteDomain(
         itemId: Long,
@@ -847,6 +853,12 @@ interface DecisionDao {
 
     @Update
     suspend fun updateDecisionOption(option: DecisionOptionEntity)
+
+    /**
+     * Updates multiple decision options at once. Useful for batch updating option states.
+     */
+    @Update
+    suspend fun updateDecisionOptions(options: List<DecisionOptionEntity>)
 
     @Delete
     suspend fun deleteDecisionOption(option: DecisionOptionEntity)

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -751,6 +751,23 @@ class AppRepository(
         }
     }
 
+    private suspend fun updateDecisionOptionsBatch(
+        options: List<DecisionOptionEntity>,
+        selectedOptionId: Long?
+    ) {
+        val updatedOptions = options.mapNotNull { option ->
+            val isSelected = option.id == selectedOptionId
+            if (option.isSelected != isSelected) {
+                option.copy(isSelected = isSelected)
+            } else {
+                null
+            }
+        }
+        if (updatedOptions.isNotEmpty()) {
+            decisionDao.updateDecisionOptions(updatedOptions)
+        }
+    }
+
     private suspend fun executeNodeSideEffects(oldNode: NodeEntity, node: NodeEntity) {
         if (oldNode.status != node.status) {
             when (node.status)
@@ -1554,18 +1571,7 @@ class AppRepository(
         val node = nodeDao.getNodeById(nodeId) ?: return
         val options = decisionDao.getOptionsForDecision(nodeId).first()
 
-        val updatedOptions = options.mapNotNull { option ->
-            if (option.id == selectedOptionId && !option.isSelected) {
-                option.copy(isSelected = true)
-            } else if (option.id != selectedOptionId && option.isSelected) {
-                option.copy(isSelected = false)
-            } else {
-                null
-            }
-        }
-        if (updatedOptions.isNotEmpty()) {
-            decisionDao.updateDecisionOptions(updatedOptions)
-        }
+        updateDecisionOptionsBatch(options, selectedOptionId)
 
         nodeDao.updateNode(
             node.copy(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -617,7 +617,7 @@ class AppRepository(
                 isPrimary = index == 0,
             )
         }
-        itemDomainDao.upsertDomains(domainEntities)
+        if (domainEntities.isNotEmpty()) itemDomainDao.upsertDomains(domainEntities)
         if (kind == ItemKind.RECORD) {
             recordFacetDao.upsertRecordFacet(
                 RecordFacetEntity(
@@ -934,7 +934,7 @@ class AppRepository(
                 isPrimary = index == 0,
             )
         }
-        itemDomainDao.upsertDomains(domainEntities)
+        if (domainEntities.isNotEmpty()) itemDomainDao.upsertDomains(domainEntities)
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -115,6 +115,7 @@ private object NoOpItemDomainDao : ItemDomainDao {
     override fun getDomainsForItem(itemId: Long): Flow<List<ItemDomainEntity>> = flowOf(emptyList())
 
     override suspend fun upsertDomain(domain: ItemDomainEntity) = Unit
+    override suspend fun upsertDomains(domains: List<ItemDomainEntity>) = Unit
 
     override suspend fun deleteDomain(
         itemId: Long,
@@ -609,13 +610,14 @@ class AppRepository(
             }
 
         val id = insertNode(node)
-        domains.forEachIndexed { index, domain ->
-            assignDomainToItem(
+        val domainEntities = domains.mapIndexed { index, domain ->
+            ItemDomainEntity(
                 itemId = id,
-                domain = domain,
+                domainKey = domain.name,
                 isPrimary = index == 0,
             )
         }
+        itemDomainDao.upsertDomains(domainEntities)
         if (kind == ItemKind.RECORD) {
             recordFacetDao.upsertRecordFacet(
                 RecordFacetEntity(
@@ -908,15 +910,14 @@ class AppRepository(
     private suspend fun syncDomainsFromNodeMetadata(node: NodeEntity) {
         val associatedDomains = node.areaMetadataOrNull()?.associatedDomains ?: return
         itemDomainDao.deleteDomainsForItem(node.id)
-        associatedDomains.forEachIndexed { index, domain ->
-            itemDomainDao.upsertDomain(
-                ItemDomainEntity(
-                    itemId = node.id,
-                    domainKey = domain.name,
-                    isPrimary = index == 0,
-                ),
+        val domainEntities = associatedDomains.mapIndexed { index, domain ->
+            ItemDomainEntity(
+                itemId = node.id,
+                domainKey = domain.name,
+                isPrimary = index == 0,
             )
         }
+        itemDomainDao.upsertDomains(domainEntities)
     }
 
     /**
@@ -1553,12 +1554,17 @@ class AppRepository(
         val node = nodeDao.getNodeById(nodeId) ?: return
         val options = decisionDao.getOptionsForDecision(nodeId).first()
 
-        options.forEach { option ->
-            if (option.id == selectedOptionId) {
-                decisionDao.updateDecisionOption(option.copy(isSelected = true))
-            } else if (option.isSelected) {
-                decisionDao.updateDecisionOption(option.copy(isSelected = false))
+        val updatedOptions = options.mapNotNull { option ->
+            if (option.id == selectedOptionId && !option.isSelected) {
+                option.copy(isSelected = true)
+            } else if (option.id != selectedOptionId && option.isSelected) {
+                option.copy(isSelected = false)
+            } else {
+                null
             }
+        }
+        if (updatedOptions.isNotEmpty()) {
+            decisionDao.updateDecisionOptions(updatedOptions)
         }
 
         nodeDao.updateNode(

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeDecisionDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeDecisionDao.kt
@@ -26,6 +26,10 @@ class FakeDecisionDao : DecisionDao {
         return newId
     }
 
+    override suspend fun updateDecisionOptions(options: List<DecisionOptionEntity>) {
+        options.forEach { updateDecisionOption(it) }
+    }
+
     override suspend fun updateDecisionOption(option: DecisionOptionEntity) {
         optionsFlow.value =
             optionsFlow.value.map {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeDecisionDao.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeDecisionDao.kt
@@ -27,7 +27,14 @@ class FakeDecisionDao : DecisionDao {
     }
 
     override suspend fun updateDecisionOptions(options: List<DecisionOptionEntity>) {
-        options.forEach { updateDecisionOption(it) }
+        val current = optionsFlow.value.toMutableList()
+        options.forEach { option ->
+            val index = current.indexOfFirst { it.id == option.id }
+            if (index >= 0) {
+                current[index] = option
+            }
+        }
+        optionsFlow.value = current
     }
 
     override suspend fun updateDecisionOption(option: DecisionOptionEntity) {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeLifeObjectDaos.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeLifeObjectDaos.kt
@@ -186,6 +186,10 @@ class FakeItemDomainDao : ItemDomainDao {
     override fun getDomainsForItem(itemId: Long): Flow<List<ItemDomainEntity>> =
         domainsFlow.map { list -> list.filter { it.itemId == itemId } }
 
+    override suspend fun upsertDomains(domains: List<ItemDomainEntity>) {
+        domains.forEach { upsertDomain(it) }
+    }
+
     override suspend fun upsertDomain(domain: ItemDomainEntity) {
         val index =
             domains.indexOfFirst { it.itemId == domain.itemId && it.domainKey == domain.domainKey }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeLifeObjectDaos.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeLifeObjectDaos.kt
@@ -187,7 +187,20 @@ class FakeItemDomainDao : ItemDomainDao {
         domainsFlow.map { list -> list.filter { it.itemId == itemId } }
 
     override suspend fun upsertDomains(domains: List<ItemDomainEntity>) {
-        domains.forEach { upsertDomain(it) }
+        val updated = this.domains.toMutableList()
+        domains.forEach { domain ->
+            val index = updated.indexOfFirst {
+                it.itemId == domain.itemId && it.domainKey == domain.domainKey
+            }
+            if (index >= 0) {
+                updated[index] = domain
+            } else {
+                updated += domain
+            }
+        }
+        this.domains.clear()
+        this.domains.addAll(updated)
+        domainsFlow.value = this.domains.toList()
     }
 
     override suspend fun upsertDomain(domain: ItemDomainEntity) {


### PR DESCRIPTION
Identified sequential DAO operations being called inside forEach loops. Converted logic to batch operations using Room @Upsert and @Update. Added relevant DAOs and Fake DAOs. Included KDocs to the code.

---
*PR created automatically by Jules for task [3421227755906945880](https://jules.google.com/task/3421227755906945880) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch Room DAO writes to cut DB round trips when assigning domains and updating decision option selection. Replaces per-item loops with bulk `@Upsert`/`@Update` and only persists changed rows.

- **Refactors**
  - Added DAO batch methods: `ItemDomainDao.upsertDomains(List<ItemDomainEntity>)` and `DecisionDao.updateDecisionOptions(List<DecisionOptionEntity>)`.
  - Repository now batches domain writes on node create and metadata sync; decision option selection uses a helper to update only changed rows in one call.
  - Implemented `upsertDomains` in `NoOpItemDomainDao`; updated `FakeItemDomainDao` and `FakeDecisionDao` to support the new batch methods.

<sup>Written for commit d4a1a320cb9b2587ebc560be266fbbd7fe977a93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

