### PR TITLE
docs: Add missing KDoc for ItemDomainDao and NoOpItemDomainDao

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -499,24 +499,67 @@ interface RecordFacetDao {
  */
 @Dao
 interface ItemDomainDao {
+    /**
+     * Retrieves a continuous stream of all domain associations across all life objects.
+     *
+     * This stream emits every domain relation currently stored in the table.
+     *
+     * @return A Flow emitting a list of all [ItemDomainEntity] objects.
+     */
     @Query("SELECT * FROM item_domains")
     fun getAllItemDomains(): Flow<List<ItemDomainEntity>>
 
+    /**
+     * Retrieves a stream of domain associations for a specific life object.
+     *
+     * The results are ordered such that primary domains appear first, followed by
+     * chronologically older assignments.
+     *
+     * @param itemId The unique identifier of the life object.
+     * @return A Flow emitting a list of [ItemDomainEntity] objects associated with the item.
+     */
     @Query("SELECT * FROM item_domains WHERE itemId = :itemId ORDER BY isPrimary DESC, assignedAt ASC")
     fun getDomainsForItem(itemId: Long): Flow<List<ItemDomainEntity>>
 
+    /**
+     * Inserts a new domain association or updates an existing one if a conflict occurs.
+     *
+     * @param domain The [ItemDomainEntity] to be inserted or updated.
+     */
     @Upsert
     suspend fun upsertDomain(domain: ItemDomainEntity)
 
+    /**
+     * Deletes a specific domain association for a life object.
+     *
+     * @param itemId The unique identifier of the life object.
+     * @param domainKey The string key of the domain (e.g., "FINANCES") to be removed.
+     */
     @Query("DELETE FROM item_domains WHERE itemId = :itemId AND domainKey = :domainKey")
     suspend fun deleteDomain(
         itemId: Long,
         domainKey: String,
     )
 
+    /**
+     * Removes all explicit domain associations for a specific life object.
+     *
+     * Used primarily when an item is permanently deleted from the system or when clearing all
+     * explicitly assigned domains.
+     *
+     * @param itemId The unique identifier of the life object.
+     */
     @Query("DELETE FROM item_domains WHERE itemId = :itemId")
     suspend fun deleteDomainsForItem(itemId: Long)
 
+    /**
+     * Clears the `isPrimary` flag for all domains associated with a specific life object.
+     *
+     * This ensures no existing domain is marked as primary before assigning a new primary domain,
+     * maintaining the invariant of having at most one primary domain per item.
+     *
+     * @param itemId The unique identifier of the life object.
+     */
     @Query("UPDATE item_domains SET isPrimary = 0 WHERE itemId = :itemId")
     suspend fun clearPrimaryFlag(itemId: Long)
 }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -513,7 +513,7 @@ interface ItemDomainDao {
      * Retrieves a stream of domain associations for a specific life object.
      *
      * The results are ordered such that primary domains appear first, followed by
-     * chronologically older assignments.
+     * remaining domains ordered chronologically from oldest to newest assignment.
      *
      * @param itemId The unique identifier of the life object.
      * @return A Flow emitting a list of [ItemDomainEntity] objects associated with the item.

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -110,19 +110,37 @@ private object NoOpRecordFacetDao : RecordFacetDao {
  * Fallback, no-operation implementation for [ItemDomainDao] used when the actual DAO is unavailable or uninitialized.
  */
 private object NoOpItemDomainDao : ItemDomainDao {
+    /**
+     * Fallback implementation that emits an empty list of domain associations.
+     */
     override fun getAllItemDomains(): Flow<List<ItemDomainEntity>> = flowOf(emptyList())
 
+    /**
+     * Fallback implementation that emits an empty list of domains for the requested item.
+     */
     override fun getDomainsForItem(itemId: Long): Flow<List<ItemDomainEntity>> = flowOf(emptyList())
 
+    /**
+     * Fallback, no-operation implementation for upserting a domain.
+     */
     override suspend fun upsertDomain(domain: ItemDomainEntity) = Unit
 
+    /**
+     * Fallback, no-operation implementation for deleting a specific domain association.
+     */
     override suspend fun deleteDomain(
         itemId: Long,
         domainKey: String,
     ) = Unit
 
+    /**
+     * Fallback, no-operation implementation for clearing all domain associations for an item.
+     */
     override suspend fun deleteDomainsForItem(itemId: Long) = Unit
 
+    /**
+     * Fallback, no-operation implementation for clearing the primary domain flag.
+     */
     override suspend fun clearPrimaryFlag(itemId: Long) = Unit
 }
 


### PR DESCRIPTION
Adds missing documentation for ItemDomainDao interface and its NoOp implementation in Repository.kt. This resolves missing KDocs for public interfaces/classes/functions.

---
*PR created automatically by Jules for task [12835450771728217165](https://jules.google.com/task/12835450771728217165) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add detailed KDoc for `ItemDomainDao` and `NoOpItemDomainDao` to clarify stream behavior, result ordering, upsert/delete semantics, and primary-flag clearing. Incorporates review feedback with parameter tags and explicit notes on fallback no-op behavior (emits empty lists, no side effects).

<sup>Written for commit a73dc91b269f21df3e28f4a6e82cdcad80ef6ce4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

