### PR TITLE
🧪 test: Add Error Path Test for IcsCalendarProvider URL Validation

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProviderTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProviderTest.kt
@@ -325,4 +325,39 @@ class IcsCalendarProviderTest {
                 assertEquals(expectedCount, events.size, "Failed for URL: $url")
             }
         }
+
+    @Test
+    fun `test URL validation rejects malformed strings`(): TestResult =
+        runTest {
+            val ics =
+                """
+                BEGIN:VCALENDAR
+                END:VCALENDAR
+                """.trimIndent()
+
+            val provider = createProviderWithIcs(ics)
+
+            val malformedUrls = listOf(
+                "not-a-url",
+                "http://",
+                "https://",
+                "://example.com",
+                "http:/example.com",
+                "\u0000\u0000",
+                " ",
+                "",
+            )
+
+            for (url in malformedUrls) {
+                val entity =
+                    CalendarProviderEntity(
+                        id = 1,
+                        name = "Test",
+                        type = "ICS",
+                        url = url,
+                    )
+                val events = provider.fetchEvents(entity, defaultFrom, defaultTo)
+                assertEquals(0, events.size, "Failed to reject malformed URL: $url")
+            }
+        }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for testing IcsCalendarProvider validation
📊 **Coverage:** Test malformed and bad URLs
✨ **Result:** Enhanced test coverage for URL validation logic

---
*PR created automatically by Jules for task [17161903080573621145](https://jules.google.com/task/17161903080573621145) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to verify `IcsCalendarProvider` rejects malformed URLs and returns no events for invalid inputs. Improves coverage of URL validation across empty strings, whitespace, invalid schemes, and control characters.

<sup>Written for commit 4bd97b3741732918c16010ba66d298237485d839. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

