### PR TITLE
🧪 test: Add tests for PackRegistry.isDependencySatisfied

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
@@ -79,4 +79,23 @@ class PackRegistryTest {
         assertTrue(missing.contains(expectedError))
         assertTrue(missing.size == 1)
     }
+
+    @Test
+    fun isDependencySatisfied_returnsTrueWhenNoDependencies() {
+        val registry = PackRegistry(emptySet(), emptySet())
+        assertTrue(registry.isDependencySatisfied(AppPack.STUDENT))
+    }
+
+    @Test
+    fun isDependencySatisfied_returnsTrueWhenDependenciesMet() {
+        val registry = PackRegistry(emptySet(), setOf(AppPack.MAINTENANCE.key))
+        assertTrue(registry.isDependencySatisfied(AppPack.FINANCE))
+    }
+
+    @Test
+    fun isDependencySatisfied_returnsFalseWhenDependenciesNotMet() {
+        val registry = PackRegistry(emptySet(), emptySet())
+        assertFalse(registry.isDependencySatisfied(AppPack.FINANCE))
+    }
+
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
@@ -82,19 +82,19 @@ class PackRegistryTest {
 
     @Test
     fun isDependencySatisfied_returnsTrueWhenNoDependencies() {
-        val registry = PackRegistry(emptySet(), emptySet())
+val registry = PackRegistry(ownedPackKeys = emptySet(), enabledPackKeys = emptySet())
         assertTrue(registry.isDependencySatisfied(AppPack.STUDENT))
     }
 
     @Test
     fun isDependencySatisfied_returnsTrueWhenDependenciesMet() {
-        val registry = PackRegistry(emptySet(), setOf(AppPack.MAINTENANCE.key))
+val registry = PackRegistry(ownedPackKeys = emptySet(), enabledPackKeys = setOf(AppPack.MAINTENANCE.key))
         assertTrue(registry.isDependencySatisfied(AppPack.FINANCE))
     }
 
     @Test
     fun isDependencySatisfied_returnsFalseWhenDependenciesNotMet() {
-        val registry = PackRegistry(emptySet(), emptySet())
+val registry = PackRegistry(ownedPackKeys = emptySet(), enabledPackKeys = emptySet())
         assertFalse(registry.isDependencySatisfied(AppPack.FINANCE))
     }
 

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
@@ -80,6 +80,7 @@ class PackRegistryTest {
         assertTrue(missing.size == 1)
     }
 
+    @Test
     /**
      * Verifies that [PackRegistry.isOwned] returns true only for packs present in `ownedPackKeys`.
      */


### PR DESCRIPTION
🎯 **What:** The testing gap for `PackRegistry.isDependencySatisfied` is addressed.
📊 **Coverage:** Happy paths, empty dependencies, and unmet dependencies are covered.
✨ **Result:** Improved test coverage for PackRegistry.

---
*PR created automatically by Jules for task [15189980842154590613](https://jules.google.com/task/15189980842154590613) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add three tests for `PackRegistry.isDependencySatisfied` (no deps, deps met, deps unmet) and a missing `@Test` in `PackRegistryTest` to ensure they run and prevent regressions.

<sup>Written for commit 051bf8590875bc75bc9887226847b3fe4ced0a34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

