### PR TITLE
perf: Optimize MainViewModel flows using mapNotNull

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2724,44 +2724,41 @@ class MainViewModel(
                 nodes.filter { it.node.isResolvedDecisionSupportItem() }
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /**
+     * Flow of active decisions that haven't been resolved for at least 7 days.
+     * Uses optimized mapNotNull for filtering and mapping in a single pass without intermediate collections.
+     */
     val stalePendingDecisions: StateFlow<List<DecisionStaleItem>> =
         allNodes
             .map { nodes ->
                 val now = Clock.System.now().toEpochMilliseconds()
                 nodes
-                    .filter {
-                        it.node.isDecisionSupportItem() &&
-                            it.node.taskStateOrNull() == TaskState.ACTIVE &&
-                            !it.node.isResolvedDecisionSupportItem()
-                    }.map { decision ->
-                        val ageDays =
-                            (
-                                (now - decision.node.createdAt).coerceAtLeast(0L) /
-                                    (24 * 60 * 60 * 1000L)
-                                    ).toInt()
-                        DecisionStaleItem(node = decision, ageDays = ageDays)
-                    }.filter { it.ageDays >= 7 }
+                    .mapNotNull { decision ->
+                        if (decision.node.isDecisionSupportItem() &&
+                            decision.node.taskStateOrNull() == TaskState.ACTIVE &&
+                            !decision.node.isResolvedDecisionSupportItem()) {
+                            val ageDays =
+                                ((now - decision.node.createdAt).coerceAtLeast(0L) / (24 * 60 * 60 * 1000L)).toInt()
+                            if (ageDays >= 7) DecisionStaleItem(node = decision, ageDays = ageDays) else null
+                        } else null
+                    }
                     .sortedByDescending { it.ageDays }
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /**
+     * Emits a list of person nodes related to a specific decision.
+     * Uses optimized mapNotNull to filter related links and extract person IDs efficiently.
+     */
     fun getRelatedPeopleForDecision(decisionId: Long): Flow<List<NodeWithPin>> =
         combine(allNodes, allRelations) { nodes, relations ->
             val personIds =
                 relations
-                    .filter { relation ->
-                        relation.relationType == "RELATED_PERSON" && // NON-NLS
-                            (
-                                relation.fromNodeId == decisionId ||
-                                    relation.toNodeId == decisionId
-                                    )
-                    }.map { relation ->
-                        if (relation.fromNodeId ==
-                            decisionId
+                    .mapNotNull { relation ->
+                        if (relation.relationType == "RELATED_PERSON" && // NON-NLS
+                            (relation.fromNodeId == decisionId || relation.toNodeId == decisionId)
                         ) {
-                            relation.toNodeId
-                        } else {
-                            relation.fromNodeId
-                        }
+                            if (relation.fromNodeId == decisionId) relation.toNodeId else relation.fromNodeId
+                        } else null
                     }.toSet()
             nodes.filter { it.node.id in personIds && it.node.type == "person" } // NON-NLS
         }


### PR DESCRIPTION
This PR refactors some logic within `MainViewModel` to optimize standard `Flow` sequences (e.g. `getRelatedItemsForPerson`, `stalePendingDecisions`). By using `.mapNotNull`, we can merge mapping and filtering into one execution, preventing extra intermediate data allocation. KDocs have been added to the impacted state/functions, and care was taken to maintain pre-existing logic correctly, including string localization `NON-NLS` marks.

---
*PR created automatically by Jules for task [12199895092872524785](https://jules.google.com/task/12199895092872524785) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized flows in `MainViewModel` by using `.mapNotNull` to combine filtering and mapping, reducing allocations while keeping behavior the same. Changes cover `stalePendingDecisions` and `getRelatedPeopleForDecision`, with new KDocs.

- **Refactors**
  - `stalePendingDecisions`: one-pass creation of `DecisionStaleItem` for active, unresolved decisions; keeps >=7-day check and descending sort.
  - `getRelatedPeopleForDecision`: one-pass extraction of related person IDs for a decision, then filters nodes; KDocs added and existing `NON-NLS` comments preserved.

<sup>Written for commit d5e8cacd6f00673c529de028abd16708c2db3123. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/520?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

