### PR TITLE
test: Add local timezone parsing test for ICS events

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsEventBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsEventBuilderTest.kt
@@ -63,6 +63,14 @@ class IcsEventBuilderTest {
         assertEquals(Instant.parse("2023-10-24T00:00:00Z"), instant)
     }
 
+    /**
+     * Regression test verifying that ISO date parsing respects local timezone (Europe/London)
+     * across DST boundaries. This test uses 2023-10-24, which is before the DST shift to GMT
+     * (DST ends on the last Sunday of October). The expected result correctly applies the BST
+     * offset (UTC+1), converting local 10:00:00 BST to 09:00:00 UTC. This guards against
+     * incorrect offset handling that could misapply timezone rules when local timezone parsing
+     * was introduced.
+     */
     @Test
     fun testParseIsoDateLocalTimeZone() {
         val builder = IcsEventBuilder()

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsEventBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsEventBuilderTest.kt
@@ -64,6 +64,17 @@ class IcsEventBuilderTest {
     }
 
     @Test
+    fun testParseIsoDateLocalTimeZone() {
+        val builder = IcsEventBuilder()
+        val prop = IcsDateProperty("20231024T100000", "DTSTART;TZID=Europe/London")
+        val instant = builder.parseIsoDate(prop)
+        // Europe/London is UTC+1 in October (BST) until last Sunday,
+        // 2023-10-24 is Tuesday, so it's UTC+1.
+        // Local 10:00:00 -> UTC 09:00:00
+        assertEquals(Instant.parse("2023-10-24T09:00:00Z"), instant)
+    }
+
+    @Test
     fun testParseIsoDateUtc() {
         val builder = IcsEventBuilder()
         val prop = IcsDateProperty("20231024T100000Z", "DTSTART")


### PR DESCRIPTION
This PR adds a unit test for the `parseIsoDate` method in `IcsEventBuilder`. The test verifies that an ICS event with an ISO date lacking a `Z` suffix is properly interpreted in the context of its specified local time zone (`Europe/London`). The date mapping from the test ensures that local time resolves to the correct UTC instant, improving overall test coverage for edge cases involving date-time timezone offsets in external calendar sources.

---
*PR created automatically by Jules for task [13990328041637196251](https://jules.google.com/task/13990328041637196251) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression unit test for `IcsEventBuilder.parseIsoDate` to ensure ISO dates without `Z` and with `TZID=Europe/London` resolve to the correct UTC instant across DST. Verifies 2023-10-24 10:00 BST → 2023-10-24T09:00:00Z and includes minor test cleanups from review.

<sup>Written for commit bc1f00151a34b22d316fa600e950c0cda01fdd6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

