### PR TITLE
fix(ui): Catch ActivityNotFoundException when launching avatar picker

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -179,11 +179,13 @@ class MainActivity : FragmentActivity() {
                         onVoiceCapture = { triggerVoiceCapture() },
                         voiceCaptureResult = voiceText,
                         onVoiceCaptureConsume = { voiceCaptureResult.value = null },
-                        onPickAvatar = { try {
-                            avatarPickerLauncher.launch("image/*")
-                        } catch (e: ActivityNotFoundException) {
-                            Log.w(TAG, "Image picker not available", e)
-                        } },
+                        onPickAvatar = {
+                            try {
+                                avatarPickerLauncher.launch("image/*")
+                            } catch (e: ActivityNotFoundException) {
+                                Log.w(TAG, "Image picker not available", e)
+                            }
+                        },
                         avatarPickResult = avatarRef,
                         onAvatarPickConsume = { avatarPickResult.value = null },
                     )

--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -179,7 +179,11 @@ class MainActivity : FragmentActivity() {
                         onVoiceCapture = { triggerVoiceCapture() },
                         voiceCaptureResult = voiceText,
                         onVoiceCaptureConsume = { voiceCaptureResult.value = null },
-                        onPickAvatar = { avatarPickerLauncher.launch("image/*") },
+                        onPickAvatar = { try {
+                            avatarPickerLauncher.launch("image/*")
+                        } catch (e: ActivityNotFoundException) {
+                            Log.w(TAG, "Image picker not available", e)
+                        } },
                         avatarPickResult = avatarRef,
                         onAvatarPickConsume = { avatarPickResult.value = null },
                     )


### PR DESCRIPTION
Fix potential crash when image picker is unavailable.

---
*PR created automatically by Jules for task [15686442885496669088](https://jules.google.com/task/15686442885496669088) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap the avatar picker launch in a try/catch for ActivityNotFoundException to prevent crashes on devices without an image picker, logging a warning instead.

<sup>Written for commit 539dd69b8e17b23bcd0e81abcb9f21b78aa1c807. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

