### PR TITLE
docs: Add missing KDocs to core entities and fix Android IntentCompat…

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -488,7 +488,7 @@ class MainActivity : FragmentActivity() {
      */
     private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableExtra(name: String): T? =
         try {
-            IntentCompat.getParcelableExtra(this, name, T::class.java)
+            androidx.core.content.IntentCompat.getParcelableExtra(this, name, T::class.java)
         } catch (e: BadParcelableException) {
             Log.e(TAG, "Failed to read parcelable extra: $name: ${e.javaClass.simpleName}")
             null
@@ -502,7 +502,7 @@ class MainActivity : FragmentActivity() {
      */
     private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableArrayListExtra(name: String): java.util.ArrayList<T>? =
         try {
-            IntentCompat.getParcelableArrayListExtra(this, name, T::class.java)
+            androidx.core.content.IntentCompat.getParcelableArrayListExtra(this, name, T::class.java)
         } catch (e: BadParcelableException) {
             Log.e(TAG, "Failed to read parcelable array list extra: $name: ${e.javaClass.simpleName}")
             null

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
@@ -14,8 +14,12 @@ import androidx.room.Relation
 import kotlinx.serialization.Serializable
 
 /**
- * NodeEntity is the central entity in TajsOS, representing everything from
- * tasks and notes to projects and areas.
+ * NodeEntity is the central polymorphic entity in TajsOS, acting as the primary system object.
+ * It represents everything from tasks and notes to projects, records, and areas.
+ *
+ * Architectural Note: This is an overloaded legacy surface. While it supports generic string types
+ * (`type`, `status`), new domain behavior should prefer typed models and companion structures
+ * (e.g. `ItemKind`) instead of relying purely on this table to prevent string-state sprawl.
  */
 @Entity(
     tableName = "nodes",
@@ -487,7 +491,10 @@ data class TrackMedicationJoinEntity(
 )
 
 /**
- * RelationEntity links items to other items or entities.
+ * Represents a directed relationship graph edge between two nodes.
+ *
+ * This table serves as a first-class capability for creating the LifeOS graph network,
+ * enabling bidirectional relationships, hierarchy representations, and knowledge linking.
  */
 @Entity(
     tableName = "relations",

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -99,7 +99,8 @@ private val healthTitleKeywords =
  * These helpers keep query logic out of UI composables and avoid pushing more orchestration
  * into [com.tajemniktv.tajsos.ui.MainViewModel].
  *
- * Domains (such as finance or health) are categorized implicitly by checking for hardcoded
+ * Domains (such as finance or health) act as product-level lenses over the shared object spine,
+ * rather than acting as hard containers. They are categorized implicitly by checking for hardcoded
  * string markers within node tags, titles, content, `maintenanceType`, and `noteType` fields.
  * This heuristic-based approach provides a zero-configuration experience, allowing items to be surfaced
  * appropriately even if the user forgets to manually assign the domain.


### PR DESCRIPTION
… issues\n\nAdds comprehensive class-level KDocs to the primary data classes\nin Entities.kt. This explicitly documents NodeEntity as an\noverloaded legacy surface that handles polymorphic items while\nemphasizing the architectural shift towards typed models.\nAlso resolves Android IntentCompat getParcelableExtra generic type resolution issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing KDocs to core entities, clarifying `NodeEntity` as a polymorphic legacy surface (prefer typed models) and `RelationEntity` as a directed graph edge, and tightening entity KDocs formatting.
Fixes Android parcelable extra retrieval by using fully qualified `androidx.core.content.IntentCompat` calls and safe wrappers for `getSafeParcelableExtra`/`getSafeParcelableArrayListExtra` that catch `BadParcelableException` and `ParcelFormatException`.

<sup>Written for commit a02b50a6e2eae01092e3b6a58526b0ec94b915f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

