### PR TITLE
🧪 test: Add GreetingTest for platform-specific greeting

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/GreetingTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/GreetingTest.kt
@@ -3,8 +3,10 @@ package com.tajemniktv.tajsos
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+/** Verifies the platform-specific greeting format returned by [Greeting.greet]. */
 class GreetingTest {
-    @Test
+    /** Ensures greeting includes greeting includes prefix, suffix, and non-empty platform segment. */
+    `@Test`
     fun testGreeting() {
         val greeting = Greeting().greet()
         assertTrue(greeting.startsWith("Hello, "), "Greeting should start with 'Hello, '")

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/GreetingTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/GreetingTest.kt
@@ -1,0 +1,14 @@
+package com.tajemniktv.tajsos
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class GreetingTest {
+    @Test
+    fun testGreeting() {
+        val greeting = Greeting().greet()
+        assertTrue(greeting.startsWith("Hello, "), "Greeting should start with 'Hello, '")
+        assertTrue(greeting.endsWith("!"), "Greeting should end with '!'")
+        assertTrue(greeting.length > 8, "Greeting should contain a platform name")
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added missing test file for Greeting class.
📊 **Coverage:** Covered the simple happy path checking prefix, suffix and minimum length for 'Hello, {platform.name}!'.
✨ **Result:** Improved test coverage by verifying the pure platform greeting string.

---
*PR created automatically by Jules for task [17937540170827656203](https://jules.google.com/task/17937540170827656203) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `GreetingTest` to validate the platform-specific greeting from `Greeting.greet()` ("Hello, {platform}!"). The test asserts the "Hello, " prefix, "!" suffix, and a minimum length to ensure a non-empty platform name.

<sup>Written for commit a231d2506da930e921dd1c6e8e6d11786f348e8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

