### PR TITLE
chore: fix TimeZone parsing fallback in IcsCalendarProvider

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
@@ -9,7 +9,6 @@ import com.tajemniktv.tajsos.data.CalendarProviderEntity
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
-import kotlinx.datetime.IllegalTimeZoneException
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
@@ -340,7 +339,7 @@ internal class IcsEventBuilder {
             Regex("TZID=([^;:]+)").find(rawKey) ?: return TimeZone.currentSystemDefault()
         return try {
             TimeZone.of(tzidMatch.groupValues[1])
-        } catch (e: IllegalTimeZoneException) {
+        } catch (e: IllegalArgumentException) {
             TimeZone.currentSystemDefault()
         }
     }


### PR DESCRIPTION
Replaced `IllegalTimeZoneException` with `IllegalArgumentException` in `IcsCalendarProvider.extractTimeZone` as it is the supported common-code fallback for invalid time zone IDs and fixes compilation errors in commonMain.

---
*PR created automatically by Jules for task [11303623829707068631](https://jules.google.com/task/11303623829707068631) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `IcsCalendarProvider.extractTimeZone` to catch `IllegalArgumentException` (the `kotlinx.datetime` behavior in common code) instead of `IllegalTimeZoneException`. Fixes a `commonMain` compile error and preserves the fallback to the system default time zone for invalid TZIDs.

<sup>Written for commit ac96e0e55e5392d632f721bee6be630a963f5222. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

