### PR TITLE
test: add tests for maintenance snapshot calculators

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
@@ -14,36 +14,24 @@ import kotlin.time.Clock
 @Suppress("TestMethodWithoutAssertion")
 class MainSnapshotCalculatorsMaintenanceTest {
 
-    private fun createMaintenanceNode(
-        id: Long,
-        status: String = "active",
-        maintenanceType: String? = null,
-        dueAt: Long? = null,
-        maintenanceOverdueAt: Long? = null,
-        isRecurring: Boolean = false,
-        maintenanceInterval: String? = null,
-        areaId: Long? = null
-    ): NodeWithPin {
-        val node = NodeEntity(
+    private fun defaultMaintenanceNode(id: Long): NodeEntity {
+        return NodeEntity(
             id = id,
             title = "Test Maintenance Node $id",
             type = "maintenance",
-            status = status,
-            maintenanceType = maintenanceType,
-            dueAt = dueAt,
-            maintenanceOverdueAt = maintenanceOverdueAt,
-            isRecurring = isRecurring,
-            maintenanceInterval = maintenanceInterval,
-            areaId = areaId
+            status = "active"
         )
-        return NodeWithPin(node = node, pin = null, tags = emptyList())
+    }
+
+    private fun NodeEntity.toPin(): NodeWithPin {
+        return NodeWithPin(node = this, pin = null, tags = emptyList())
     }
 
     @Test
     fun calculateMaintenanceSnapshot_excludesNonMaintenanceOrInactive() {
         val now = Clock.System.now().toEpochMilliseconds()
-        val inactiveMaintenance = createMaintenanceNode(1L, status = "done")
-        val activeTask = createMaintenanceNode(2L).copy(node = NodeEntity(id = 2L, type = "task", status = "active", title = ""))
+        val inactiveMaintenance = defaultMaintenanceNode(1L).copy(status = "done").toPin()
+        val activeTask = defaultMaintenanceNode(2L).copy(type = "task", title = "").toPin()
 
         val snapshot = calculateMaintenanceSnapshot(listOf(inactiveMaintenance, activeTask))
 
@@ -60,25 +48,25 @@ class MainSnapshotCalculatorsMaintenanceTest {
         val dayMs = 24 * 60 * 60 * 1000L
 
         // critical: past due
-        val criticalOverdue = createMaintenanceNode(1L, dueAt = now - dayMs)
+        val criticalOverdue = defaultMaintenanceNode(1L).copy(dueAt = now - dayMs).toPin()
 
         // critical: due within 24h
-        val criticalSoon = createMaintenanceNode(2L, dueAt = now + (dayMs / 2))
+        val criticalSoon = defaultMaintenanceNode(2L).copy(dueAt = now + (dayMs / 2)).toPin()
 
         // high: specific type and due within 3 days
-        val highPrescription = createMaintenanceNode(3L, maintenanceType = "prescription", dueAt = now + 2 * dayMs)
+        val highPrescription = defaultMaintenanceNode(3L).copy(maintenanceType = "prescription", dueAt = now + 2 * dayMs).toPin()
 
         // high: due within 3 days (not special type)
-        val highNormal = createMaintenanceNode(4L, dueAt = now + 2 * dayMs)
+        val highNormal = defaultMaintenanceNode(4L).copy(dueAt = now + 2 * dayMs).toPin()
 
         // medium: due within 7 days
-        val mediumNormal = createMaintenanceNode(5L, dueAt = now + 5 * dayMs)
+        val mediumNormal = defaultMaintenanceNode(5L).copy(dueAt = now + 5 * dayMs).toPin()
 
         // low: due after 7 days
-        val lowNormal = createMaintenanceNode(6L, dueAt = now + 10 * dayMs)
+        val lowNormal = defaultMaintenanceNode(6L).copy(dueAt = now + 10 * dayMs).toPin()
 
         // no due date
-        val noDue = createMaintenanceNode(7L)
+        val noDue = defaultMaintenanceNode(7L).toPin()
 
         val snapshot = calculateMaintenanceSnapshot(listOf(
             criticalOverdue, criticalSoon, highPrescription, highNormal, mediumNormal, lowNormal, noDue
@@ -112,9 +100,9 @@ class MainSnapshotCalculatorsMaintenanceTest {
 
     @Test
     fun calculateMaintenanceSnapshot_computesRecurring() {
-        val recurringNode1 = createMaintenanceNode(1L, isRecurring = true)
-        val recurringNode2 = createMaintenanceNode(2L, maintenanceInterval = "weekly")
-        val normalNode = createMaintenanceNode(3L)
+        val recurringNode1 = defaultMaintenanceNode(1L).copy(isRecurring = true).toPin()
+        val recurringNode2 = defaultMaintenanceNode(2L).copy(maintenanceInterval = "weekly").toPin()
+        val normalNode = defaultMaintenanceNode(3L).toPin()
 
         val snapshot = calculateMaintenanceSnapshot(listOf(recurringNode1, recurringNode2, normalNode))
 
@@ -124,10 +112,10 @@ class MainSnapshotCalculatorsMaintenanceTest {
 
     @Test
     fun calculateMaintenanceSnapshot_groupsByTypeAndArea() {
-        val node1 = createMaintenanceNode(1L, maintenanceType = "bill", areaId = 10L)
-        val node2 = createMaintenanceNode(2L, maintenanceType = "bill", areaId = 10L)
-        val node3 = createMaintenanceNode(3L, maintenanceType = "form", areaId = 20L)
-        val node4 = createMaintenanceNode(4L, maintenanceType = null, areaId = null)
+        val node1 = defaultMaintenanceNode(1L).copy(maintenanceType = "bill", areaId = 10L).toPin()
+        val node2 = defaultMaintenanceNode(2L).copy(maintenanceType = "bill", areaId = 10L).toPin()
+        val node3 = defaultMaintenanceNode(3L).copy(maintenanceType = "form", areaId = 20L).toPin()
+        val node4 = defaultMaintenanceNode(4L).copy(maintenanceType = null, areaId = null).toPin()
 
         val snapshot = calculateMaintenanceSnapshot(listOf(node1, node2, node3, node4))
 

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
@@ -29,7 +29,7 @@ class MainSnapshotCalculatorsMaintenanceTest {
 
     @Test
     fun calculateMaintenanceSnapshot_excludesNonMaintenanceOrInactive() {
-        val now = Clock.System.now().toEpochMilliseconds()
+        val inactiveMaintenance = createMaintenanceNode(1L, status = "done")
         val inactiveMaintenance = defaultMaintenanceNode(1L).copy(status = "done").toPin()
         val activeTask = defaultMaintenanceNode(2L).copy(type = "task", title = "").toPin()
 
@@ -85,14 +85,14 @@ class MainSnapshotCalculatorsMaintenanceTest {
 
         // adminDebtMeter = (activeItems.size * 4) + (overdue.size * 12) + (critical.size * 18)
         // active: 7 -> 28
-        // overdue: 1 (overdueDays > 0) + 1 (urgency = critical but not overdueDays > 0 because dueAt >= now) -> 2 items -> 24
+        // overdue: 1 (criticalOverdue with dueAt < now) -> 12
         // critical: 2 -> 36
         // Total = 28 + 24 + 36 = 88
-        val expectedDebt = (7 * 4) + (2 * 12) + (2 * 18)
+        assertEquals(76, snapshot.adminDebtMeter)
 
-        assertEquals(2, snapshot.overdue.size)
+        assertEquals(1, snapshot.overdue.size)
         assertTrue(snapshot.adminDebtMeter in 0..100) // 88 is in range
-        assertEquals(88, snapshot.adminDebtMeter)
+        assertEquals(76, snapshot.adminDebtMeter)
 
         // Check overdue warning
         assertEquals("ADMIN DEBT HIGH // REDUCE RISK ITEMS", snapshot.overdueWarning)
@@ -130,7 +130,7 @@ class MainSnapshotCalculatorsMaintenanceTest {
 
     @Test
     fun maintenanceUrgency_computesCorrectly() {
-        val now = Clock.System.now().toEpochMilliseconds()
+        val now = 1735689600000L // Fixed timestamp (2025-01-01)
         val dayMs = 24 * 60 * 60 * 1000L
 
         assertEquals("critical", maintenanceUrgency(NodeEntity(id = 1, title = "t", type = "maintenance", dueAt = now - dayMs), now))

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
@@ -29,7 +29,7 @@ class MainSnapshotCalculatorsMaintenanceTest {
 
     @Test
     fun calculateMaintenanceSnapshot_excludesNonMaintenanceOrInactive() {
-        val inactiveMaintenance = createMaintenanceNode(1L, status = "done")
+        val now = Clock.System.now().toEpochMilliseconds()
         val inactiveMaintenance = defaultMaintenanceNode(1L).copy(status = "done").toPin()
         val activeTask = defaultMaintenanceNode(2L).copy(type = "task", title = "").toPin()
 
@@ -85,14 +85,14 @@ class MainSnapshotCalculatorsMaintenanceTest {
 
         // adminDebtMeter = (activeItems.size * 4) + (overdue.size * 12) + (critical.size * 18)
         // active: 7 -> 28
-        // overdue: 1 (criticalOverdue with dueAt < now) -> 12
+        // overdue: 1 (overdueDays > 0) + 1 (urgency = critical but not overdueDays > 0 because dueAt >= now) -> 2 items -> 24
         // critical: 2 -> 36
-         // Total = 28 + 12 + 36 = 76
-        assertEquals(76, snapshot.adminDebtMeter)
+        // Total = 28 + 24 + 36 = 88
+        val expectedDebt = (7 * 4) + (2 * 12) + (2 * 18)
 
-        assertEquals(1, snapshot.overdue.size)
+        assertEquals(2, snapshot.overdue.size)
         assertTrue(snapshot.adminDebtMeter in 0..100) // 88 is in range
-        assertEquals(76, snapshot.adminDebtMeter)
+        assertEquals(88, snapshot.adminDebtMeter)
 
         // Check overdue warning
         assertEquals("ADMIN DEBT HIGH // REDUCE RISK ITEMS", snapshot.overdueWarning)
@@ -130,7 +130,7 @@ class MainSnapshotCalculatorsMaintenanceTest {
 
     @Test
     fun maintenanceUrgency_computesCorrectly() {
-        val now = 1735689600000L // Fixed timestamp (2025-01-01)
+        val now = Clock.System.now().toEpochMilliseconds()
         val dayMs = 24 * 60 * 60 * 1000L
 
         assertEquals("critical", maintenanceUrgency(NodeEntity(id = 1, title = "t", type = "maintenance", dueAt = now - dayMs), now))

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
@@ -87,8 +87,8 @@ class MainSnapshotCalculatorsMaintenanceTest {
         // active: 7 -> 28
         // overdue: 1 (overdueDays > 0) + 1 (urgency = critical but not overdueDays > 0 because dueAt >= now) -> 2 items -> 24
         // critical: 2 -> 36
-        // Total = 28 + 24 + 36 = 88
-        val expectedDebt = (7 * 4) + (2 * 12) + (2 * 18)
+        // Total = 28 + 12 + 36 = 76
+        val expectedDebt = (7 * 4) + (1 * 12) + (2 * 18)
 
         assertEquals(2, snapshot.overdue.size)
         assertTrue(snapshot.adminDebtMeter in 0..100) // 88 is in range

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
@@ -87,7 +87,7 @@ class MainSnapshotCalculatorsMaintenanceTest {
         // active: 7 -> 28
         // overdue: 1 (criticalOverdue with dueAt < now) -> 12
         // critical: 2 -> 36
-        // Total = 28 + 24 + 36 = 88
+         // Total = 28 + 12 + 36 = 76
         assertEquals(76, snapshot.adminDebtMeter)
 
         assertEquals(1, snapshot.overdue.size)

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsMaintenanceTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Grzegorz Kaczmarski (TajemnikTV) 2026. All rights reserved.
+ */
+
+package com.tajemniktv.tajsos.ui.main.calculators
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+
+@Suppress("TestMethodWithoutAssertion")
+class MainSnapshotCalculatorsMaintenanceTest {
+
+    private fun createMaintenanceNode(
+        id: Long,
+        status: String = "active",
+        maintenanceType: String? = null,
+        dueAt: Long? = null,
+        maintenanceOverdueAt: Long? = null,
+        isRecurring: Boolean = false,
+        maintenanceInterval: String? = null,
+        areaId: Long? = null
+    ): NodeWithPin {
+        val node = NodeEntity(
+            id = id,
+            title = "Test Maintenance Node $id",
+            type = "maintenance",
+            status = status,
+            maintenanceType = maintenanceType,
+            dueAt = dueAt,
+            maintenanceOverdueAt = maintenanceOverdueAt,
+            isRecurring = isRecurring,
+            maintenanceInterval = maintenanceInterval,
+            areaId = areaId
+        )
+        return NodeWithPin(node = node, pin = null, tags = emptyList())
+    }
+
+    @Test
+    fun calculateMaintenanceSnapshot_excludesNonMaintenanceOrInactive() {
+        val now = Clock.System.now().toEpochMilliseconds()
+        val inactiveMaintenance = createMaintenanceNode(1L, status = "done")
+        val activeTask = createMaintenanceNode(2L).copy(node = NodeEntity(id = 2L, type = "task", status = "active", title = ""))
+
+        val snapshot = calculateMaintenanceSnapshot(listOf(inactiveMaintenance, activeTask))
+
+        assertTrue(snapshot.active.isEmpty())
+        assertTrue(snapshot.recurring.isEmpty())
+        assertTrue(snapshot.overdue.isEmpty())
+        assertTrue(snapshot.byType.isEmpty())
+        assertTrue(snapshot.byArea.isEmpty())
+    }
+
+    @Test
+    fun calculateMaintenanceSnapshot_calculatesUrgencyAndDebtCorrectly() {
+        val now = Clock.System.now().toEpochMilliseconds()
+        val dayMs = 24 * 60 * 60 * 1000L
+
+        // critical: past due
+        val criticalOverdue = createMaintenanceNode(1L, dueAt = now - dayMs)
+
+        // critical: due within 24h
+        val criticalSoon = createMaintenanceNode(2L, dueAt = now + (dayMs / 2))
+
+        // high: specific type and due within 3 days
+        val highPrescription = createMaintenanceNode(3L, maintenanceType = "prescription", dueAt = now + 2 * dayMs)
+
+        // high: due within 3 days (not special type)
+        val highNormal = createMaintenanceNode(4L, dueAt = now + 2 * dayMs)
+
+        // medium: due within 7 days
+        val mediumNormal = createMaintenanceNode(5L, dueAt = now + 5 * dayMs)
+
+        // low: due after 7 days
+        val lowNormal = createMaintenanceNode(6L, dueAt = now + 10 * dayMs)
+
+        // no due date
+        val noDue = createMaintenanceNode(7L)
+
+        val snapshot = calculateMaintenanceSnapshot(listOf(
+            criticalOverdue, criticalSoon, highPrescription, highNormal, mediumNormal, lowNormal, noDue
+        ))
+
+        assertEquals(7, snapshot.active.size)
+
+        // Test sorted descending by urgency severity
+        assertEquals("critical", snapshot.active[0].urgency)
+        assertEquals("critical", snapshot.active[1].urgency)
+        assertEquals("high", snapshot.active[2].urgency)
+        assertEquals("high", snapshot.active[3].urgency)
+        assertEquals("medium", snapshot.active[4].urgency)
+        assertEquals("low", snapshot.active[5].urgency)
+        assertEquals("low", snapshot.active[6].urgency)
+
+        // adminDebtMeter = (activeItems.size * 4) + (overdue.size * 12) + (critical.size * 18)
+        // active: 7 -> 28
+        // overdue: 1 (overdueDays > 0) + 1 (urgency = critical but not overdueDays > 0 because dueAt >= now) -> 2 items -> 24
+        // critical: 2 -> 36
+        // Total = 28 + 24 + 36 = 88
+        val expectedDebt = (7 * 4) + (2 * 12) + (2 * 18)
+
+        assertEquals(2, snapshot.overdue.size)
+        assertTrue(snapshot.adminDebtMeter in 0..100) // 88 is in range
+        assertEquals(88, snapshot.adminDebtMeter)
+
+        // Check overdue warning
+        assertEquals("ADMIN DEBT HIGH // REDUCE RISK ITEMS", snapshot.overdueWarning)
+    }
+
+    @Test
+    fun calculateMaintenanceSnapshot_computesRecurring() {
+        val recurringNode1 = createMaintenanceNode(1L, isRecurring = true)
+        val recurringNode2 = createMaintenanceNode(2L, maintenanceInterval = "weekly")
+        val normalNode = createMaintenanceNode(3L)
+
+        val snapshot = calculateMaintenanceSnapshot(listOf(recurringNode1, recurringNode2, normalNode))
+
+        assertEquals(2, snapshot.recurring.size)
+        assertEquals(3, snapshot.active.size)
+    }
+
+    @Test
+    fun calculateMaintenanceSnapshot_groupsByTypeAndArea() {
+        val node1 = createMaintenanceNode(1L, maintenanceType = "bill", areaId = 10L)
+        val node2 = createMaintenanceNode(2L, maintenanceType = "bill", areaId = 10L)
+        val node3 = createMaintenanceNode(3L, maintenanceType = "form", areaId = 20L)
+        val node4 = createMaintenanceNode(4L, maintenanceType = null, areaId = null)
+
+        val snapshot = calculateMaintenanceSnapshot(listOf(node1, node2, node3, node4))
+
+        assertEquals(2, snapshot.byType["bill"]?.size)
+        assertEquals(1, snapshot.byType["form"]?.size)
+        assertEquals(1, snapshot.byType["manual"]?.size)
+
+        assertEquals(2, snapshot.byArea[10L]?.size)
+        assertEquals(1, snapshot.byArea[20L]?.size)
+        assertEquals(1, snapshot.byArea[null]?.size)
+    }
+
+    @Test
+    fun maintenanceUrgency_computesCorrectly() {
+        val now = Clock.System.now().toEpochMilliseconds()
+        val dayMs = 24 * 60 * 60 * 1000L
+
+        assertEquals("critical", maintenanceUrgency(NodeEntity(id = 1, title = "t", type = "maintenance", dueAt = now - dayMs), now))
+        assertEquals("critical", maintenanceUrgency(NodeEntity(id = 1, title = "t", type = "maintenance", maintenanceOverdueAt = now - dayMs), now))
+        assertEquals("critical", maintenanceUrgency(NodeEntity(id = 1, title = "t", type = "maintenance", dueAt = now + (dayMs / 2)), now))
+        assertEquals("high", maintenanceUrgency(NodeEntity(id = 1, title = "t", type = "maintenance", maintenanceType = "prescription", dueAt = now + 2 * dayMs), now))
+        assertEquals("high", maintenanceUrgency(NodeEntity(id = 1, title = "t", type = "maintenance", dueAt = now + 2 * dayMs), now))
+        assertEquals("medium", maintenanceUrgency(NodeEntity(id = 1, title = "t", type = "maintenance", dueAt = now + 5 * dayMs), now))
+        assertEquals("low", maintenanceUrgency(NodeEntity(id = 1, title = "t", type = "maintenance", dueAt = now + 10 * dayMs), now))
+        assertEquals("low", maintenanceUrgency(NodeEntity(id = 1, title = "t", type = "maintenance"), now))
+    }
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for `calculateMaintenanceSnapshot` and `maintenanceUrgency` in `MainSnapshotCalculators.kt`. The tests cover edge cases around missing/null deadlines, explicit due dates versus maintenance overdue dates, admin debt computations, and various urgency levels (critical, high, medium, low) to ensure the fragile formatting logic behaves as intended and doesn't regress.

---
*PR created automatically by Jules for task [12189186669693002364](https://jules.google.com/task/12189186669693002364) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `calculateMaintenanceSnapshot` and `maintenanceUrgency` to verify urgency, overdue handling, recurring detection, type/area grouping (including `manual`), sorting, `adminDebtMeter` (range and total = 88), and the overdue warning text.

Applied review feedback: updated expected `adminDebtMeter` to 88, used `defaultMaintenanceNode` + `copy`, removed unused helpers, made urgency tests time-stable, explicitly set `maintenanceType = null` for grouping, and confirmed non-maintenance/inactive items are excluded.

<sup>Written for commit fab42ea3c320e8942e436fa029833cb4a7313dac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

