### PR TITLE
perf: optimize Kotlin collection operations

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
@@ -124,8 +124,8 @@ fun buildModeQueryProfile(
             ),
         filtering =
             ModeFilterProfile(
-                includeAreaIds = areaFilters.filter { it.include }.map { it.areaId }.toSet(),
-                includeTypes = typeFilters.filter { it.include }.map { it.nodeType }.toSet(),
+                includeAreaIds = areaFilters.mapNotNull { if (it.include) it.areaId else null }.toSet(),
+                includeTypes = typeFilters.mapNotNull { if (it.include) it.nodeType else null }.toSet(),
                 sortStrategy = preference.sortStrategy,
             ),
         actions = ModeActionProfile(quickActions = actions),

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
@@ -124,8 +124,8 @@ fun buildModeQueryProfile(
             ),
         filtering =
             ModeFilterProfile(
-                includeAreaIds = areaFilters.mapNotNull { if (it.include) it.areaId else null }.toSet(),
-                includeTypes = typeFilters.mapNotNull { if (it.include) it.nodeType else null }.toSet(),
+                includeAreaIds = areaFilters.mapNotNullTo(mutableSetOf()) { if (it.include) it.areaId else null },
+                includeTypes = typeFilters.mapNotNullTo(mutableSetOf()) { if (it.include) it.nodeType else null },
                 sortStrategy = preference.sortStrategy,
             ),
         actions = ModeActionProfile(quickActions = actions),

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PackRegistry.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PackRegistry.kt
@@ -28,7 +28,7 @@ enum class AppPack(
 
     companion object {
         val defaultFreePackKeys: Set<String> =
-            entries.filter { it.isFree }.map { it.key }.toSet()
+            entries.mapNotNull { if (it.isFree) it.key else null }.toSet()
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PackRegistry.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PackRegistry.kt
@@ -28,7 +28,7 @@ enum class AppPack(
 
     companion object {
         val defaultFreePackKeys: Set<String> =
-            entries.mapNotNull { if (it.isFree) it.key else null }.toSet()
+            entries.mapNotNullTo(mutableSetOf()) { if (it.isFree) it.key else null }
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/ProtocolCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/ProtocolCommands.kt
@@ -204,7 +204,7 @@ class ProtocolCommands(
         areaId: Long? = null,
     ) {
         val cleanLabel = label.trim().ifBlank { return }
-        val cleanChecklist = checklistLines.map { it.trim() }.filter { it.isNotBlank() }
+        val cleanChecklist = checklistLines.mapNotNull { it.trim().ifBlank { null } }
         if (cleanChecklist.isEmpty()) return
         scope.launch {
             val nodeId =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpers.kt
@@ -123,9 +123,9 @@ fun buildProtocolChecklistContent(template: TransitionProtocolTemplate): String 
  */
 fun protocolChecklistProgress(content: String): Pair<Int, Int> {
     val checklistLines =
-        content.lines().mapNotNull { line ->
+        content.lineSequence().mapNotNull { line ->
             line.trimStart().takeIf { it.startsWith("- [ ] ") || it.startsWith("- [x] ") }
-        }
+        }.toList()
     val total = checklistLines.size
     val done = checklistLines.count { it.startsWith("- [x] ") }
     return done to total

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpers.kt
@@ -123,8 +123,8 @@ fun buildProtocolChecklistContent(template: TransitionProtocolTemplate): String 
  */
 fun protocolChecklistProgress(content: String): Pair<Int, Int> {
     val checklistLines =
-        content.lines().map { it.trimStart() }.filter {
-            it.startsWith("- [ ] ") || it.startsWith("- [x] ")
+        content.lines().mapNotNull { line ->
+            line.trimStart().takeIf { it.startsWith("- [ ] ") || it.startsWith("- [x] ") }
         }
     val total = checklistLines.size
     val done = checklistLines.count { it.startsWith("- [x] ") }


### PR DESCRIPTION
This commit combines chained `.map` and `.filter` calls into single `.mapNotNull` passes to avoid intermediate list allocations. Affected files include MainProtocolHelpers, ProtocolCommands, ModeQueryProfile, and PackRegistry.

---
*PR created automatically by Jules for task [2269857123981562842](https://jules.google.com/task/2269857123981562842) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized Kotlin collections by replacing filter+map chains with single `mapNotNull` passes and building sets directly to cut allocations. `MainProtocolHelpers` now uses `lineSequence()`; updates across `ModeQueryProfile`, `PackRegistry`, and `ProtocolCommands` clean and filter in one pass.

<sup>Written for commit db5d6e04100629192274000f9ed07c5936eee3f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

