### PR TITLE
🧹 [code health] Narrow exception type in URL validation

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
@@ -72,7 +72,7 @@ class IcsCalendarProvider(
             val parsedUrl = io.ktor.http.Url(url)
             if (!isValidScheme(parsedUrl.protocol.name.lowercase())) return false
             isPublicRoutableHost(parsedUrl.host.lowercase())
-        } catch (e: Exception) {
+        } catch (e: io.ktor.http.URLParserException) {
             false
         }
     }


### PR DESCRIPTION
🎯 **What:** Modified `isValidHttpUrl` in `IcsCalendarProvider` to catch `URLParserException` instead of the broad `Exception`.
💡 **Why:** Catching a broad `Exception` could swallow unexpected errors unrelated to URL parsing (like thread interruptions or network problems if any was there). Narrowing the exception targets only the specific type of error expected when `io.ktor.http.Url()` fails to parse a malformed string, improving maintainability.
✅ **Verification:** Verified by running tests `:shared:jvmTest --tests "*IcsCalendarProviderTest*"`.
✨ **Result:** Better visibility into non-parsing errors.

---
*PR created automatically by Jules for task [8882316184594184855](https://jules.google.com/task/8882316184594184855) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed the catch in `IcsCalendarProvider.isValidHttpUrl` to `io.ktor.http.URLParserException` so only URL parse errors are handled. This avoids masking unrelated exceptions and improves error visibility.

<sup>Written for commit 58944d4d4472bbb120490ee3d73bea0fe474cec4. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/528?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

