### PR TITLE
docs: Add missing KDocs and clarify intent in DomainLensQueries

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -103,7 +103,7 @@ private val healthTitleKeywords =
  * Provides static heuristic queries to categorize active nodes into broader LifeOS domains.
  *
  * This singleton relies heavily on zero-configuration implicit matching—such as tags,
- * keywords within title and content, and specific note types—rather than explicit database
+ * keywords within title and content, maintenance types, and specific note types—rather than explicit database
  * entity associations. This design significantly lowers the friction of capturing new items,
  * ensuring they surface in relevant domains (like Finances or Health) automatically.
  *

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -12,11 +12,17 @@ import com.tajemniktv.tajsos.ui.MaintenanceStatusItem
 
 /**
  * Explicit maintenance item types that classify as financial responsibilities.
+ *
+ * This set is used in heuristic matching to implicitly map items with these maintenance
+ * types into the finance domain without requiring an explicit [com.tajemniktv.tajsos.domain.DomainKind] assignment.
  */
 private val financeMaintenanceTypes = setOf("bill", "subscription", "renewal")
 
 /**
  * Explicit maintenance item types that classify as health and medical responsibilities.
+ *
+ * This set is used in heuristic matching to implicitly map items with these maintenance
+ * types into the health domain without requiring an explicit [com.tajemniktv.tajsos.domain.DomainKind] assignment.
  */
 private val healthMaintenanceTypes = setOf("appointment", "prescription", "med_refill")
 
@@ -94,31 +100,16 @@ private val healthTitleKeywords =
     )
 
 /**
- * Shared projection helpers for domain screens.
+ * Provides static heuristic queries to categorize active nodes into broader LifeOS domains.
  *
- * These helpers keep query logic out of UI composables and avoid pushing more orchestration
- * into [com.tajemniktv.tajsos.ui.MainViewModel].
+ * This singleton relies heavily on zero-configuration implicit matching—such as tags,
+ * keywords within title and content, and specific note types—rather than explicit database
+ * entity associations. This design significantly lowers the friction of capturing new items,
+ * ensuring they surface in relevant domains (like Finances or Health) automatically.
  *
- * Domains (such as finance or health) act as product-level lenses over the shared object spine,
- * rather than acting as hard containers. They are categorized implicitly by checking for hardcoded
- * string markers within node tags, titles, content, `maintenanceType`, and `noteType` fields.
- * This heuristic-based approach provides a zero-configuration experience, allowing items to be surfaced
- * appropriately even if the user forgets to manually assign the domain.
- *
- * Note: These queries intentionally bypass explicit domain associations (e.g., via [com.tajemniktv.tajsos.data.ItemDomainEntity])
- * in favor of terminology matching to lower the friction of capturing new data.
- *
- * This object implements a zero-configuration classification strategy. Instead of relying on
- * explicit database associations (like a many-to-many domain relation table), items are
- * implicitly categorized into domains via keyword matching in titles, content, tags, and
- * specific maintenance/note types. This decoupling allows items to naturally surface in the
- * right lenses without requiring manual user curation.
- *
- * Currently, heuristic matching queries are only implemented for the `FINANCES` and `HEALTH` domains.
- * `EDUCATION` and `RELATIONSHIPS` (defined in [com.tajemniktv.tajsos.domain.DomainKind])
- * do not yet have dedicated queries in this object. Adding support for them would require
- * establishing similar heuristic marker sets (e.g., `educationTagMarkers`, `educationTitleKeywords`,
- * `relationshipsMaintenanceTypes`) and implementing their respective projection queries.
+ * Current implementation supports heuristic matching for [com.tajemniktv.tajsos.domain.DomainKind.FINANCES] and
+ * [com.tajemniktv.tajsos.domain.DomainKind.HEALTH]. Future implementations may add projection
+ * support for other domains defined in [com.tajemniktv.tajsos.domain.DomainKind].
  */
 object DomainLensQueries {
     /**


### PR DESCRIPTION
This PR improves the documentation of the `DomainLensQueries` object.

- **Missing KDocs**: Added explanations for the previously undocumented `financeMaintenanceTypes` and `healthMaintenanceTypes` private properties, clarifying how they contribute to implicit domain categorization without explicit `ItemDomainEntity` assignments.
- **Intent Clarification**: Refactored the `DomainLensQueries` object-level KDoc to remove repetitive paragraphs and clarify the intent behind zero-configuration heuristic matching, lowering the friction of capturing new data.

These changes strictly improve documentation and do not alter any runtime behavior, reducing onboarding friction for developers trying to understand domain categorizations.

---
*PR created automatically by Jules for task [10584643464074804966](https://jules.google.com/task/10584643464074804966) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing KDocs for `financeMaintenanceTypes` and `healthMaintenanceTypes`, and refine the `DomainLensQueries` KDoc to explain zero-config matching (tags, keywords, maintenance/note types) and current support for `DomainKind.FINANCES` and `DomainKind.HEALTH`.
Docs-only; no runtime or behavioral changes.

<sup>Written for commit 7b6ab5fcc70060b7ed33f81a64e70e808425afc1. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/522?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

