### PR TITLE
refactor: 🧹 restrict exception catch in timezone fallback

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
@@ -9,6 +9,7 @@ import com.tajemniktv.tajsos.data.CalendarProviderEntity
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
+import kotlinx.datetime.IllegalTimeZoneException
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
@@ -339,7 +340,7 @@ internal class IcsEventBuilder {
             Regex("TZID=([^;:]+)").find(rawKey) ?: return TimeZone.currentSystemDefault()
         return try {
             TimeZone.of(tzidMatch.groupValues[1])
-        } catch (e: Exception) {
+        } catch (e: IllegalTimeZoneException) {
             TimeZone.currentSystemDefault()
         }
     }


### PR DESCRIPTION
🎯 **What:** Restricting the broad `Exception` catch to `IllegalTimeZoneException` in the `extractTimeZone` method of `IcsCalendarProvider.kt`.

💡 **Why:** Catching a broad `Exception` can hide unexpected issues (like `NullPointerException` or other runtime errors) that should be surfaced. Restricting it to `IllegalTimeZoneException` ensures that only known, expected parsing errors are handled by the fallback mechanism, improving code robustness and observability.

✅ **Verification:**
- Manually verified the code change using `read_file` to ensure correct syntax and logic.
- Attempted to run the relevant unit tests (`IcsEventBuilderTest`), though execution was blocked by local environment issues (Gradle download timeout).
- Obtained a successful code review validating the fix.

✨ **Result:** Improved error handling precision in the ICS calendar provider, leading to a more maintainable and predictable codebase.

---
*PR created automatically by Jules for task [12415034644573468907](https://jules.google.com/task/12415034644573468907) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit timezone parsing catch in `IcsEventBuilder.extractTimeZone` to `kotlinx.datetime.IllegalTimeZoneException` instead of broad `Exception`. This avoids masking unexpected errors while preserving the fallback to the system default timezone.

<sup>Written for commit c98e31f9794d6f681d342a8cfc30acd461ed97a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

