### PR TITLE
perf: Optimize list filtering to avoid intermediate allocations

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt
@@ -86,11 +86,13 @@ internal fun CalendarMainBlock(
     val pendingNodes =
         remember(activeNodes, todayEpoch) {
             activeNodes
-                .map { it.node }
-                .filter { node ->
-                    node.type == "task" &&
-                        node.status == "active" &&
-                        (node.dueAt?.let { it >= todayEpoch } == true)
+                /** Optimized to avoid intermediate allocations */
+                .mapNotNull { item ->
+                    item.node.takeIf { node ->
+                        node.type == "task" &&
+                            node.status == "active" &&
+                            (node.dueAt?.let { it >= todayEpoch } == true)
+                    }
                 }.sortedBy { it.dueAt }
                 .take(6)
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -126,8 +126,8 @@ fun NotesWorkspaceDetail(
     val noteItems =
         remember(allNodes) {
             allNodes
-                .map { it.node }
-                .filter { it.isNoteItem() && it.status != "archived" }
+                /** Optimized to avoid intermediate allocations */
+                .mapNotNull { item -> item.node.takeIf { it.isNoteItem() && it.status != "archived" } }
                 .sortedByDescending { it.updatedAt }
         }
 

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
@@ -125,10 +125,12 @@ fun TaskDetailRoute(
 
             val childSubtasks =
                 nodes
-                    .map { it.node }
-                    .filter { node ->
-                        node.parentNodeId == task.id &&
-                            node.isTaskItem()
+                    /** Optimized to avoid intermediate allocations */
+                    .mapNotNull { item ->
+                        item.node.takeIf { node ->
+                            node.parentNodeId == task.id &&
+                                node.isTaskItem()
+                        }
                     }
 
             val subtaskNodes =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -548,17 +548,17 @@ suspend fun buildDashboardUIState(
         criticalProjects =
             filteredNodes
                 .filter { it.node.type == "project" && it.node.status == "active" } // NON-NLS
-                /** Optimized to avoid intermediate allocations */
-                .mapNotNull { item ->
-                    item.node.takeIf { proj ->
-                        val projectNodes = nodes.filter { it.node.projectId == proj.id }
-                        val hasCritical =
-                            projectNodes.any {
+                .let { list ->
+                    val nodesByProject = nodes.groupBy { it.node.projectId }
+                    list.mapNotNull { item ->
+                        item.node.takeIf { proj ->
+                            val projectNodes = nodesByProject[proj.id] ?: emptyList()
+                            val hasCritical = projectNodes.any {
                                 it.node.status == "active" && it.node.isHardDeadline && it.node.dueAt != null && it.node.dueAt < now // NON-NLS
                             }
-                        val isNeglected =
-                            proj.status == "active" && !proj.isFrozen && projectNodes.none { it.node.updatedAt >= fourteenDaysAgo } // NON-NLS
-                        hasCritical || isNeglected
+                            val isNeglected = !proj.isFrozen && projectNodes.none { it.node.updatedAt >= fourteenDaysAgo } // NON-NLS
+                            hasCritical || isNeglected
+                        }
                     }
                 },
         forgottenWisdom =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -548,16 +548,18 @@ suspend fun buildDashboardUIState(
         criticalProjects =
             filteredNodes
                 .filter { it.node.type == "project" && it.node.status == "active" } // NON-NLS
-                .map { it.node }
-                .filter { proj ->
-                    val projectNodes = nodes.filter { it.node.projectId == proj.id }
-                    val hasCritical =
-                        projectNodes.any {
-                            it.node.status == "active" && it.node.isHardDeadline && it.node.dueAt != null && it.node.dueAt < now // NON-NLS
-                        }
-                    val isNeglected =
-                        proj.status == "active" && !proj.isFrozen && projectNodes.none { it.node.updatedAt >= fourteenDaysAgo } // NON-NLS
-                    hasCritical || isNeglected
+                /** Optimized to avoid intermediate allocations */
+                .mapNotNull { item ->
+                    item.node.takeIf { proj ->
+                        val projectNodes = nodes.filter { it.node.projectId == proj.id }
+                        val hasCritical =
+                            projectNodes.any {
+                                it.node.status == "active" && it.node.isHardDeadline && it.node.dueAt != null && it.node.dueAt < now // NON-NLS
+                            }
+                        val isNeglected =
+                            proj.status == "active" && !proj.isFrozen && projectNodes.none { it.node.updatedAt >= fourteenDaysAgo } // NON-NLS
+                        hasCritical || isNeglected
+                    }
                 },
         forgottenWisdom =
             filteredNodes


### PR DESCRIPTION
This pull request optimizes list processing in multiple Compose UI screens and State Assemblers by replacing chained `.map { ... }.filter { ... }` operations with single `.mapNotNull { ... takeIf { ... } }` operations.

**Reasoning:**
In Kotlin, chaining `map` and `filter` on a `List` creates an intermediate `List` object for each step. For example, `list.map { it.node }.filter { it.isActive }` first allocates a new list of all nodes, and then allocates a second list for the filtered nodes. By using `mapNotNull { item -> item.node.takeIf { it.isActive } }`, the mapping and filtering are performed in a single pass without allocating the intermediate list, reducing GC pressure during recomposition and state assembly.

**Changes:**
- `composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt`
- `composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarDashboardBlocks.kt`
- `composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt`
- `shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt`

**Risk:**
Very low. The logical output remains exactly the same. No public APIs were altered. KDocs were added indicating the performance optimization.

**Tests Executed:**
- Compiles successfully for `iosSimulatorArm64`
- Passed `:shared:jvmTest --tests "*Calculators*"`
- Passed `:composeApp:jvmTest --tests "*Dashboard*"`

---
*PR created automatically by Jules for task [2134304921851239116](https://jules.google.com/task/2134304921851239116) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized list processing by replacing chained map/filter calls with single mapNotNull passes, and reduced per-project scans by grouping nodes once. This lowers GC pressure and CPU time during recomposition and state assembly without changing behavior.

- **Refactors**
  - Applied in `CalendarDashboardBlocks.kt`, `NotesWorkspaceDetail.kt`, `TaskDetailScreen.kt`, and `MainStateAssemblers.kt`.
  - Precompute `nodesByProject` for `criticalProjects` to remove repeated list filters.
  - No public API changes.

<sup>Written for commit 30c820921508328a60a4cce7a557e3f68413171f. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/514?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

