### PR TITLE
refactor: 🧹 restrict exception catch in timezone fallback (v2)

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
@@ -339,7 +339,7 @@ internal class IcsEventBuilder {
             Regex("TZID=([^;:]+)").find(rawKey) ?: return TimeZone.currentSystemDefault()
         return try {
             TimeZone.of(tzidMatch.groupValues[1])
-        } catch (e: Exception) {
+        } catch (e: IllegalArgumentException) {
             TimeZone.currentSystemDefault()
         }
     }


### PR DESCRIPTION
🎯 **What:** Restricting the broad `Exception` catch to `IllegalArgumentException` in the `extractTimeZone` method of `IcsCalendarProvider.kt`.

💡 **Why:** My previous attempt to use `IllegalTimeZoneException` caused a CI failure because that specific type was not found during compilation. `IllegalArgumentException` is a safe, widely available fallback that still provides significantly better specificity than a broad `Exception` catch, ensuring that unexpected runtime errors are not swallowed while still handling invalid time zone identifiers.

✅ **Verification:**
- Manually verified the code change using `read_file`.
- Obtained a successful code review validating the second iteration of the fix.
- Re-read `AGENTS.md` and ensured compliance with project standards.

✨ **Result:** Resolved the CI compilation error while successfully addressing the code health issue of broad exception catching.

---
*PR created automatically by Jules for task [12415034644573468907](https://jules.google.com/task/12415034644573468907) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the catch in extractTimeZone to IllegalArgumentException. This preserves the system-default fallback for invalid time zone IDs and avoids swallowing unexpected errors.

<sup>Written for commit dd67cc4044494dbdb651c213f6cefea734edfc23. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/525?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

