### PR TITLE
docs: fix starlight blog and video markdown content imports

### DIFF
--- a/website/src/components/MarkdownContent.astro
+++ b/website/src/components/MarkdownContent.astro
@@ -1,6 +1,6 @@
 ---
-import BlogMarkdownContent from 'starlight-blog/components/MarkdownContent.astro';
-import VideosMarkdownContent from 'starlight-videos/components/MarkdownContent.astro';
+import BlogMarkdownContent from 'starlight-blog/overrides/MarkdownContent.astro';
+import VideosMarkdownContent from 'starlight-videos/overrides/MarkdownContent.astro';
 
 const props = Astro.props;
 ---


### PR DESCRIPTION
Updates the import paths in `website/src/components/MarkdownContent.astro` to correctly point to `starlight-blog/overrides/MarkdownContent.astro` and `starlight-videos/overrides/MarkdownContent.astro`, resolving Astro build warnings and correctly overriding the components.

---
*PR created automatically by Jules for task [9984245321859008473](https://jules.google.com/task/9984245321859008473) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MarkdownContent imports to use `starlight-blog/overrides/MarkdownContent.astro` and `starlight-videos/overrides/MarkdownContent.astro` in the website. This removes Astro build warnings and ensures our overrides are applied.

<sup>Written for commit 93642e8b0fa87bf42373c7a7de7382edccadda45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

