### PR TITLE
docs: explain heuristic zero-configuration domain mapping

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/DomainKind.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/DomainKind.kt
@@ -18,6 +18,9 @@ import kotlinx.serialization.Serializable
  * intentionally bypasses explicit assignments like [com.tajemniktv.tajsos.data.ItemDomainEntity]
  * to provide a seamless user experience, ensuring items surface in appropriate lenses
  * without requiring the user to constantly curate their metadata.
+ *
+ * Explicit domain tracking via models like [com.tajemniktv.tajsos.data.ItemDomainEntity] may still exist
+ * in the schema, but is superseded by this heuristic design for low-friction item capture.
  */
 @Serializable
 enum class DomainKind {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/DomainKind.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/DomainKind.kt
@@ -19,8 +19,8 @@ import kotlinx.serialization.Serializable
  * to provide a seamless user experience, ensuring items surface in appropriate lenses
  * without requiring the user to constantly curate their metadata.
  *
- * Explicit domain tracking via models like [com.tajemniktv.tajsos.data.ItemDomainEntity] may still exist
- * in the schema, but is superseded by this heuristic design for low-friction item capture.
+ * While explicit tracking models may still exist in the schema, they are superseded
+ * by this heuristic design to ensure low-friction item capture.
  */
 @Serializable
 enum class DomainKind {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -105,7 +105,7 @@ private val healthTitleKeywords =
  * This heuristic-based approach provides a zero-configuration experience, allowing items to be surfaced
  * appropriately even if the user forgets to manually assign the domain.
  *
- * Note: These queries intentionally bypass explicit domain associations (e.g., via ItemDomainEntity)
+ * Note: These queries intentionally bypass explicit domain associations (e.g., via [com.tajemniktv.tajsos.data.ItemDomainEntity])
  * in favor of terminology matching to lower the friction of capturing new data.
  *
  * This object implements a zero-configuration classification strategy. Instead of relying on


### PR DESCRIPTION
This PR improves the repository documentation by clarifying the non-obvious architecture behind the domain categorization system.

It updates the KDocs for `DomainLensQueries` and `DomainKind` to explicitly document that TajsOS intentionally relies on a zero-configuration, heuristic-based string matching system (tag markers, title keywords, etc.) to categorize domains, rather than relying on explicit schema models like `ItemDomainEntity`. This clarifies the intent, assumptions, and non-obvious state flow of the domain lens system, reducing maintenance risk and onboarding friction.

---
*PR created automatically by Jules for task [15020670293515112021](https://jules.google.com/task/15020670293515112021) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies domain categorization docs: we use heuristic, zero‑config matching (tags, title keywords) and bypass explicit associations.

Updates KDocs in `DomainLensQueries` and `DomainKind` to state that any schema models (e.g., `com.tajemniktv.tajsos.data.ItemDomainEntity`) may exist but are superseded by this design for low‑friction capture.

<sup>Written for commit 2d97c79f40e885b52e5357de9f9b820189fe8586. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/518?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

