### PR TITLE
🧹 [code health improvement] Use specific IllegalArgumentException for SidebarMode parsing

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -136,7 +136,7 @@ class PreferencesRepository(
             val modeStr = preferences[PreferencesKeys.SIDEBAR_MODE]
             try {
                 if (modeStr != null) SidebarMode.valueOf(modeStr) else SidebarMode.EXPANDED
-            } catch (e: Exception) {
+            } catch (_: IllegalArgumentException) {
                 SidebarMode.EXPANDED
             }
         }


### PR DESCRIPTION
🎯 **What:** Modified `SidebarMode.valueOf` error handling in `PreferencesRepository` to catch `IllegalArgumentException` instead of a generic `Exception`.
💡 **Why:** Using a specific exception prevents masking other potential, unrelated runtime errors (like OutOfMemoryError) and clearly documents the expected failure mode of the enum `valueOf()` call, improving maintainability.
✅ **Verification:** Verified safe via `git diff` and ran existing tests (`./gradlew :shared:jvmTest --tests "*PreferencesRepository*"`) which passed successfully.
✨ **Result:** Enhanced code health by eliminating a broad exception catch.

---
*PR created automatically by Jules for task [5128629293149217349](https://jules.google.com/task/5128629293149217349) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Catch `IllegalArgumentException` when parsing `SidebarMode` in `PreferencesRepository`, instead of a broad `Exception`. This makes the failure mode explicit and avoids hiding unrelated errors.

<sup>Written for commit eec764136c766e1021b6168dccb910ba76f002bf. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/526?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

