### PR TITLE
🧪 [test] add error path tests for IcsCalendarProvider date parsing

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsEventBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsEventBuilderTest.kt
@@ -129,4 +129,39 @@ class IcsEventBuilderTest {
         builder.processLine("DTSTART:20231024T") // length < 15, parseIsoDate throws IllegalArgumentException
         assertNull(builder.build(1L))
     }
+
+    @Test
+    fun testParseDateInvalidAllDayDateContent() {
+        val builder = IcsEventBuilder()
+        builder.processLine("DTSTART;VALUE=DATE:2023102A")
+        assertNull(builder.build(1L))
+    }
+
+    @Test
+    fun testParseDateInvalidAllDayDateValue() {
+        val builder = IcsEventBuilder()
+        builder.processLine("DTSTART;VALUE=DATE:20231324")
+        assertNull(builder.build(1L))
+    }
+
+    @Test
+    fun testParseDateInvalidIsoDateContent() {
+        val builder = IcsEventBuilder()
+        builder.processLine("DTSTART:20231024T250000Z")
+        assertNull(builder.build(1L))
+    }
+
+    @Test
+    fun testParseDateInvalidIsoDateLength() {
+        val builder = IcsEventBuilder()
+        builder.processLine("DTSTART:20231024T10000")
+        assertNull(builder.build(1L))
+    }
+
+    @Test
+    fun testParseDateInvalidLengthNoT() {
+        val builder = IcsEventBuilder()
+        builder.processLine("DTSTART:2023102")
+        assertNull(builder.build(1L))
+    }
 }


### PR DESCRIPTION
This PR addresses the missing error path tests for ICS date parsing in `IcsCalendarProvider`. 

🎯 **What:** Added comprehensive error path tests for `IcsEventBuilder.parseDate` (tested via `IcsEventBuilder.build`).
📊 **Coverage:** 
- `testParseDateInvalidAllDayDateContent`: Tests dates with invalid characters (e.g., `2023102A`).
- `testParseDateInvalidAllDayDateValue`: Tests dates with invalid calendar values (e.g., month `13`).
- `testParseDateInvalidIsoDateContent`: Tests ISO dates with invalid time values (e.g., hour `25`).
- `testParseDateInvalidIsoDateLength`: Tests ISO dates that are too short (14 instead of 15+ characters).
- `testParseDateInvalidLengthNoT`: Tests strings that are neither 8 characters nor contain 'T' (e.g., length 7).
✨ **Result:** Improved reliability and test coverage for the ICS calendar provider, ensuring it gracefully handles various malformed date formats common in the wild.

Note: Local Gradle execution was hindered by sandbox environment network/timeout constraints, but the logic was verified against the source code and simulated via script. All temporary environment changes (JVM downgrades) and scratchpad scripts have been reverted/cleaned up.

---
*PR created automatically by Jules for task [611117062166539674](https://jules.google.com/task/611117062166539674) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add error-path tests for ICS date parsing so `IcsCalendarProvider` returns null for malformed dates via `IcsEventBuilder.build`. Covers invalid characters, invalid calendar values, invalid ISO times, too-short ISO strings, and missing 'T'.

<sup>Written for commit 06aa8b6231bec25e871b532ffb526d1e48b580e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

