### PR TITLE
🧹 [code health] narrow down exception type in date parsing

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
@@ -280,7 +280,7 @@ internal class IcsEventBuilder {
             } else {
                 null
             }
-        } catch (e: Exception) {
+        } catch (e: IllegalArgumentException) {
             null
         }
 


### PR DESCRIPTION
🎯 **What:** Narrowed down the generic `Exception` to `IllegalArgumentException` in `IcsCalendarProvider.parseDate`.
💡 **Why:** It improves readability and maintainability. Also avoids silently swallowing unexpected exceptions like `NullPointerException` or `IndexOutOfBoundsException`.
✅ **Verification:** Verified that tests pass via `./gradlew :shared:jvmTest --tests "*IcsCalendarProviderTest*"` and checked the difference using `git diff`.
✨ **Result:** A smaller code scope for handling parser exception limits unintended side effects.

---
*PR created automatically by Jules for task [11554161601137143804](https://jules.google.com/task/11554161601137143804) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Date parsing now catches only `IllegalArgumentException` in `IcsCalendarProvider.parseDate`. This avoids masking unrelated exceptions and makes the intent clear.

<sup>Written for commit 57e826ca4354529518189d5b739380ab9ee60a44. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/527?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

