### PR TITLE
🧪 [test] add test coverage for isPrivateOrLocal

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserTest.kt
@@ -97,4 +97,39 @@ class InetAddressParserTest {
         assertNull(parseIpAddress(":::"), "Should reject triple colons or more")
         assertNull(parseIpAddress("1:::2"), "Should reject triple colons or more")
     }
+
+    @Test
+    fun testIsPrivateOrLocal() {
+        val loopbackV4 = parseIpAddress("127.0.0.1")
+        assertNotNull(loopbackV4)
+        assertTrue(loopbackV4.isPrivateOrLocal())
+
+        val loopbackV6 = parseIpAddress("::1")
+        assertNotNull(loopbackV6)
+        assertTrue(loopbackV6.isPrivateOrLocal())
+
+        val linkLocalV4 = parseIpAddress("169.254.1.2")
+        assertNotNull(linkLocalV4)
+        assertTrue(linkLocalV4.isPrivateOrLocal())
+
+        val linkLocalV6 = parseIpAddress("fe80::1")
+        assertNotNull(linkLocalV6)
+        assertTrue(linkLocalV6.isPrivateOrLocal())
+
+        val siteLocalV4 = parseIpAddress("192.168.1.1")
+        assertNotNull(siteLocalV4)
+        assertTrue(siteLocalV4.isPrivateOrLocal())
+
+        val siteLocalV6 = parseIpAddress("fd00::1")
+        assertNotNull(siteLocalV6)
+        assertTrue(siteLocalV6.isPrivateOrLocal())
+
+        val publicV4 = parseIpAddress("8.8.8.8")
+        assertNotNull(publicV4)
+        assertFalse(publicV4.isPrivateOrLocal())
+
+        val publicV6 = parseIpAddress("2001:4860:4860::8888")
+        assertNotNull(publicV6)
+        assertFalse(publicV6.isPrivateOrLocal())
+    }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserTest.kt
@@ -116,9 +116,17 @@ class InetAddressParserTest {
         assertNotNull(linkLocalV6)
         assertTrue(linkLocalV6.isPrivateOrLocal())
 
-        val siteLocalV4 = parseIpAddress("192.168.1.1")
-        assertNotNull(siteLocalV4)
-        assertTrue(siteLocalV4.isPrivateOrLocal())
+        val siteLocalV4_10 = parseIpAddress("10.0.0.1")
+        assertNotNull(siteLocalV4_10)
+        assertTrue(siteLocalV4_10.isPrivateOrLocal())
+
+        val siteLocalV4_172 = parseIpAddress("172.16.0.1")
+        assertNotNull(siteLocalV4_172)
+        assertTrue(siteLocalV4_172.isPrivateOrLocal())
+
+        val siteLocalV4_192 = parseIpAddress("192.168.1.1")
+        assertNotNull(siteLocalV4_192)
+        assertTrue(siteLocalV4_192.isPrivateOrLocal())
 
         val siteLocalV6 = parseIpAddress("fd00::1")
         assertNotNull(siteLocalV6)


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for the `isPrivateOrLocal` public method in `IpAddress`.

📊 **Coverage:** Covered all states: loopback, link-local, site-local, and public ranges for both IPv4 and IPv6.

✨ **Result:** Enhanced test coverage and ensured safety against potential SSRF vulnerabilities.

---
*PR created automatically by Jules for task [297230632971972644](https://jules.google.com/task/297230632971972644) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add IPv4/IPv6 tests for `IpAddress.isPrivateOrLocal()` covering loopback, link-local, site-local, and public addresses, including positive/negative cases to prevent SSRF regressions.

<sup>Written for commit f128d2043abc3b230bddf0d8818cdd809feb71dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

