### PR TITLE
fix(ui): Standardize corner radii to use design system tokens

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
@@ -38,7 +38,7 @@ fun OptionCard(
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.Background,
-        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusXs),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingSm)) {
             Row(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
@@ -38,7 +38,7 @@ fun OptionCard(
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.Background,
-        shape = RoundedCornerShape(2.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     ) {
         Column(modifier = Modifier.padding(TajsOSTheme.SpacingSm)) {
             Row(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/GeneralCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/GeneralCards.kt
@@ -152,7 +152,7 @@ fun LinkedNodeItem(
                 modifier =
                     Modifier
                         .size(40.dp)
-                        .background(TajsOSTheme.Background, RoundedCornerShape(8.dp)),
+                        .background(TajsOSTheme.Background, RoundedCornerShape(TajsOSTheme.RadiusSm)),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/GlassEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/GlassEffects.kt
@@ -94,7 +94,7 @@ fun isGlassEnabled(): Boolean {
 @OptIn(ExperimentalHazeMaterialsApi::class)
 @Composable
 fun Modifier.glassChrome(
-    shape: Shape = RoundedCornerShape(16.dp),
+    shape: Shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
     material: GlassMaterial = GlassMaterial.REGULAR,
     edgeWidth: Dp = 1.dp,
 ): Modifier {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
@@ -447,7 +447,7 @@ fun ExpandableNavSection(
                                 onSecondaryClickAt = { contextMenuState.showAt(it) },
                                 middleClickFallbackToPrimary = true,
                             ),
-                    shape = RoundedCornerShape(10.dp),
+                    shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                     color =
                         if (isActiveBranch) {
                             TajsOSTheme.Primary.copy(alpha = 0.17f)
@@ -642,7 +642,7 @@ fun ExpandableNavSection(
                                 } else {
                                     Color.Transparent
                                 },
-                            shape = RoundedCornerShape(8.dp),
+                            shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                             tonalElevation = 0.dp,
                             shadowElevation = 0.dp,
                         ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -232,7 +232,7 @@ fun DecisionDetailContent(
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
                     color = TajsOSTheme.Background,
-                    shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                    shape = RoundedCornerShape(TajsOSTheme.RadiusXs),
                 ) {
                     Row(
                         modifier = Modifier.padding(TajsOSTheme.SpacingSm),
@@ -345,7 +345,7 @@ fun DecisionDetailContent(
                 onClick = { viewModel.convertDecisionToProject(node.id) },
                 colors = ButtonDefaults.buttonColors(containerColor = TajsOSTheme.Accent),
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusXs),
             ) {
                 Text(stringResource(Res.string.decision_convert_project))
             }
@@ -353,7 +353,7 @@ fun DecisionDetailContent(
             OutlinedButton(
                 onClick = { viewModel.convertDecisionToTask(node.id) },
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusXs),
             ) {
                 Text(stringResource(Res.string.decision_convert_task), color = TajsOSTheme.Text)
             }
@@ -362,7 +362,7 @@ fun DecisionDetailContent(
                 onClick = { showDecideDialog = true },
                 colors = ButtonDefaults.buttonColors(containerColor = TajsOSTheme.Primary),
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusXs),
             ) {
                 Text(stringResource(Res.string.decision_finalize))
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -232,7 +232,7 @@ fun DecisionDetailContent(
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
                     color = TajsOSTheme.Background,
-                    shape = RoundedCornerShape(2.dp),
+                    shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 ) {
                     Row(
                         modifier = Modifier.padding(TajsOSTheme.SpacingSm),
@@ -345,7 +345,7 @@ fun DecisionDetailContent(
                 onClick = { viewModel.convertDecisionToProject(node.id) },
                 colors = ButtonDefaults.buttonColors(containerColor = TajsOSTheme.Accent),
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(2.dp),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             ) {
                 Text(stringResource(Res.string.decision_convert_project))
             }
@@ -353,7 +353,7 @@ fun DecisionDetailContent(
             OutlinedButton(
                 onClick = { viewModel.convertDecisionToTask(node.id) },
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(2.dp),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             ) {
                 Text(stringResource(Res.string.decision_convert_task), color = TajsOSTheme.Text)
             }
@@ -362,7 +362,7 @@ fun DecisionDetailContent(
                 onClick = { showDecideDialog = true },
                 colors = ButtonDefaults.buttonColors(containerColor = TajsOSTheme.Primary),
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(2.dp),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             ) {
                 Text(stringResource(Res.string.decision_finalize))
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
@@ -654,7 +654,7 @@ private fun BriefingActionCard(action: BriefingAction) {
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             Surface(
-                shape = RoundedCornerShape(10.dp),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 color = TajsOSTheme.Primary.copy(alpha = 0.2f),
                 modifier = Modifier.size(34.dp),
             ) {
@@ -696,7 +696,7 @@ private fun BriefingActionCard(action: BriefingAction) {
 private fun BriefingCaptureField(onClick: () -> Unit) {
     Surface(
         onClick = onClick,
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceHighest.copy(alpha = 0.9f),
         modifier = Modifier.widthIn(max = 720.dp).fillMaxWidth().height(58.dp),
         tonalElevation = 0.dp,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -250,7 +250,7 @@ fun MonthView(
                                     .weight(1f)
                                     .aspectRatio(1f)
                                     .padding(3.dp)
-                                    .clip(RoundedCornerShape(10.dp))
+                                    .clip(RoundedCornerShape(TajsOSTheme.RadiusMd))
                                     .background(
                                         if (isSelected) {
                                             TajsOSTheme.CalendarSelectedDay

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
@@ -443,7 +443,7 @@ private fun RenderDashboardBlock(
                         modifier =
                             Modifier
                                 .clickable { context.onNewEntry() }
-                                .background(TajsOSTheme.Primary, RoundedCornerShape(TajsOSTheme.RadiusMd))
+                                .background(TajsOSTheme.Primary, RoundedCornerShape(TajsOSTheme.RadiusXs))
                                 .padding(horizontal = 12.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
@@ -637,7 +637,7 @@ private fun CommandItem(
             key,
             modifier =
                 Modifier
-                    .background(TajsOSTheme.Border, RoundedCornerShape(TajsOSTheme.RadiusMd))
+                    .background(TajsOSTheme.Border, RoundedCornerShape(TajsOSTheme.RadiusXs))
                     .padding(horizontal = 6.dp, vertical = 2.dp),
             style = MaterialTheme.typography.labelSmall,
             color = TajsOSTheme.Text,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
@@ -443,7 +443,7 @@ private fun RenderDashboardBlock(
                         modifier =
                             Modifier
                                 .clickable { context.onNewEntry() }
-                                .background(TajsOSTheme.Primary, RoundedCornerShape(4.dp))
+                                .background(TajsOSTheme.Primary, RoundedCornerShape(TajsOSTheme.RadiusMd))
                                 .padding(horizontal = 12.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
@@ -637,7 +637,7 @@ private fun CommandItem(
             key,
             modifier =
                 Modifier
-                    .background(TajsOSTheme.Border, RoundedCornerShape(4.dp))
+                    .background(TajsOSTheme.Border, RoundedCornerShape(TajsOSTheme.RadiusMd))
                     .padding(horizontal = 6.dp, vertical = 2.dp),
             style = MaterialTheme.typography.labelSmall,
             color = TajsOSTheme.Text,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/inbox/InboxDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/inbox/InboxDashboardBlocks.kt
@@ -144,7 +144,7 @@ private fun InboxCaptureCard(
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = TajsOSTheme.CardSurface,
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
     ) {
         Column(
             modifier = Modifier.padding(16.dp),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
@@ -540,7 +540,7 @@ private fun renderNoteContextGraph(context: NoteDetailContext) {
                                 .size(32.dp)
                                 .background(
                                     TajsOSTheme.Surface,
-                                    RoundedCornerShape(8.dp),
+                                    RoundedCornerShape(TajsOSTheme.RadiusSm),
                                 ),
                         contentAlignment = Alignment.Center,
                     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -297,7 +297,7 @@ private fun HeaderTitleEditor(
     onValueChange: (String) -> Unit,
 ) {
     Surface(
-        shape = RoundedCornerShape(10.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         color = TajsOSTheme.SurfaceHighest,
     ) {
         BasicTextField(
@@ -386,7 +386,7 @@ private fun renderTaskDescription(context: TaskDetailContext) {
             SectionTitle(stringResource(Res.string.task_detail_directives_section))
             if (context.isEditing) {
                 Surface(
-                    shape = RoundedCornerShape(10.dp),
+                    shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                     color = TajsOSTheme.SurfaceHighest,
                 ) {
                     BasicTextField(
@@ -572,7 +572,7 @@ private fun SubtaskRow(
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(10.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         color = background,
     ) {
         Row(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/vaults/VaultsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/vaults/VaultsScreen.kt
@@ -586,7 +586,7 @@ private fun VaultCard(
                     modifier =
                         Modifier
                             .size(34.dp)
-                            .clip(RoundedCornerShape(10.dp))
+                            .clip(RoundedCornerShape(TajsOSTheme.RadiusMd))
                             .background(TajsOSTheme.Primary.copy(alpha = 0.2f)),
                     contentAlignment = Alignment.Center,
                 ) {
@@ -650,7 +650,7 @@ private fun ApplicationStatusCard(
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = TajsOSTheme.VaultSoft),
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         border = BorderStroke(1.dp, TajsOSTheme.VaultBorder),
     ) {
         Column(
@@ -710,7 +710,7 @@ private fun VaultEntryComposer(
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = TajsOSTheme.VaultShell),
-        shape = RoundedCornerShape(16.dp),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         border = BorderStroke(1.dp, TajsOSTheme.VaultBorder),
     ) {
         Column(


### PR DESCRIPTION
This pull request replaces hardcoded UI shape corner radius values (like `RoundedCornerShape(2.dp)`, `4.dp`, `8.dp`, `10.dp`, `16.dp`) with official design system theme tokens (`TajsOSTheme.RadiusSm`, `RadiusMd`, `RadiusLg`).

This strictly applies existing design patterns and standardizes UI components across the app, ensuring a more cohesive, maintainable, and uniform design language.

It affects:
- Briefing screen actions and capture fields
- Calendar month view days
- Dashboard modules
- Decision cards and detail content
- Inbox capture cards
- Notes context graph
- Task descriptions and rows
- Vault application cards

---
*PR created automatically by Jules for task [8117718264714326676](https://jules.google.com/task/8117718264714326676) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized all corner radii by replacing hardcoded `RoundedCornerShape(x.dp)` with design system tokens for consistent shapes across the app. Applied review feedback to use `TajsOSTheme.RadiusXs` where 2–4dp radii were used.

- **Refactors**
  - Replaced dp-based radii with `TajsOSTheme.RadiusXs`, `RadiusSm`, `RadiusMd`, and `RadiusLg` across Briefing, Calendar, Dashboard, Inbox, Notes, Tasks, Vaults, Sidebar, Decision views, and card components.
  - Set `glassChrome` default shape to `RadiusLg`.

<sup>Written for commit df3bf7b61e89902324948d55ca5ad567f5442e2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

