### PR TITLE
fix(ui): standardize component border radii to design system scale

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
@@ -146,7 +146,7 @@ fun TactileSlider(
                                 .blur(8.dp)
                                 .background(
                                     TajsOSTheme.Primary.copy(alpha = 0.5f),
-                                    RoundedCornerShape(4.dp),
+                                    RoundedCornerShape(TajsOSTheme.RadiusXs),
                                 ),
                     )
                     // Core thumb
@@ -154,7 +154,7 @@ fun TactileSlider(
                         modifier =
                             Modifier
                                 .size(16.dp)
-                                .background(TajsOSTheme.Primary, RoundedCornerShape(4.dp)),
+                                .background(TajsOSTheme.Primary, RoundedCornerShape(TajsOSTheme.RadiusXs)),
                     )
                 }
             },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/GeneralCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/GeneralCards.kt
@@ -152,7 +152,7 @@ fun LinkedNodeItem(
                 modifier =
                     Modifier
                         .size(40.dp)
-                        .background(TajsOSTheme.Background, RoundedCornerShape(8.dp)),
+                        .background(TajsOSTheme.Background, RoundedCornerShape(TajsOSTheme.RadiusSm)),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/SelectorDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/SelectorDialog.kt
@@ -112,7 +112,7 @@ fun <T> SelectorDialog(
                     }
                     Surface(
                         color = Color.Black.copy(alpha = 0.5f),
-                        shape = RoundedCornerShape(4.dp),
+                        shape = RoundedCornerShape(TajsOSTheme.RadiusXs),
                     ) {
                         Text(
                             "STATUS: READY",

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -334,7 +334,7 @@ fun GlobalSearchBar(modifier: Modifier = Modifier) {
         singleLine = true,
         modifier =
             modifier.glassChrome(
-                shape = RoundedCornerShape(12.dp),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 material = GlassMaterial.THIN,
             ),
         textStyle = MaterialTheme.typography.bodyMedium.copy(color = TajsOSTheme.Text),
@@ -359,7 +359,7 @@ fun GlobalSearchBar(modifier: Modifier = Modifier) {
                 tint = TajsOSTheme.Muted,
             )
         },
-        shape = RoundedCornerShape(12.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     )
 }
 
@@ -401,10 +401,10 @@ fun HeaderModeSwitcher(
                 Modifier
                     .height(42.dp)
                     .glassChrome(
-                        shape = RoundedCornerShape(12.dp),
+                        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                         material = GlassMaterial.REGULAR,
                     ),
-            shape = RoundedCornerShape(12.dp),
+            shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             color = glassContainerColor(TajsOSTheme.SurfaceHigh),
             tonalElevation = 0.dp,
             shadowElevation = 0.dp,
@@ -493,10 +493,10 @@ fun NotificationsPopover(
         Surface(
             modifier =
                 Modifier.glassChrome(
-                    shape = RoundedCornerShape(12.dp),
+                    shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                     material = GlassMaterial.REGULAR,
                 ),
-            shape = RoundedCornerShape(12.dp),
+            shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             color = glassContainerColor(TajsOSTheme.SurfaceHigh),
             tonalElevation = 0.dp,
             shadowElevation = 0.dp,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
@@ -642,7 +642,7 @@ fun ExpandableNavSection(
                                 } else {
                                     Color.Transparent
                                 },
-                            shape = RoundedCornerShape(8.dp),
+                            shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                             tonalElevation = 0.dp,
                             shadowElevation = 0.dp,
                         ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
@@ -557,7 +557,7 @@ private fun BriefingSignalSections(
                 )
             } else {
                 Surface(
-                    shape = RoundedCornerShape(14.dp),
+                    shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
                     color = TajsOSTheme.SurfaceHigh.copy(alpha = 0.7f),
                     tonalElevation = 0.dp,
                     shadowElevation = 0.dp,
@@ -601,7 +601,7 @@ private fun BriefingSignalCard(
 ) {
     Surface(
         modifier = modifier,
-        shape = RoundedCornerShape(14.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceLow.copy(alpha = 0.55f),
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
@@ -643,7 +643,7 @@ private fun BriefingSectionLabel(text: String) {
 private fun BriefingActionCard(action: BriefingAction) {
     Surface(
         onClick = action.onClick,
-        shape = RoundedCornerShape(14.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceLow.copy(alpha = 0.72f),
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
@@ -654,7 +654,7 @@ private fun BriefingActionCard(action: BriefingAction) {
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             Surface(
-                shape = RoundedCornerShape(10.dp),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 color = TajsOSTheme.Primary.copy(alpha = 0.2f),
                 modifier = Modifier.size(34.dp),
             ) {
@@ -696,7 +696,7 @@ private fun BriefingActionCard(action: BriefingAction) {
 private fun BriefingCaptureField(onClick: () -> Unit) {
     Surface(
         onClick = onClick,
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceHighest.copy(alpha = 0.9f),
         modifier = Modifier.widthIn(max = 720.dp).fillMaxWidth().height(58.dp),
         tonalElevation = 0.dp,
@@ -756,7 +756,7 @@ private fun BriefingAtmosphere(modifier: Modifier = Modifier) {
     Box(
         modifier =
             modifier
-                .clip(RoundedCornerShape(20.dp))
+                .clip(RoundedCornerShape(TajsOSTheme.RadiusXl))
                 .hazeSource(state = hazeState),
     ) {
         Box(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt
@@ -120,7 +120,7 @@ internal fun CalendarMainBlock(
                         modifier = Modifier.weight(1.75f).fillMaxHeight(),
                         shape =
                             androidx.compose.foundation.shape
-                                .RoundedCornerShape(20.dp),
+                                .RoundedCornerShape(TajsOSTheme.RadiusXl),
                         color = TajsOSTheme.CalendarPanel,
                         border =
                             androidx.compose.foundation.BorderStroke(
@@ -164,7 +164,7 @@ internal fun CalendarMainBlock(
                         modifier = Modifier.weight(1f).fillMaxHeight(),
                         shape =
                             androidx.compose.foundation.shape
-                                .RoundedCornerShape(20.dp),
+                                .RoundedCornerShape(TajsOSTheme.RadiusXl),
                         color = TajsOSTheme.CalendarPanelSoft,
                         border =
                             androidx.compose.foundation.BorderStroke(
@@ -284,7 +284,7 @@ internal fun CalendarMainBlock(
                         modifier = Modifier.fillMaxWidth(),
                         shape =
                             androidx.compose.foundation.shape
-                                .RoundedCornerShape(20.dp),
+                                .RoundedCornerShape(TajsOSTheme.RadiusXl),
                         color = TajsOSTheme.CalendarPanel,
                         border =
                             androidx.compose.foundation.BorderStroke(
@@ -328,7 +328,7 @@ internal fun CalendarMainBlock(
                         modifier = Modifier.fillMaxWidth(),
                         shape =
                             androidx.compose.foundation.shape
-                                .RoundedCornerShape(20.dp),
+                                .RoundedCornerShape(TajsOSTheme.RadiusXl),
                         color = TajsOSTheme.CalendarPanelSoft,
                         border =
                             androidx.compose.foundation.BorderStroke(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -250,7 +250,7 @@ fun MonthView(
                                     .weight(1f)
                                     .aspectRatio(1f)
                                     .padding(3.dp)
-                                    .clip(RoundedCornerShape(10.dp))
+                                    .clip(RoundedCornerShape(TajsOSTheme.RadiusMd))
                                     .background(
                                         if (isSelected) {
                                             TajsOSTheme.CalendarSelectedDay
@@ -379,7 +379,7 @@ fun AgendaRow(
 
     Surface(
         onClick = onClick,
-        shape = RoundedCornerShape(14.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.CalendarPanelStrong,
         border =
             androidx.compose.foundation.BorderStroke(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/inbox/InboxDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/inbox/InboxDashboardBlocks.kt
@@ -144,7 +144,7 @@ private fun InboxCaptureCard(
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
     ) {
         Column(
             modifier = Modifier.padding(16.dp),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
@@ -540,7 +540,7 @@ private fun renderNoteContextGraph(context: NoteDetailContext) {
                                 .size(32.dp)
                                 .background(
                                     TajsOSTheme.Surface,
-                                    RoundedCornerShape(8.dp),
+                                    RoundedCornerShape(TajsOSTheme.RadiusSm),
                                 ),
                         contentAlignment = Alignment.Center,
                     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -569,7 +569,7 @@ private fun SearchSupportPanel(
         modifier = Modifier.width(284.dp).fillMaxHeight(),
         verticalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingMd),
     ) {
-        Surface(shape = RoundedCornerShape(14.dp), color = TajsOSTheme.SurfaceLow) {
+        Surface(shape = RoundedCornerShape(TajsOSTheme.RadiusLg), color = TajsOSTheme.SurfaceLow) {
             Column(
                 modifier = Modifier.padding(TajsOSTheme.SpacingMd),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -621,7 +621,7 @@ private fun SearchSupportPanel(
             }
         }
 
-        Surface(shape = RoundedCornerShape(14.dp), color = TajsOSTheme.SurfaceLow) {
+        Surface(shape = RoundedCornerShape(TajsOSTheme.RadiusLg), color = TajsOSTheme.SurfaceLow) {
             Column(
                 modifier = Modifier.padding(TajsOSTheme.SpacingMd),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -668,7 +668,7 @@ private fun SearchResultCard(
 
     Surface(
         onClick = onOpen,
-        shape = RoundedCornerShape(14.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceLow,
     ) {
         Column(modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd)) {
@@ -686,7 +686,7 @@ private fun SearchResultCard(
                         modifier =
                             Modifier
                                 .size(26.dp)
-                                .clip(RoundedCornerShape(7.dp))
+                                .clip(RoundedCornerShape(TajsOSTheme.RadiusSm))
                                 .background(iconTintForType(node.type).copy(alpha = 0.2f)),
                         contentAlignment = Alignment.Center,
                     ) {
@@ -743,7 +743,7 @@ private fun SearchResultCard(
                 Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                     chips.forEach { chip ->
                         Surface(
-                            shape = RoundedCornerShape(6.dp),
+                            shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                             color = TajsOSTheme.SurfaceHigh,
                         ) {
                             Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -598,14 +598,14 @@ private fun AppearanceSectionCard(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .glassChrome(shape = RoundedCornerShape(14.dp), material = GlassMaterial.REGULAR)
+                .glassChrome(shape = RoundedCornerShape(TajsOSTheme.RadiusLg), material = GlassMaterial.REGULAR)
                 .background(
                     color = glassContainerColor(TajsOSTheme.SurfaceLow.copy(alpha = 0.55f)),
-                    shape = RoundedCornerShape(14.dp),
+                    shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
                 ).border(
                     width = 1.dp,
                     color = TajsOSTheme.Border.copy(alpha = 0.35f),
-                    shape = RoundedCornerShape(14.dp),
+                    shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
                 ).padding(TajsOSTheme.SpacingMd),
         verticalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingMd),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -112,7 +112,7 @@ import tajsos.composeapp.generated.resources.task_detail_snooze
 import tajsos.composeapp.generated.resources.tasks_detail_updated
 import tajsos.composeapp.generated.resources.track_empty
 
-private val detailPanelShape = RoundedCornerShape(12.dp)
+private val detailPanelShape = RoundedCornerShape(TajsOSTheme.RadiusMd)
 private val detailPanelBorder = TajsOSTheme.GhostBorder.copy(alpha = 0.22f)
 
 private enum class HeaderBadgeTone {
@@ -297,7 +297,7 @@ private fun HeaderTitleEditor(
     onValueChange: (String) -> Unit,
 ) {
     Surface(
-        shape = RoundedCornerShape(10.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         color = TajsOSTheme.SurfaceHighest,
     ) {
         BasicTextField(
@@ -386,7 +386,7 @@ private fun renderTaskDescription(context: TaskDetailContext) {
             SectionTitle(stringResource(Res.string.task_detail_directives_section))
             if (context.isEditing) {
                 Surface(
-                    shape = RoundedCornerShape(10.dp),
+                    shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                     color = TajsOSTheme.SurfaceHighest,
                 ) {
                     BasicTextField(
@@ -572,7 +572,7 @@ private fun SubtaskRow(
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(10.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         color = background,
     ) {
         Row(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/vaults/VaultsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/vaults/VaultsScreen.kt
@@ -276,7 +276,7 @@ internal fun VaultsLayer(
         Surface(
             modifier = Modifier.fillMaxWidth(),
             color = TajsOSTheme.VaultShell,
-            shape = RoundedCornerShape(22.dp),
+            shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
             border = BorderStroke(1.dp, TajsOSTheme.VaultBorder),
         ) {
             BoxWithConstraints {
@@ -302,7 +302,7 @@ internal fun VaultsLayer(
                         value = searchQuery,
                         onValueChange = { searchQuery = it },
                         modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(14.dp),
+                        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
                         singleLine = true,
                         leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
                         label = { Text(stringResource(Res.string.lens_reference_search)) },
@@ -586,7 +586,7 @@ private fun VaultCard(
                     modifier =
                         Modifier
                             .size(34.dp)
-                            .clip(RoundedCornerShape(10.dp))
+                            .clip(RoundedCornerShape(TajsOSTheme.RadiusMd))
                             .background(TajsOSTheme.Primary.copy(alpha = 0.2f)),
                     contentAlignment = Alignment.Center,
                 ) {
@@ -650,7 +650,7 @@ private fun ApplicationStatusCard(
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = TajsOSTheme.VaultSoft),
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         border = BorderStroke(1.dp, TajsOSTheme.VaultBorder),
     ) {
         Column(
@@ -710,7 +710,7 @@ private fun VaultEntryComposer(
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = TajsOSTheme.VaultShell),
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         border = BorderStroke(1.dp, TajsOSTheme.VaultBorder),
     ) {
         Column(


### PR DESCRIPTION
Replaced hardcoded RoundedCornerShape dp values with TajsOSTheme radius constants.

---
*PR created automatically by Jules for task [1233590550795645147](https://jules.google.com/task/1233590550795645147) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized border radii across the app by replacing hardcoded dp values with `TajsOSTheme` radius tokens. This unifies the look and makes future theming changes easier.

- **Refactors**
  - Replaced fixed `dp` corners with `TajsOSTheme.RadiusXs/Sm/Md/Lg/Xl` in sliders, cards, dialogs, search bar, header, sidebar, Briefing, Calendar, Inbox, Notes, Search, Settings, Tasks, and Vaults.
  - No behavior changes; small visual tweaks to match the design scale.
  - Centralizes radius control in the theme for consistency and easier maintenance.

<sup>Written for commit 362859f119265d76268f47cce595838def69514a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

