### PR TITLE
fix(ui): update shapes for cards and modules according to DESIGN.md

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AlertCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AlertCards.kt
@@ -4,7 +4,6 @@
 
 package com.tajemniktv.tajsos.ui.components.cards
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -50,8 +49,7 @@ fun AlertCard(
         onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         color = color.copy(alpha = 0.05f),
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Row(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AreaCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AreaCards.kt
@@ -31,7 +31,7 @@ fun AreaHealthOverviewCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DashboardCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DashboardCards.kt
@@ -5,7 +5,6 @@
 package com.tajemniktv.tajsos.ui.components.cards
 
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -68,8 +67,7 @@ fun StickyNoteCard(
         onClick = onClick,
         modifier = modifier.width(200.dp),
         color = TajsOSTheme.Accent.copy(alpha = 0.1f),
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(
@@ -412,7 +410,7 @@ fun VaultCard(
         onClick = onClick,
         modifier = modifier,
         color = TajsOSTheme.CardSurface,
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Icon(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/GeneralCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/GeneralCards.kt
@@ -49,11 +49,11 @@ fun InfoCard(
         onClick = onClick,
         modifier =
             modifier.glassChrome(
-                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                 material = GlassMaterial.REGULAR,
             ),
         color = glassContainerColor(TajsOSTheme.Surface),
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Row(
@@ -97,11 +97,11 @@ fun StatusCard(
         onClick = onClick,
         modifier =
             modifier.fillMaxWidth().glassChrome(
-                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                 material = GlassMaterial.REGULAR,
             ),
         color = glassContainerColor(TajsOSTheme.Surface),
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(
@@ -138,11 +138,11 @@ fun LinkedNodeItem(
         onClick = onClick,
         modifier =
             modifier.fillMaxWidth().glassChrome(
-                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                 material = GlassMaterial.REGULAR,
             ),
         color = glassContainerColor(TajsOSTheme.Surface),
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Row(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -196,11 +196,11 @@ fun ConnectionCard(
         onClick = onClick,
         modifier =
             modifier.fillMaxWidth().glassChrome(
-                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                 material = GlassMaterial.THIN,
             ),
         color = glassContainerColor(Color.Transparent),
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Row(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/InsightsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/InsightsCards.kt
@@ -64,7 +64,7 @@ fun AutoReviewCard(review: String) {
         color = TajsOSTheme.Primary.copy(alpha = 0.05f),
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             androidx.compose.foundation.BorderStroke(
                 1.dp,
@@ -93,7 +93,7 @@ fun CompletionCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             androidx.compose.foundation.BorderStroke(
                 1.dp,
@@ -160,7 +160,7 @@ fun FocusInsightCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             androidx.compose.foundation.BorderStroke(
                 1.dp,
@@ -230,7 +230,7 @@ fun EfficiencyCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             androidx.compose.foundation.BorderStroke(
                 1.dp,
@@ -315,7 +315,7 @@ fun VaultInsightCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             androidx.compose.foundation.BorderStroke(
                 1.dp,
@@ -374,7 +374,7 @@ fun AdvancedSystemCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             androidx.compose.foundation.BorderStroke(
                 1.dp,
@@ -443,7 +443,7 @@ fun StateAveragesCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             androidx.compose.foundation.BorderStroke(
                 1.dp,
@@ -482,7 +482,7 @@ fun CorrelationsCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             androidx.compose.foundation.BorderStroke(
                 1.dp,
@@ -600,8 +600,7 @@ fun InsightPatternCard(
         color = color.copy(alpha = 0.05f),
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.GhostBorder),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Row(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -633,7 +632,7 @@ fun AreaHealthSystemCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(
@@ -679,7 +678,6 @@ fun AreaHealthInsightCard(area: AreaHealthMetrics) {
         shape =
             androidx.compose.foundation.shape
                 .RoundedCornerShape(TajsOSTheme.RadiusSm),
-        border = androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.GhostBorder),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/ModuleCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/ModuleCard.kt
@@ -57,7 +57,7 @@ fun ModuleCard(
             modifier
                 .graphicsLayer(scaleX = scale, scaleY = scale)
                 .glassChrome(
-                    shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                    shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                     material = GlassMaterial.REGULAR,
                 ).mouseClickable(
                     interactionSource = interactionSource,
@@ -68,7 +68,7 @@ fun ModuleCard(
                     onSecondaryClick = onClick,
                     middleClickFallbackToPrimary = true,
                 ),
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
         color = glassContainerColor(TajsOSTheme.Surface),
         shadowElevation = 2.dp,
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
@@ -88,7 +88,7 @@ fun NodeCard(
     Surface(
         modifier = modifier.fillMaxWidth(),
         color = Color.Transparent,
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         MouseContextMenuHost(
             state = contextMenuState,
@@ -108,7 +108,7 @@ fun NodeCard(
                         .fillMaxWidth()
                         .graphicsLayer(scaleX = animatedScale, scaleY = animatedScale)
                         .glassChrome(
-                            shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                            shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                             material = GlassMaterial.REGULAR,
                         ).mouseClickable(
                             onClick = onClick,
@@ -117,7 +117,7 @@ fun NodeCard(
                             middleClickFallbackToPrimary = true,
                         ),
                 color = glassContainerColor(TajsOSTheme.Surface),
-                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                 border =
                     BorderStroke(
                         1.dp,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
@@ -95,7 +95,7 @@ fun OpenLoopCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border = BorderStroke(1.dp, urgencyColor.copy(alpha = 0.25f)),
     ) {
         Column(
@@ -226,7 +226,7 @@ fun MaintenanceCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border = BorderStroke(1.dp, urgencyColor.copy(alpha = 0.25f)),
     ) {
         Column(
@@ -346,7 +346,7 @@ fun ProtocolCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),
@@ -405,7 +405,7 @@ fun DistinctionQuestionCard(item: DistinctionQuestionState) {
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             BorderStroke(
                 1.dp,
@@ -444,7 +444,7 @@ fun DirectionCommitmentCard(item: DirectionCommitmentStatus) {
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             BorderStroke(
                 1.dp,
@@ -495,7 +495,7 @@ fun CoreShiftCriterionCard(item: CoreLifeOSShiftItem) {
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             BorderStroke(
                 1.dp,
@@ -569,7 +569,7 @@ fun PersonRelationshipCard(
         color = TajsOSTheme.CardSurface,
         shape =
             androidx.compose.foundation.shape
-                .RoundedCornerShape(TajsOSTheme.RadiusMd),
+                .RoundedCornerShape(TajsOSTheme.RadiusXl),
         border =
             BorderStroke(
                 1.dp,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
@@ -4,7 +4,6 @@
 
 package com.tajemniktv.tajsos.ui.components.cards
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -30,7 +29,7 @@ fun DashCard(
         onClick = onClick,
         modifier = modifier,
         color = TajsOSTheme.CardSurface,
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
         content = content,
     )
 }
@@ -45,7 +44,7 @@ fun TactileCard(
         modifier =
             modifier
                 .fillMaxWidth()
-                .background(TajsOSTheme.CardSurface, RoundedCornerShape(TajsOSTheme.RadiusMd))
+                .background(TajsOSTheme.CardSurface, RoundedCornerShape(TajsOSTheme.RadiusXl))
 
                 .then(
                     if (onClick != null) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/RecoveryCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/RecoveryCards.kt
@@ -4,7 +4,6 @@
 
 package com.tajemniktv.tajsos.ui.components.cards
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -37,8 +36,7 @@ fun BasicSurvivalCard(
         onClick = onClick,
         modifier = modifier,
         color = TajsOSTheme.CardSurface,
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Column(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/SystemOverviewCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/SystemOverviewCards.kt
@@ -165,8 +165,7 @@ fun AreaHealthCard(
         onClick = onClick,
         modifier = modifier.width(190.dp),
         color = TajsOSTheme.CardSurface,
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingMd)) {
             Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/theme/Theme.kt
@@ -186,16 +186,22 @@ object TajsOSTheme {
     val SidebarWidth = 280.dp
 
     /** Extra small corner radius. */
-    val RadiusXs = 2.dp
+    val RadiusXs = 4.dp
 
     /** Small corner radius. */
-    val RadiusSm = 4.dp
+    val RadiusSm = 8.dp
 
     /** Medium corner radius. */
     val RadiusMd = 12.dp
 
     /** Large corner radius. */
     val RadiusLg = 16.dp
+
+    /** Extra large corner radius. */
+    val RadiusXl = 24.dp
+
+    /** 2x extra large corner radius. */
+    val Radius2Xl = 32.dp
 
     /** Extra small spacing. */
     val SpacingXs = 4.dp


### PR DESCRIPTION
This PR updates the Jetpack Compose card and module components to utilize the proper `RadiusXl` styling, in compliance with the newest `DESIGN.md` rules. It ensures that semantic borders (e.g., error indicators, active highlights) are strictly preserved while strictly standardizing corner radii to enhance the `Calm Life Instrument` aesthetic.

---
*PR created automatically by Jules for task [16460241560907701671](https://jules.google.com/task/16460241560907701671) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized card and module shapes to `TajsOSTheme.RadiusXl` to match DESIGN.md and create a consistent rounded look. Also tuned theme radius tokens and removed non-semantic borders to reduce visual noise.

- **Refactors**
  - Replaced `RoundedCornerShape(TajsOSTheme.RadiusMd)` with `RoundedCornerShape(TajsOSTheme.RadiusXl)` across cards and `ModuleCard`.
  - Preserved semantic borders (error/urgency/active); removed decorative `BorderStroke` on lightweight cards.
  - Updated `TajsOSTheme` radii: `RadiusXs` → 4dp, `RadiusSm` → 8dp; added `RadiusXl` (24dp) and `Radius2Xl` (32dp).

<sup>Written for commit 4eb7b85dddf130c3d471ac738e1ac9a1b737a5ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

