### PR TITLE
docs: Add missing KDocs to core entities

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
@@ -14,8 +14,12 @@ import androidx.room.Relation
 import kotlinx.serialization.Serializable
 
 /**
- * NodeEntity is the central entity in TajsOS, representing everything from
- * tasks and notes to projects and areas.
+ * NodeEntity is the central polymorphic entity in TajsOS, acting as the primary system object.
+ * It represents everything from tasks and notes to projects, records, and areas.
+ *
+ * Architectural Note: This is an overloaded legacy surface. While it supports generic string types
+ * (`type`, `status`), new domain behavior should prefer typed models and companion structures
+ * (e.g. `ItemKind`) instead of relying purely on this table to prevent string-state sprawl.
  */
 @Entity(
     tableName = "nodes",
@@ -487,7 +491,10 @@ data class TrackMedicationJoinEntity(
 )
 
 /**
- * RelationEntity links items to other items or entities.
+ * Represents a directed relationship graph edge between two nodes.
+ *
+ * This table serves as a first-class capability for creating the LifeOS graph network,
+ * enabling bidirectional relationships, hierarchy representations, and knowledge linking.
  */
 @Entity(
     tableName = "relations",

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
@@ -18,8 +18,8 @@ import kotlinx.serialization.Serializable
  * It represents everything from tasks and notes to projects, records, and areas.
  *
  * Architectural Note: This is an overloaded legacy surface. While it supports generic string types
- * (`type`, `status`), new domain behavior should prefer typed models and companion structures
- * (e.g. `ItemKind`) instead of relying purely on this table to prevent string-state sprawl.
+ * ([type], [status]), new domain behavior should prefer typed models and companion structures
+ * (e.g. [ItemKind]) instead of relying purely on this table to prevent string-state sprawl.
  */
 @Entity(
     tableName = "nodes",

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -99,7 +99,8 @@ private val healthTitleKeywords =
  * These helpers keep query logic out of UI composables and avoid pushing more orchestration
  * into [com.tajemniktv.tajsos.ui.MainViewModel].
  *
- * Domains (such as finance or health) are categorized implicitly by checking for hardcoded
+ * Domains (such as finance or health) act as product-level lenses over the shared object spine,
+ * rather than acting as hard containers. They are categorized implicitly by checking for hardcoded
  * string markers within node tags, titles, content, `maintenanceType`, and `noteType` fields.
  * This heuristic-based approach provides a zero-configuration experience, allowing items to be surfaced
  * appropriately even if the user forgets to manually assign the domain.


### PR DESCRIPTION
Added class-level KDocs to public entities in Entities.kt

---
*PR created automatically by Jules for task [8861529090054145001](https://jules.google.com/task/8861529090054145001) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added class-level KDocs for `NodeEntity` (polymorphic legacy surface) and `RelationEntity` (directed graph edge for links and hierarchy). Updated `com.tajemniktv.tajsos.domain.lens.DomainLensQueries` docs to present domains as product lenses and reinforce the shift to typed models over string fields.

<sup>Written for commit 70c61fa6d9e190e580595fa49379b54f2fd2c8ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

