### PR TITLE
perf: Optimize list processing with mapNotNull

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksScreen.kt
@@ -45,7 +45,7 @@ fun TasksRoute(
         val allProjects by viewModel.allProjects.collectAsState()
         val allAreas by viewModel.allAreas.collectAsState()
 
-        /** Active task nodes optimally mapped directly to items */
+        // Active task nodes filtered to non-archived task items
         val activeTasks =
             remember(activeNodes) {
                 activeNodes.mapNotNull { item -> item.node.takeIf { it.isTaskItem() && it.status != "archived" } }
@@ -55,7 +55,7 @@ fun TasksRoute(
             remember(archivedNodes) { archivedNodes.mapNotNull { item -> item.node.takeIf { it.isTaskItem() } } }
         /** Set of today's task node IDs, optimally mapped */
         val todayTaskIds =
-            remember(todayNodes) { todayNodes.mapNotNull { item -> item.id.takeIf { item.isTaskItem() } }.toSet() }
+            remember(todayNodes) { todayNodes.mapNotNullTo(mutableSetOf()) { item -> item.id.takeIf { item.isTaskItem() } } }
         val projectById = remember(allProjects) { allProjects.associate { it.id to it.title } }
         val areaById = remember(allAreas) { allAreas.associate { it.id to it.title } }
 

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksScreen.kt
@@ -45,14 +45,17 @@ fun TasksRoute(
         val allProjects by viewModel.allProjects.collectAsState()
         val allAreas by viewModel.allAreas.collectAsState()
 
+        /** Active task nodes optimally mapped directly to items */
         val activeTasks =
             remember(activeNodes) {
-                activeNodes.map { it.node }.filter { it.isTaskItem() && it.status != "archived" }
+                activeNodes.mapNotNull { item -> item.node.takeIf { it.isTaskItem() && it.status != "archived" } }
             }
+        /** Archived task nodes optimally mapped directly to items */
         val archivedTasks =
-            remember(archivedNodes) { archivedNodes.map { it.node }.filter { it.isTaskItem() } }
+            remember(archivedNodes) { archivedNodes.mapNotNull { item -> item.node.takeIf { it.isTaskItem() } } }
+        /** Set of today's task node IDs, optimally mapped */
         val todayTaskIds =
-            remember(todayNodes) { todayNodes.filter { it.isTaskItem() }.map { it.id }.toSet() }
+            remember(todayNodes) { todayNodes.mapNotNull { item -> item.id.takeIf { item.isTaskItem() } }.toSet() }
         val projectById = remember(allProjects) { allProjects.associate { it.id to it.title } }
         val areaById = remember(allAreas) { allAreas.associate { it.id to it.title } }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -222,7 +222,7 @@ class MainViewModel(
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     /**
-     * Flow of all nodes classified as area items. Uses mapNotNull for optimized filtering and mapping.
+     * Flow of all nodes classified as area items, emitting only nodes where [NodeEntity.isAreaItem] is true.
      */
     val allAreas: StateFlow<List<NodeEntity>> =
         allNodes

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -221,9 +221,12 @@ class MainViewModel(
             modes.filter { packs.canUseMode(it.key) }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /**
+     * Flow of all nodes classified as area items. Uses mapNotNull for optimized filtering and mapping.
+     */
     val allAreas: StateFlow<List<NodeEntity>> =
         allNodes
-            .map { nodes -> nodes.map { it.node }.filter { it.isAreaItem() } }
+            .map { nodes -> nodes.mapNotNull { item -> item.node.takeIf { it.isAreaItem() } } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     val activeNodes: StateFlow<List<NodeWithPin>> =
@@ -296,9 +299,12 @@ class MainViewModel(
             .getAllMedications()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /**
+     * Flow of all nodes classified as project items. Uses mapNotNull for optimized filtering and mapping.
+     */
     val allProjects: StateFlow<List<NodeEntity>> =
         allNodes
-            .map { nodes -> nodes.map { it.node }.filter { it.isProjectItem() } }
+            .map { nodes -> nodes.mapNotNull { item -> item.node.takeIf { it.isProjectItem() } } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     val calendarProviders: StateFlow<List<CalendarProviderEntity>> =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -349,7 +349,8 @@ fun calculateInsights(
             hasNotes && !hasTasks
         }
 
-    val areas = nodes.filter { it.node.isAreaItem() }.map { it.node }
+    /** Optimally mapped subset containing only Area items */
+    val areas = nodes.mapNotNull { item -> item.node.takeIf { it.isAreaItem() } }
     val neglectedAreas =
         areas.filter { area ->
             val areaNodes = nodes.filter { it.node.areaId == area.id }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -349,7 +349,7 @@ fun calculateInsights(
             hasNotes && !hasTasks
         }
 
-    /** Optimally mapped subset containing only Area items */
+    // Area nodes used below to detect neglected areas
     val areas = nodes.mapNotNull { item -> item.node.takeIf { it.isAreaItem() } }
     val neglectedAreas =
         areas.filter { area ->

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -283,8 +283,9 @@ suspend fun buildDashboardUIState(
         } else {
             emptyList()
         }
-    val includedAreaIds = areaFilters.filter { it.include }.map { it.areaId }
-    val excludedAreaIds = areaFilters.filter { !it.include }.map { it.areaId }
+    /** Optimally filtered area IDs for inclusion */
+    val includedAreaIds = areaFilters.mapNotNull { filter -> filter.areaId.takeIf { filter.include } }
+    val excludedAreaIds = areaFilters.mapNotNull { filter -> filter.areaId.takeIf { !filter.include } }
 
     var filteredNodes = nodes
     if (mode?.key != "ALL")
@@ -304,8 +305,9 @@ suspend fun buildDashboardUIState(
         } else {
             emptyList()
         }
-    val includedTypes = typeFilters.filter { it.include }.map { it.nodeType }
-    val excludedTypes = typeFilters.filter { !it.include }.map { it.nodeType }
+    /** Optimally filtered type configurations for inclusion */
+    val includedTypes = typeFilters.mapNotNull { filter -> filter.nodeType.takeIf { filter.include } }
+    val excludedTypes = typeFilters.mapNotNull { filter -> filter.nodeType.takeIf { !filter.include } }
 
     if (mode?.key != "ALL")
     { // NON-NLS

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -283,7 +283,7 @@ suspend fun buildDashboardUIState(
         } else {
             emptyList()
         }
-    /** Optimally filtered area IDs for inclusion */
+    // Optimally filtered area IDs for inclusion
     val includedAreaIds = areaFilters.mapNotNull { filter -> filter.areaId.takeIf { filter.include } }
     val excludedAreaIds = areaFilters.mapNotNull { filter -> filter.areaId.takeIf { !filter.include } }
 


### PR DESCRIPTION
Replaced chained `.map { ... }.filter { ... }` operations with `.mapNotNull { ... }` in view models and state assemblers to minimize unnecessary intermediate list allocations during state updates. Added corresponding KDocs per review requirements.

---
*PR created automatically by Jules for task [18051560519993168764](https://jules.google.com/task/18051560519993168764) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized list transformations by replacing chained map+filter with `mapNotNull`/`mapNotNullTo` to cut intermediate allocations and speed up state updates. This reduces memory churn and improves rendering in list-heavy views.

- **Refactors**
  - `TasksScreen`: use `mapNotNull` for `activeTasks` and `archivedTasks`; build `todayTaskIds` with `mapNotNullTo(mutableSetOf())`.
  - `MainViewModel`: switch `allAreas` and `allProjects` flows to `mapNotNull`; add KDocs.
  - `MainSnapshotCalculators`: compute `areas` with `mapNotNull`.
  - `MainStateAssemblers`: build included/excluded area/type lists with `mapNotNull`; add brief inline comments for clarity.

<sup>Written for commit 787110e7797a02bff8ef65cd227c9812a1680eef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

