### PR TITLE
test: Add GreetingTest to verify platform-specific greeting

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -69,8 +69,8 @@ import com.tajemniktv.tajsos.ui.MainViewModel
 class MainActivity : FragmentActivity() {
     companion object {
         private const val TAG = "MainActivity"
-        private const val BIOMETRIC_KEY_ALIAS = "tajsos_biometric_key"
-        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        const val BIOMETRIC_KEY_ALIAS = "tajsos_biometric_key"
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
         private const val CIPHER_TRANSFORMATION =
             "${KeyProperties.KEY_ALGORITHM_AES}/${KeyProperties.BLOCK_MODE_GCM}/${KeyProperties.ENCRYPTION_PADDING_NONE}"
     }
@@ -311,8 +311,6 @@ class MainActivity : FragmentActivity() {
                 )
                 putExtra(RecognizerIntent.EXTRA_PROMPT, getString(R.string.voice_speak_now))
             }
-        try {
-            speechRecognizerLauncher.launch(intent)
         try {
             speechRecognizerLauncher.launch(intent)
         } catch (e: android.content.ActivityNotFoundException) {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/GreetingTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/GreetingTest.kt
@@ -1,0 +1,14 @@
+package com.tajemniktv.tajsos
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class GreetingTest {
+    @Test
+    fun testGreeting() {
+        val greeting = Greeting().greet()
+        assertTrue(greeting.startsWith("Hello, "), "Greeting should start with 'Hello, '")
+        assertTrue(greeting.endsWith("!"), "Greeting should end with '!'")
+        assertTrue(greeting.length > 8, "Greeting should contain a platform name")
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `GreetingTest` to verify the platform-specific greeting format ("Hello, …!") across targets. Exposes `BIOMETRIC_KEY_ALIAS` and `ANDROID_KEYSTORE` as public `const` in `MainActivity` for reuse and removes a duplicate speech recognizer launch.

<sup>Written for commit 8ece281820e4d9fd97b8d2e2eeba5bb66e43c149. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

