### PR TITLE
fix(android): improve intent handling reliability

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -178,7 +178,11 @@ class MainActivity : FragmentActivity() {
                         onVoiceCapture = { triggerVoiceCapture() },
                         voiceCaptureResult = voiceText,
                         onVoiceCaptureConsume = { voiceCaptureResult.value = null },
-                        onPickAvatar = { avatarPickerLauncher.launch("image/*") },
+                        onPickAvatar = { try {
+                            avatarPickerLauncher.launch("image/*")
+                        } catch (e: android.content.ActivityNotFoundException) {
+                            Log.e(TAG, "No image picker available", e)
+                        } },
                         avatarPickResult = avatarRef,
                         onAvatarPickConsume = { avatarPickResult.value = null },
                     )
@@ -216,6 +220,7 @@ class MainActivity : FragmentActivity() {
      * @param intent The new intent that was started for the activity.
      */
     override fun onNewIntent(intent: Intent) {
+        setIntent(intent)
         super.onNewIntent(intent)
         handleIntent(intent)
     }
@@ -307,7 +312,7 @@ class MainActivity : FragmentActivity() {
             }
         try {
             speechRecognizerLauncher.launch(intent)
-        } catch (e: Exception) {
+        } catch (e: android.content.ActivityNotFoundException) {
             // Speech recognizer not available
         }
     }

--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -220,8 +220,8 @@ class MainActivity : FragmentActivity() {
      * @param intent The new intent that was started for the activity.
      */
     override fun onNewIntent(intent: Intent) {
-        setIntent(intent)
         super.onNewIntent(intent)
+        setIntent(intent)
         handleIntent(intent)
     }
 

--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -312,8 +312,10 @@ class MainActivity : FragmentActivity() {
             }
         try {
             speechRecognizerLauncher.launch(intent)
+        try {
+            speechRecognizerLauncher.launch(intent)
         } catch (e: android.content.ActivityNotFoundException) {
-            // Speech recognizer not available
+            Log.w(TAG, "Speech recognizer activity not found", e)
         }
     }
 


### PR DESCRIPTION
This PR improves the reliability of Android intent handling in `MainActivity`.

Changes:
1. Narrows the generic exception catching around `speechRecognizerLauncher.launch` to specifically catch `ActivityNotFoundException`. This prevents unrelated bugs (like `NullPointerException` or `OutOfMemoryError`) from being silently swallowed during speech recognition launch.
2. Wraps `avatarPickerLauncher.launch` in a try-catch for `ActivityNotFoundException`. This prevents potential app crashes on specific devices (or custom ROMs) that lack a default image picker application.
3. Adds a call to `setIntent(intent)` inside `onNewIntent`. This is a standard Android best practice to ensure that any subsequent calls to `getIntent()` return the most recent intent, averting bugs related to stale intent data (especially given `singleTop` or similar launch modes).

---
*PR created automatically by Jules for task [2851638464285070475](https://jules.google.com/task/2851638464285070475) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Android intent handling in `MainActivity` to prevent crashes when required activities are missing and ensure `getIntent()` returns the latest intent. Adds clearer logs for missing image picker and speech recognizer.

- **Bug Fixes**
  - Call `setIntent(intent)` in `onNewIntent` so `getIntent()` returns the latest intent.
  - Catch only `android.content.ActivityNotFoundException` around `speechRecognizerLauncher.launch` and log a warning when the recognizer activity is missing.
  - Wrap `avatarPickerLauncher.launch("image/*")` in a try/catch for `android.content.ActivityNotFoundException` and log an error when no picker is available.

<sup>Written for commit d34d0d70aa0217e82f91e26797b31d28084bb8fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

