### PR TITLE
fix(ui): remove neon glow from waitlist input

### DIFF
--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -38,8 +38,8 @@ const title = "WAITLIST";
             </p>
 <!-- Waitlist Module -->
 <div class="w-full max-w-lg group relative">
-<div class="absolute -inset-0.5 bg-linear-to-r from-primary to-primary-dim rounded-xl blur opacity-20 group-focus-within:opacity-50 transition duration-1000"></div>
-<form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-outline-variant/30 rounded-xl overflow-hidden focus-within:border-outline-variant focus-within:shadow-[0_0_8px_var(--color-primary)] transition-all duration-500">
+<div class="absolute -inset-0.5 bg-linear-to-r from-primary to-primary-dim rounded-xl blur opacity-20 transition duration-1000"></div>
+<form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-outline-variant/30 rounded-xl overflow-hidden focus-within:border-outline-variant focus-within:ring-1 focus-within:ring-primary focus-within:border-primary transition-all duration-500">
 <label for="waitlist-email" class="sr-only">Email address</label>
 <input id="waitlist-email" class="bg-transparent border-none focus:ring-0 text-on-surface placeholder:text-outline font-mono py-5 px-6 w-full text-lg" placeholder="email@example.com" type="email" required autocomplete="email"/>
 <button id="waitlist-submit" type="submit" class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold px-12 py-6 text-xl hover:shadow-[0_0_50px_rgba(186,158,255,0.4)] transition-all flex items-center gap-2 group/btn relative overflow-hidden">

--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -39,7 +39,7 @@ const title = "WAITLIST";
 <!-- Waitlist Module -->
 <div class="w-full max-w-lg group relative">
 <div class="absolute -inset-0.5 bg-linear-to-r from-primary to-primary-dim rounded-xl blur opacity-20 transition duration-1000"></div>
-<form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-outline-variant/30 rounded-xl overflow-hidden focus-within:border-outline-variant focus-within:ring-1 focus-within:ring-primary focus-within:border-primary transition-all duration-500">
+<form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-outline-variant/30 rounded-xl overflow-hidden focus-within:ring-1 focus-within:ring-primary focus-within:border-primary transition-all duration-500">
 <label for="waitlist-email" class="sr-only">Email address</label>
 <input id="waitlist-email" class="bg-transparent border-none focus:ring-0 text-on-surface placeholder:text-outline font-mono py-5 px-6 w-full text-lg" placeholder="email@example.com" type="email" required autocomplete="email"/>
 <button id="waitlist-submit" type="submit" class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold px-12 py-6 text-xl hover:shadow-[0_0_50px_rgba(186,158,255,0.4)] transition-all flex items-center gap-2 group/btn relative overflow-hidden">


### PR DESCRIPTION
Replaced neon glow effect with proper tonal ring according to design guidelines on waitlist page.

---
*PR created automatically by Jules for task [13056813811506108632](https://jules.google.com/task/13056813811506108632) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the neon glow on the waitlist input and the overlay’s focus opacity bump. Added a subtle 1px primary focus ring and border to match design and improve accessibility.

<sup>Written for commit 2fc2b57a915eb036ed854109eff58dd70bbcb737. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

