### PR TITLE
fix(ui): Replace border-none with border-transparent

### DIFF
--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -204,7 +204,7 @@ const title = "Changelog";
 
 <div class="bg-surface-container-low px-8 py-4 flex items-center gap-4 focus-within:ring-1 focus-within:ring-primary focus-within:ring-inset">
 <span class="text-primary font-mono text-sm">tajsos@root:~ $</span>
-<input class="bg-transparent border-none outline-none w-full text-white font-mono placeholder:text-zinc-700" placeholder="Execute command..." type="text"/>
+<input class="bg-transparent border-transparent outline-none w-full text-white font-mono placeholder:text-zinc-700" placeholder="Execute command..." type="text"/>
 <div class="flex gap-3">
 <span class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors">history</span>
 <span class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors">terminal</span>

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -181,7 +181,7 @@ const title = "PRICING";
 <section class="max-w-4xl">
 <h2 class="font-headline text-4xl font-bold mb-12 tracking-tight">PROTOCOL // <span class="text-primary-dim">FAQ</span></h2>
 <div class="space-y-4">
-<details class="group glass-panel rounded-3xl overflow-hidden border-none">
+<details class="group glass-panel rounded-3xl overflow-hidden border-transparent">
 <summary class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors">
 <span class="font-label text-sm font-medium tracking-tight">How secure is my neural data payload?</span>
 <span class="material-symbols-outlined group-open:rotate-180 transition-transform">expand_more</span>
@@ -190,7 +190,7 @@ const title = "PRICING";
                         TajsOS employs end-to-end polymorphic encryption. Your data is fragmented across decentralized nodes; only your private neural key can reconstruct the interface.
                     </div>
 </details>
-<details class="group glass-panel rounded-3xl overflow-hidden border-none">
+<details class="group glass-panel rounded-3xl overflow-hidden border-transparent">
 <summary class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors">
 <span class="font-label text-sm font-medium tracking-tight">Can I downgrade my subscription tier?</span>
 <span class="material-symbols-outlined group-open:rotate-180 transition-transform">expand_more</span>
@@ -199,7 +199,7 @@ const title = "PRICING";
                         Downgrades take effect at the end of the current billing cycle. Data overages will be archived but inaccessible until the tier is restored.
                     </div>
 </details>
-<details class="group glass-panel rounded-3xl overflow-hidden border-none">
+<details class="group glass-panel rounded-3xl overflow-hidden border-transparent">
 <summary class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors">
 <span class="font-label text-sm font-medium tracking-tight">What happens if my neural link fails?</span>
 <span class="material-symbols-outlined group-open:rotate-180 transition-transform">expand_more</span>

--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -41,7 +41,7 @@ const title = "WAITLIST";
 <div class="absolute -inset-0.5 bg-linear-to-r from-primary to-primary-dim rounded-xl blur opacity-20 transition duration-1000"></div>
 <form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-outline-variant/30 rounded-xl overflow-hidden focus-within:ring-1 focus-within:ring-primary focus-within:ring-inset transition-all duration-500">
 <label for="waitlist-email" class="sr-only">Email address</label>
-<input id="waitlist-email" class="bg-transparent border-none text-on-surface placeholder:text-outline font-mono py-5 px-6 w-full text-lg" placeholder="email@example.com" type="email" required autocomplete="email"/>
+<input id="waitlist-email" class="bg-transparent border-transparent text-on-surface placeholder:text-outline font-mono py-5 px-6 w-full text-lg" placeholder="email@example.com" type="email" required autocomplete="email"/>
 <button id="waitlist-submit" type="submit" class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold px-12 py-6 text-xl transition-all flex items-center gap-2 group/btn relative overflow-hidden">
                         <span id="waitlist-button-text">JOIN NOW</span>
                         <div id="waitlist-loading" class="hidden absolute inset-0 bg-primary flex items-center justify-center">


### PR DESCRIPTION
Tailwind CSS does not support opacity modifiers on the border-none utility class. Replace with border-transparent to maintain layout dimensions and improve accessibility.

---
*PR created automatically by Jules for task [6161739981708967038](https://jules.google.com/task/6161739981708967038) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Tailwind `border-none` with `border-transparent` on interactive elements to keep layout dimensions and enable opacity modifiers, improving focus visuals and accessibility. Changes apply to the changelog command input, pricing FAQ accordions, and waitlist email input.

<sup>Written for commit d94e28bd65c977138084dcfd82eafb9072edb820. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

