### PR TITLE
fix(ui): remove expensive blur focus glow

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
@@ -40,7 +40,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
@@ -138,17 +137,6 @@ fun TactileSlider(
                     modifier = Modifier.size(24.dp),
                     contentAlignment = Alignment.Center,
                 ) {
-                    // Glow effect
-                    Box(
-                        modifier =
-                            Modifier
-                                .size(20.dp)
-                                .blur(8.dp)
-                                .background(
-                                    TajsOSTheme.Primary.copy(alpha = 0.5f),
-                                    RoundedCornerShape(TajsOSTheme.RadiusXs),
-                                ),
-                    )
                     // Core thumb
                     Box(
                         modifier =
@@ -215,18 +203,7 @@ fun TactileTextField(
                 Modifier
                     .fillMaxWidth(),
         ) {
-            if (isFocused) {
-                Box(
-                    modifier =
-                        Modifier
-                            .matchParentSize()
-                            .blur(8.dp)
-                            .background(
-                                TajsOSTheme.Primary.copy(alpha = 0.2f),
-                                RoundedCornerShape(TajsOSTheme.RadiusMd),
-                            ),
-                )
-            }
+
 
             Box(
                 modifier =
@@ -320,17 +297,7 @@ fun TactileOutlinedTextField(
     val isFocused by interactionSource.collectIsFocusedAsState()
 
     Box(modifier = containerModifier, propagateMinConstraints = true) {
-        if (isFocused) {
-            Box(
-                modifier = Modifier
-                    .matchParentSize()
-                    .blur(8.dp)
-                    .background(
-                        TajsOSTheme.Primary.copy(alpha = 0.2f),
-                        shape
-                    )
-            )
-        }
+
         OutlinedTextField(
             value = value,
             onValueChange = onValueChange,


### PR DESCRIPTION
Removes the blur modifier and neon glow layers from TactileSlider, TactileTextField, and TactileOutlinedTextField to improve rendering performance and align with DESIGN.md constraints.

---
*PR created automatically by Jules for task [10343910357603506996](https://jules.google.com/task/10343910357603506996) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed blur-based focus glows from TactileSlider, TactileTextField, and TactileOutlinedTextField to improve rendering performance and match DESIGN.md. Focus states now rely on the existing border/shape without blurred layers.

<sup>Written for commit 2394b38468f818c0857a1e8f2a171410903e9ca3. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/524?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

