### PR TITLE
test: improve PackRegistry test coverage

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
@@ -60,8 +60,14 @@ class PackRegistryTest {
     @Test
     fun isDependencySatisfied_returnsCorrectStatus() {
         // AppPack.FINANCE requires "maintenance"
-        val registryWithDep = PackRegistry(emptySet(), setOf(AppPack.MAINTENANCE.key))
-        val registryWithoutDep = PackRegistry(emptySet(), emptySet())
+        val registryWithDep = PackRegistry(
+            ownedPackKeys = emptySet(),
+            enabledPackKeys = setOf(AppPack.MAINTENANCE.key),
+        )
+        val registryWithoutDep = PackRegistry(
+            ownedPackKeys = emptySet(),
+            enabledPackKeys = emptySet(),
+        )
 
         assertTrue(registryWithDep.isDependencySatisfied(AppPack.FINANCE))
         assertFalse(registryWithoutDep.isDependencySatisfied(AppPack.FINANCE))

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PackRegistryTest.kt
@@ -32,23 +32,49 @@ class PackRegistryTest {
         assertFalse(noPacks.canUseMode("STUDY"))
         assertTrue(studentPack.canUseMode("STUDY"))
         assertTrue(studentPack.canUseMode("study")) // Case sensitivity
+        assertTrue(studentPack.canUseMode("StUdY"))
 
         // ADMIN
         assertFalse(noPacks.canUseMode("ADMIN"))
         assertTrue(financePack.canUseMode("ADMIN"))
+        assertTrue(financePack.canUseMode("admin"))
         assertTrue(maintenancePack.canUseMode("ADMIN"))
+        assertTrue(maintenancePack.canUseMode("AdMiN"))
 
         // ERRAND
         assertFalse(noPacks.canUseMode("ERRAND"))
         assertTrue(maintenancePack.canUseMode("ERRAND"))
+        assertTrue(maintenancePack.canUseMode("errand"))
 
         // SHUTDOWN
         assertFalse(noPacks.canUseMode("SHUTDOWN"))
         assertTrue(protocolsPack.canUseMode("SHUTDOWN"))
+        assertTrue(protocolsPack.canUseMode("shutdown"))
 
         // Unknown modes
         assertTrue(noPacks.canUseMode("UNKNOWN"))
+        assertTrue(noPacks.canUseMode("unknown"))
         assertTrue(noPacks.canUseMode(""))
+    }
+
+    @Test
+    fun isDependencySatisfied_returnsCorrectStatus() {
+        // AppPack.FINANCE requires "maintenance"
+        val registryWithDep = PackRegistry(emptySet(), setOf(AppPack.MAINTENANCE.key))
+        val registryWithoutDep = PackRegistry(emptySet(), emptySet())
+
+        assertTrue(registryWithDep.isDependencySatisfied(AppPack.FINANCE))
+        assertFalse(registryWithoutDep.isDependencySatisfied(AppPack.FINANCE))
+
+        // AppPack.STUDENT requires nothing
+        assertTrue(registryWithoutDep.isDependencySatisfied(AppPack.STUDENT))
+    }
+
+    @Test
+    fun isOwned_returnsCorrectStatus() {
+        val registry = PackRegistry(setOf(AppPack.STUDENT.key), emptySet())
+        assertTrue(registry.isOwned(AppPack.STUDENT))
+        assertFalse(registry.isOwned(AppPack.FINANCE))
     }
 
     @Test


### PR DESCRIPTION
Expands canUseMode tests with case insensitivity checks and adds tests for isOwned and isDependencySatisfied.

---
*PR created automatically by Jules for task [2546323952452712361](https://jules.google.com/task/2546323952452712361) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand PackRegistry test coverage to verify case-insensitive mode checks (including mixed-case and "unknown"), and add tests for isOwned and dependency satisfaction (FINANCE requires MAINTENANCE; STUDENT has none). This reduces risk of regressions in mode handling and pack dependency logic.

<sup>Written for commit 1458fd57fd181d6829c7f83166038805b09c13e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

