### PR TITLE
🧪 [test(shared): cover validateIpv6Host boundary checks]

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserTest.kt
@@ -140,4 +140,10 @@ class InetAddressParserTest {
         assertNotNull(publicV6)
         assertFalse(publicV6.isPrivateOrLocal())
     }
+
+    @Test
+    fun testInvalidIpv6EdgeCases() {
+        assertNull(parseIpAddress(":1:2:3:4:5:6:7"), "Should reject starting with single colon")
+        assertNull(parseIpAddress("1:2:3:4:5:6:7:"), "Should reject ending with single colon")
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `validateIpv6Host` private function explicitely checks and rejects IPv6 address strings that start or end with a single colon (e.g. `:1:2:3:4:5:6:7` or `1:2:3:4:5:6:7:`). These boundary checks were previously untested in the `InetAddressParserTest.kt` test suite.
📊 **Coverage:** Added the `testInvalidIpv6EdgeCases` method to cover the rejection logic for addresses starting or ending with a single colon.
✨ **Result:** Increased test coverage for `validateIpv6Host` through the public `parseIpAddress` API, ensuring that these boundary validations function correctly and remain protected against regressions.

---
*PR created automatically by Jules for task [8690915833661937370](https://jules.google.com/task/8690915833661937370) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test for IPv6 boundary checks to ensure parseIpAddress rejects addresses that start or end with a single colon. Improves coverage of validateIpv6Host and guards against regressions.

<sup>Written for commit 74ef19c36926a45f272d9f9d19e97c557622bd0b. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/533?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

