### PR TITLE
docs: Add KDocs for query profiles, state assemblers and preferences

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -374,6 +374,14 @@ class PreferencesRepository(
     }
 }
 
+/**
+ * A safety extension for handling data store reads.
+ *
+ * It traps [okio.IOException] (or its platform equivalents) which occur when the underlying
+ * data store file is missing, corrupted, or inaccessible. Instead of crashing the stream,
+ * it emits [emptyPreferences] to ensure the application can start using default values.
+ * Other non-IO exceptions are rethrown.
+ */
 private fun Flow<Preferences>.catchIoException(): Flow<Preferences> = catch { e ->
     if (e is IOException) {
         emit(emptyPreferences())

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -145,11 +145,10 @@ fun buildCalendarEntries(
  * Partitions a flat list of nodes into specialized buckets based on their type, status, and timeline position.
  *
  * This function acts as the primary triage router, separating actionable tasks from
- * reference knowledge, reminders, and historical data (done/archived). It also calculates
- * which tasks are actively in progress versus those stuck in the backlog.
+ * reference knowledge, reminders, and historical data (done/archived).
  *
  * @param list The raw list of active and historic nodes to categorize.
- * @return A structured [NodeCategorization] splitting the nodes into logical buckets (inbox, tasks, knowledge, etc.).
+ * @return A structured [NodeCategorization] split into inbox, archived, and reminder buckets.
  */
 fun categorizeNodes(list: List<NodeWithPin>): NodeCategorization {
     val now = Clock.System.now().toEpochMilliseconds()
@@ -281,8 +280,8 @@ fun buildPlaybookSnapshot(
  * overarching UI state for the main command center.
  *
  * This massive aggregator relies on specialized snapshot calculators (e.g., [calculateAreaHealthSnapshot],
- * [calculateOpenLoopsSnapshot], etc.) to derive specific subsystem states. It then applies the current
- * [ModeQueryProfile] to filter and contextualize the data based on the operator's current active mode
+ * open-loop decay scoring, etc.) to derive specific subsystem states. It then applies the current
+ * [com.tajemniktv.tajsos.data.ModeQueryProfile] to filter and contextualize the data based on the operator's current active mode
  * (e.g., "Deep Work", "Evening Wind Down", "Planning").
  *
  * The resulting state is the source of truth for the entire dashboard UI, driving what blocks, tasks,
@@ -293,6 +292,7 @@ fun buildPlaybookSnapshot(
  * @param modesList The list of available operating modes.
  * @param activeId The ID of the currently active mode, if any.
  * @param areasList The list of all system Area nodes.
+ * @param packs The pack registry for feature availability checks.
  * @return A fully populated [DashboardUIState] reflecting the entire system's status filtered by the active mode.
  */
 suspend fun buildDashboardUIState(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -37,6 +37,19 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 
+/**
+ * Merges internal scheduling data with external calendar events into a unified timeline view.
+ *
+ * This function translates system nodes into generic calendar entries, maps explicit schedule
+ * entries directly onto the timeline, and incorporates external synchronization data (e.g., from
+ * Google Calendar or local ICS files) to give the operator a single, comprehensive view of their
+ * day.
+ *
+ * @param nodes A list of system nodes mapped with their today pin context.
+ * @param scheduleEntries Explicit time-boxed entries configured within TajsOS.
+ * @param externalEvents Pre-synchronized read-only events from external calendar providers.
+ * @return A unified, chronologically sortable list of all temporal commitments.
+ */
 fun buildCalendarEntries(
     nodes: List<NodeWithPin>,
     scheduleEntries: List<ScheduleEntryEntity>,
@@ -128,6 +141,16 @@ fun buildCalendarEntries(
     return entries.sortedBy { it.startAt }
 }
 
+/**
+ * Partitions a flat list of nodes into specialized buckets based on their type, status, and timeline position.
+ *
+ * This function acts as the primary triage router, separating actionable tasks from
+ * reference knowledge, reminders, and historical data (done/archived). It also calculates
+ * which tasks are actively in progress versus those stuck in the backlog.
+ *
+ * @param list The raw list of active and historic nodes to categorize.
+ * @return A structured [NodeCategorization] splitting the nodes into logical buckets (inbox, tasks, knowledge, etc.).
+ */
 fun categorizeNodes(list: List<NodeWithPin>): NodeCategorization {
     val now = Clock.System.now().toEpochMilliseconds()
     val inbox = mutableListOf<NodeWithPin>()
@@ -254,13 +277,23 @@ fun buildPlaybookSnapshot(
 }
 
 /**
- * Assembles the comprehensive view state required for the Dashboard.
+ * Aggregates all domain logic, system health indicators, and snapshot calculators into a single
+ * overarching UI state for the main command center.
  *
- * This function orchestrates a complex, non-obvious data flow by combining raw database nodes
- * with current Operating Mode filters (e.g., excluding specific areas/types). It evaluates
- * heuristic rules to calculate critical state projections such as system load, open loop decay,
- * and area health imbalances. It also derives contextual suggestions (like mode or context hints)
- * based on the current time and available tasks.
+ * This massive aggregator relies on specialized snapshot calculators (e.g., [calculateAreaHealthSnapshot],
+ * [calculateOpenLoopsSnapshot], etc.) to derive specific subsystem states. It then applies the current
+ * [ModeQueryProfile] to filter and contextualize the data based on the operator's current active mode
+ * (e.g., "Deep Work", "Evening Wind Down", "Planning").
+ *
+ * The resulting state is the source of truth for the entire dashboard UI, driving what blocks, tasks,
+ * and warnings are currently visible.
+ *
+ * @param repository The central app repository providing primary read sources.
+ * @param nodes The full list of relevant system nodes wrapped with pin context.
+ * @param modesList The list of available operating modes.
+ * @param activeId The ID of the currently active mode, if any.
+ * @param areasList The list of all system Area nodes.
+ * @return A fully populated [DashboardUIState] reflecting the entire system's status filtered by the active mode.
  */
 suspend fun buildDashboardUIState(
     repository: AppRepository,


### PR DESCRIPTION
Adds KDoc documentation explaining non-obvious flows and trick business rules.

Includes KDoc for:
- `buildCalendarEntries`, `categorizeNodes`, and `buildDashboardUIState` in `MainStateAssemblers.kt`
- `catchIoException` in `PreferencesRepository.kt`

---
*PR created automatically by Jules for task [1230982312120008943](https://jules.google.com/task/1230982312120008943) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add KDocs to clarify complex flows in state assemblers, mode query profiles in dashboard aggregation, and preferences for easier maintenance and onboarding.
Covers `buildCalendarEntries`, `categorizeNodes`, `buildDashboardUIState` in `MainStateAssemblers.kt` (timeline merging with external events, node bucketing, mode-aware UI state via `ModeQueryProfile`) and `catchIoException` in `PreferencesRepository.kt` (IO-safe preference reads).

<sup>Written for commit dc85ba99068ccb92d81b82922d3c29c4e27de6c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

