### PR TITLE
test: add coverage for PackRegistry isOwned

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
@@ -79,4 +79,18 @@ class PackRegistryTest {
         assertTrue(missing.contains(expectedError))
         assertTrue(missing.size == 1)
     }
+
+    @Test
+    fun packRegistry_reportsOwnedPacks() {
+        val registry =
+            PackRegistry(
+                ownedPackKeys = setOf(AppPack.STUDENT.key, AppPack.CREATOR.key),
+                enabledPackKeys = emptySet(),
+            )
+        assertTrue(registry.isOwned(AppPack.STUDENT))
+        assertTrue(registry.isOwned(AppPack.CREATOR))
+        assertFalse(registry.isOwned(AppPack.FINANCE))
+        assertFalse(registry.isOwned(AppPack.MAINTENANCE))
+    }
+
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
@@ -81,6 +81,9 @@ class PackRegistryTest {
     }
 
     @Test
+    /**
+    * Verifies that [PackRegistry.isOwned] returns true only for packs present in `ownedPackKeys`.
+    */
     fun packRegistry_reportsOwnedPacks() {
         val registry =
             PackRegistry(


### PR DESCRIPTION
Added unit tests for PackRegistry.isOwned.

---
*PR created automatically by Jules for task [10609712238477097152](https://jules.google.com/task/10609712238477097152) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added unit tests for PackRegistry.isOwned to ensure it returns true only for packs in ownedPackKeys and false for others.

<sup>Written for commit 6db573b28e6385c82a2e26bde1049eff6acc307b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

