### PR TITLE
test: add test coverage for isPrivateOrLocal

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -313,8 +313,6 @@ class MainActivity : FragmentActivity() {
             }
         try {
             speechRecognizerLauncher.launch(intent)
-        try {
-            speechRecognizerLauncher.launch(intent)
         } catch (e: android.content.ActivityNotFoundException) {
             Log.w(TAG, "Speech recognizer activity not found", e)
         }
@@ -492,7 +490,7 @@ class MainActivity : FragmentActivity() {
      * Safely extracts a Parcelable extra from an Intent, handling OS version differences
      * and catching potential unparcelling exceptions (e.g., BadParcelableException).
      */
-    private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableExtra(name: String): T? =
+    internal inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableExtra(name: String): T? =
         try {
             androidx.core.content.IntentCompat.getParcelableExtra(this, name, T::class.java)
         } catch (e: BadParcelableException) {
@@ -506,7 +504,7 @@ class MainActivity : FragmentActivity() {
     /**
      * Safely extracts a Parcelable ArrayList extra from an Intent.
      */
-    private inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableArrayListExtra(name: String): java.util.ArrayList<T>? =
+    internal inline fun <reified T : android.os.Parcelable> Intent.getSafeParcelableArrayListExtra(name: String): java.util.ArrayList<T>? =
         try {
             androidx.core.content.IntentCompat.getParcelableArrayListExtra(this, name, T::class.java)
         } catch (e: BadParcelableException) {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserTest.kt
@@ -97,4 +97,39 @@ class InetAddressParserTest {
         assertNull(parseIpAddress(":::"), "Should reject triple colons or more")
         assertNull(parseIpAddress("1:::2"), "Should reject triple colons or more")
     }
+
+    @Test
+    fun testIsPrivateOrLocal() {
+        val loopbackV4 = parseIpAddress("127.0.0.1")
+        assertNotNull(loopbackV4)
+        assertTrue(loopbackV4.isPrivateOrLocal())
+
+        val loopbackV6 = parseIpAddress("::1")
+        assertNotNull(loopbackV6)
+        assertTrue(loopbackV6.isPrivateOrLocal())
+
+        val linkLocalV4 = parseIpAddress("169.254.1.2")
+        assertNotNull(linkLocalV4)
+        assertTrue(linkLocalV4.isPrivateOrLocal())
+
+        val linkLocalV6 = parseIpAddress("fe80::1")
+        assertNotNull(linkLocalV6)
+        assertTrue(linkLocalV6.isPrivateOrLocal())
+
+        val siteLocalV4 = parseIpAddress("192.168.1.1")
+        assertNotNull(siteLocalV4)
+        assertTrue(siteLocalV4.isPrivateOrLocal())
+
+        val siteLocalV6 = parseIpAddress("fd00::1")
+        assertNotNull(siteLocalV6)
+        assertTrue(siteLocalV6.isPrivateOrLocal())
+
+        val publicV4 = parseIpAddress("8.8.8.8")
+        assertNotNull(publicV4)
+        assertFalse(publicV4.isPrivateOrLocal())
+
+        val publicV6 = parseIpAddress("2001:4860:4860::8888")
+        assertNotNull(publicV6)
+        assertFalse(publicV6.isPrivateOrLocal())
+    }
 }

--- a/shared/src/iosMain/kotlin/com/tajemniktv/tajsos/data/DataStore.kt
+++ b/shared/src/iosMain/kotlin/com/tajemniktv/tajsos/data/DataStore.kt
@@ -4,6 +4,8 @@
 
 package com.tajemniktv.tajsos.data
 
+import com.tajemniktv.tajsos.utils.getDocumentDirectory
+
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory

--- a/shared/src/iosMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
+++ b/shared/src/iosMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
@@ -4,6 +4,8 @@
 
 package com.tajemniktv.tajsos.data
 
+import com.tajemniktv.tajsos.utils.getDocumentDirectory
+
 import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import platform.Foundation.NSBundle

--- a/shared/src/iosMain/kotlin/com/tajemniktv/tajsos/utils/AppDirs.kt
+++ b/shared/src/iosMain/kotlin/com/tajemniktv/tajsos/utils/AppDirs.kt
@@ -1,0 +1,21 @@
+package com.tajemniktv.tajsos.utils
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
+
+@OptIn(ExperimentalForeignApi::class)
+internal fun getDocumentDirectory(): String {
+    val documentDirectory: NSURL? = NSFileManager.defaultManager.URLForDirectory(
+        directory = NSDocumentDirectory,
+        inDomain = NSUserDomainMask,
+        appropriateForURL = null,
+        create = false,
+        error = null
+    )
+    return requireNotNull(documentDirectory?.path) {
+        "Failed to retrieve the document directory."
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds unit tests for `isPrivateOrLocal` to verify correct IPv4/IPv6 classification (loopback, link-local, private, public).

- **Bug Fixes**
  - Android: removed duplicate speech recognizer launch to prevent double invocation.

- **Refactors**
  - Android: made `Intent.getSafeParcelableExtra` and `Intent.getSafeParcelableArrayListExtra` `internal` for reuse and testing.
  - iOS: added `com.tajemniktv.tajsos.utils.getDocumentDirectory()` and imported it in DataStore/Database to centralize document path resolution.

<sup>Written for commit c595799992adc11cdd3620fd37e817a2362dee0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

