### PR TITLE
fix(server): replace hardcoded version in health route

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -15,7 +15,10 @@ application {
     mainClass.set("com.tajemniktv.tajsos.ApplicationKt")
 
     val isDevelopment: Boolean = project.ext.has("development")
-    applicationDefaultJvmArgs = listOf("-Dio.ktor.development=$isDevelopment")
+    applicationDefaultJvmArgs = listOf(
+        "-Dio.ktor.development=$isDevelopment",
+        "-Dktor.application.version=${project.version}"
+    )
 }
 
 kotlin {

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/routes/HealthRoutes.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/routes/HealthRoutes.kt
@@ -9,10 +9,13 @@ fun Route.healthRoutes() {
     val startTime = System.currentTimeMillis()
 
     get("/health") {
+        val version = application.environment.config.propertyOrNull("ktor.application.version")?.getString()
+            ?: "1.0.0"
+
         call.respond(
             HealthResponse(
                 status = "OK",
-                version = "1.0.0", // Hardcoded for now, could be passed from build
+                version = version,
                 uptime = System.currentTimeMillis() - startTime
             )
         )

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/routes/HealthRoutes.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/routes/HealthRoutes.kt
@@ -10,7 +10,7 @@ fun Route.healthRoutes() {
 
     get("/health") {
         val version = application.environment.config.propertyOrNull("ktor.application.version")?.getString()
-            ?: "1.0.0"
+            ?: "unknown"
 
         call.respond(
             HealthResponse(

--- a/server/src/test/kotlin/com/tajemniktv/tajsos/ApplicationTest.kt
+++ b/server/src/test/kotlin/com/tajemniktv/tajsos/ApplicationTest.kt
@@ -32,7 +32,10 @@ class ApplicationTest {
     @Test
     fun testSyncEndpoint_Unauthorized(): TestResult = testApplication {
         environment {
-            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+            config = io.ktor.server.config.MapApplicationConfig(
+                "TAJSOS_SYNC_TOKEN" to "default-dev-token",
+                "ktor.application.version" to "1.0.0"
+            )
         }
         application {
             module()
@@ -48,7 +51,10 @@ class ApplicationTest {
     @Test
     fun testRoot(): TestResult = testApplication {
         environment {
-            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+            config = io.ktor.server.config.MapApplicationConfig(
+                "TAJSOS_SYNC_TOKEN" to "default-dev-token",
+                "ktor.application.version" to "1.0.0"
+            )
         }
         application {
             module()
@@ -61,7 +67,10 @@ class ApplicationTest {
     @Test
     fun testHealthEndpoint(): TestResult = testApplication {
         environment {
-            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+            config = io.ktor.server.config.MapApplicationConfig(
+                "TAJSOS_SYNC_TOKEN" to "default-dev-token",
+                "ktor.application.version" to "1.2.3"
+            )
         }
         application {
             module()
@@ -82,14 +91,17 @@ class ApplicationTest {
 
         val health = response.body<HealthResponse>()
         assertEquals("OK", health.status)
-        assertEquals("1.0.0", health.version)
+        assertEquals("1.2.3", health.version)
         assertTrue(health.uptime >= 0)
     }
 
     @Test
     fun testSyncEndpoint_HappyPath(): TestResult = testApplication {
         environment {
-            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+            config = io.ktor.server.config.MapApplicationConfig(
+                "TAJSOS_SYNC_TOKEN" to "default-dev-token",
+                "ktor.application.version" to "1.0.0"
+            )
         }
         application {
             module()
@@ -141,7 +153,10 @@ class ApplicationTest {
     @Test
     fun testSyncEndpoint_BadPayload(): TestResult = testApplication {
         environment {
-            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+            config = io.ktor.server.config.MapApplicationConfig(
+                "TAJSOS_SYNC_TOKEN" to "default-dev-token",
+                "ktor.application.version" to "1.0.0"
+            )
         }
         application {
             module()
@@ -162,7 +177,10 @@ class ApplicationTest {
     @Test
     fun testSyncEndpoint_returnsDeltaAndConflict(): TestResult = testApplication {
         environment {
-            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+            config = io.ktor.server.config.MapApplicationConfig(
+                "TAJSOS_SYNC_TOKEN" to "default-dev-token",
+                "ktor.application.version" to "1.0.0"
+            )
         }
         application {
             module()
@@ -234,7 +252,10 @@ class ApplicationTest {
     @Test
     fun testSyncEndpoint_MissingContentType(): TestResult = testApplication {
         environment {
-            config = io.ktor.server.config.MapApplicationConfig("TAJSOS_SYNC_TOKEN" to "default-dev-token")
+            config = io.ktor.server.config.MapApplicationConfig(
+                "TAJSOS_SYNC_TOKEN" to "default-dev-token",
+                "ktor.application.version" to "1.0.0"
+            )
         }
         application {
             module()


### PR DESCRIPTION
### 🎯 What
Replaced the hardcoded application version "1.0.0" in the server's health check route with a dynamic value injected from the Gradle build configuration.

### ⚠️ Risk
Hardcoded versions lead to maintenance overhead and can expose stale or misleading diagnostic information to monitoring tools and users. In a security context, accurate versioning is crucial for vulnerability management and incident response.

### 🛡️ Solution
- Modified `server/build.gradle.kts` to pass `project.version` to the application via the `ktor.application.version` JVM system property.
- Updated `HealthRoutes.kt` to retrieve the version from the Ktor environment configuration with a safe fallback.
- Updated `ApplicationTest.kt` to include the version in the test environment, ensuring all tests remain valid and verifying the health endpoint logic.

**Note on Testing:** Full test execution in the sandbox was blocked due to the environment lacking JVM 25 (required by the project). However, the implementation was verified through manual code inspection and is designed to be safe, idiomatic, and backward-compatible.

---
*PR created automatically by Jules for task [15064365981846299240](https://jules.google.com/task/15064365981846299240) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the app version dynamically in the `/health` endpoint by injecting Gradle `project.version`. Monitoring now reports the correct version without code changes.

- **Bug Fixes**
  - Pass version via JVM arg `-Dktor.application.version` from `server/build.gradle.kts`.
  - Read version in `HealthRoutes` with a fallback to "unknown".
  - Update tests to set `ktor.application.version` and verify the reported version (e.g., "1.2.3").

<sup>Written for commit a7523ff0fb00ccd9ac7ca4f964f3610313b067b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

