### PR TITLE
⚡ perf: Use remember for templates in StudentCards

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.tajemniktv.tajsos.data.NodeEntity
 import com.tajemniktv.tajsos.data.NodeWithPin
@@ -159,12 +160,15 @@ fun TemplateQuickActionsCard(
     onSemesterChange: (String) -> Unit,
     onCreate: (TemplateEntity, String) -> Unit,
 ) {
-    val lectureTemplate =
+    val lectureTemplate = remember(templates) {
         templates.firstOrNull { it.name.equals("Lecture Note Template", ignoreCase = true) }
-    val readingTemplate =
+    }
+    val readingTemplate = remember(templates) {
         templates.firstOrNull { it.name.equals("Reading Note Template", ignoreCase = true) }
-    val paperTemplate =
+    }
+    val paperTemplate = remember(templates) {
         templates.firstOrNull { it.name.equals("Paper Summary Template", ignoreCase = true) }
+    }
 
     Card(colors = CardDefaults.cardColors(containerColor = TajsOSTheme.CardSurface)) {
         Column(


### PR DESCRIPTION
💡 **What:**
Wrapped `templates.firstOrNull { ... }` calls within `TemplateQuickActionsCard` inside a `remember(templates)` block.

🎯 **Why:**
`TemplateQuickActionsCard` is a `@Composable` function that may be recomposed frequently as parent state changes (e.g., input field values like `courseId` or `semester` changing). Calling `firstOrNull` with string manipulation (`ignoreCase = true`) over a potentially large list of templates during every recomposition is inefficient.

By remembering the result keyed on the `templates` list, we prevent redundant linear scans and memory allocations when the template list hasn't changed. This improves rendering performance and reduces CPU overhead during UI updates.

📊 **Measured Improvement:**
We did not explicitly benchmark this as setting up a proper Compose UI benchmark across multiplatform targets for a single `firstOrNull` call is non-trivial and may require specific Android Context setups, but the theoretical improvement is clear based on standard Compose best practices. Instead of executing O(N) string comparisons on every frame/recomposition, the cost is amortized to O(1) after the initial composition, provided the `templates` list is stable.

---
*PR created automatically by Jules for task [4905999698748406184](https://jules.google.com/task/4905999698748406184) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized template lookups in `TemplateQuickActionsCard` with `remember(templates)` to avoid re-running `firstOrNull` scans on each recomposition. This cuts redundant work and smooths UI updates when inputs like courseId or semester change.

<sup>Written for commit 956a8a88d22fb06a5d41e2bfa718ad44835fbb6a. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/532?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

