### PR TITLE
fix(reliability): handle missing speech recognizer gracefully

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -309,6 +309,7 @@ class MainActivity : FragmentActivity() {
         try {
             speechRecognizerLauncher.launch(intent)
         } catch (e: ActivityNotFoundException) {
+            Log.w(TAG, "Speech recognizer not available", e)
             // Speech recognizer not available
         }
     }

--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -10,6 +10,7 @@ import android.os.BadParcelableException
 import android.os.Build
 import android.os.Bundle
 import android.os.ParcelFormatException
+import android.content.ActivityNotFoundException
 import android.speech.RecognizerIntent
 import android.util.Log
 import android.security.keystore.KeyGenParameterSpec
@@ -307,7 +308,7 @@ class MainActivity : FragmentActivity() {
             }
         try {
             speechRecognizerLauncher.launch(intent)
-        } catch (e: Exception) {
+        } catch (e: ActivityNotFoundException) {
             // Speech recognizer not available
         }
     }


### PR DESCRIPTION
Catches ActivityNotFoundException specifically when triggering voice capture instead of a generic Exception.

---
*PR created automatically by Jules for task [7214245557891388922](https://jules.google.com/task/7214245557891388922) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Catch `ActivityNotFoundException` when launching voice capture and log a warning, preventing crashes on devices without speech recognition support.

<sup>Written for commit 1bb7eb807ed220c947ad55e83aa7bbb973f7651e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

