### PR TITLE
docs: Add KDocs for query profiles, state assemblers and preferences

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -530,6 +530,14 @@ interface ItemDomainDao {
     suspend fun upsertDomain(domain: ItemDomainEntity)
 
     /**
+     * Batch inserts new domain associations or updates existing ones.
+     *
+     * @param domains The list of [ItemDomainEntity] objects to be inserted or updated.
+     */
+    @Upsert
+    suspend fun upsertDomains(domains: List<ItemDomainEntity>)
+
+    /**
      * Deletes a specific domain association for a life object.
      *
      * @param itemId The unique identifier of the life object.

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -374,6 +374,14 @@ class PreferencesRepository(
     }
 }
 
+/**
+ * A safety extension for handling data store reads.
+ *
+ * It traps [okio.IOException] (or its platform equivalents) which occur when the underlying
+ * data store file is missing, corrupted, or inaccessible. Instead of crashing the stream,
+ * it emits [emptyPreferences] to ensure the application can start using default values.
+ * Other non-IO exceptions are rethrown.
+ */
 private fun Flow<Preferences>.catchIoException(): Flow<Preferences> = catch { e ->
     if (e is IOException) {
         emit(emptyPreferences())

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -128,6 +128,11 @@ private object NoOpItemDomainDao : ItemDomainDao {
     /**
      * Fallback, no-operation implementation for deleting a specific domain association.
      */
+    /**
+     * Fallback, no-operation implementation for batch upserting domains.
+     */
+    override suspend fun upsertDomains(domains: List<ItemDomainEntity>) = Unit
+
     override suspend fun deleteDomain(
         itemId: Long,
         domainKey: String,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -37,6 +37,19 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 
+/**
+ * Merges internal scheduling data with external calendar events into a unified timeline view.
+ *
+ * This function translates system nodes into generic calendar entries, maps explicit schedule
+ * entries directly onto the timeline, and incorporates external synchronization data (e.g., from
+ * Google Calendar or local ICS files) to give the operator a single, comprehensive view of their
+ * day.
+ *
+ * @param nodes A list of system nodes mapped with their today pin context.
+ * @param scheduleEntries Explicit time-boxed entries configured within TajsOS.
+ * @param externalEvents Pre-synchronized read-only events from external calendar providers.
+ * @return A unified, chronologically sortable list of all temporal commitments.
+ */
 fun buildCalendarEntries(
     nodes: List<NodeWithPin>,
     scheduleEntries: List<ScheduleEntryEntity>,
@@ -128,6 +141,16 @@ fun buildCalendarEntries(
     return entries.sortedBy { it.startAt }
 }
 
+/**
+ * Partitions a flat list of nodes into specialized buckets based on their type, status, and timeline position.
+ *
+ * This function acts as the primary triage router, separating actionable tasks from
+ * reference knowledge, reminders, and historical data (done/archived). It also calculates
+ * which tasks are actively in progress versus those stuck in the backlog.
+ *
+ * @param list The raw list of active and historic nodes to categorize.
+ * @return A structured [NodeCategorization] splitting the nodes into logical buckets (inbox, tasks, knowledge, etc.).
+ */
 fun categorizeNodes(list: List<NodeWithPin>): NodeCategorization {
     val now = Clock.System.now().toEpochMilliseconds()
     val inbox = mutableListOf<NodeWithPin>()
@@ -254,13 +277,23 @@ fun buildPlaybookSnapshot(
 }
 
 /**
- * Assembles the comprehensive view state required for the Dashboard.
+ * Aggregates all domain logic, system health indicators, and snapshot calculators into a single
+ * overarching UI state for the main command center.
  *
- * This function orchestrates a complex, non-obvious data flow by combining raw database nodes
- * with current Operating Mode filters (e.g., excluding specific areas/types). It evaluates
- * heuristic rules to calculate critical state projections such as system load, open loop decay,
- * and area health imbalances. It also derives contextual suggestions (like mode or context hints)
- * based on the current time and available tasks.
+ * This massive aggregator relies on specialized snapshot calculators (e.g., [calculateAreaHealthSnapshot],
+ * [calculateOpenLoopsSnapshot], etc.) to derive specific subsystem states. It then applies the current
+ * [ModeQueryProfile] to filter and contextualize the data based on the operator's current active mode
+ * (e.g., "Deep Work", "Evening Wind Down", "Planning").
+ *
+ * The resulting state is the source of truth for the entire dashboard UI, driving what blocks, tasks,
+ * and warnings are currently visible.
+ *
+ * @param repository The central app repository providing primary read sources.
+ * @param nodes The full list of relevant system nodes wrapped with pin context.
+ * @param modesList The list of available operating modes.
+ * @param activeId The ID of the currently active mode, if any.
+ * @param areasList The list of all system Area nodes.
+ * @return A fully populated [DashboardUIState] reflecting the entire system's status filtered by the active mode.
  */
 suspend fun buildDashboardUIState(
     repository: AppRepository,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -293,6 +293,7 @@ fun buildPlaybookSnapshot(
  * @param modesList The list of available operating modes.
  * @param activeId The ID of the currently active mode, if any.
  * @param areasList The list of all system Area nodes.
+ * @param packs The registry of enabled and owned application packs.
  * @return A fully populated [DashboardUIState] reflecting the entire system's status filtered by the active mode.
  */
 suspend fun buildDashboardUIState(

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeLifeObjectDaos.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/FakeLifeObjectDaos.kt
@@ -197,6 +197,10 @@ class FakeItemDomainDao : ItemDomainDao {
         domainsFlow.value = domains.toList()
     }
 
+    override suspend fun upsertDomains(domains: List<ItemDomainEntity>) {
+        domains.forEach { upsertDomain(it) }
+    }
+
     override suspend fun deleteDomain(
         itemId: Long,
         domainKey: String,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds KDocs for query profiles, main state assemblers, and preferences safety. Adds batch upsert for item–domain associations via `ItemDomainDao.upsertDomains`, with no-op and test DAO support.

- **New Features**
  - Added `upsertDomains(List<ItemDomainEntity>)` to `ItemDomainDao`; implemented in `NoOpItemDomainDao` and `FakeItemDomainDao`.
  - Clarified KDocs for `buildCalendarEntries`, `categorizeNodes` (in-progress vs backlog), and `buildDashboardUIState` (references `calculateOpenLoopsSnapshot`, `ModeQueryProfile`, and refined `packs` param).
  - Documented `Flow<Preferences>.catchIoException()` for IO-safe defaults.

- **Migration**
  - Update any concrete `ItemDomainDao` implementations to support `upsertDomains` (batch upsert).

<sup>Written for commit 994ac31744a5f200fca40ec56426efe81f800970. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

