### PR TITLE
🧪 Add test for PreferencesRepository DataStore Try-Catch error path

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
@@ -134,4 +134,26 @@ class PreferencesRepositoryTest {
             assertEquals(DesktopWindowStartupMode.RESTORE_LAST, awaitItem())
         }
     }
+
+    private class FatalErrorDataStore : DataStore<Preferences> {
+        override val data: Flow<Preferences> = flow {
+            throw IllegalStateException("Database is closed")
+        }
+
+        override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences {
+            return emptyPreferences()
+        }
+    }
+
+    @Test
+    fun catchIoException_rethrowsNonIoExceptions() = runTest {
+        val dataStore = FatalErrorDataStore()
+        val repository = PreferencesRepository(dataStore)
+
+        repository.sidebarMode.test {
+            val error = awaitError()
+            assertEquals("Database is closed", error.message)
+            assertEquals(true, error is IllegalStateException)
+        }
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that the `PreferencesRepository` DataStore try-catch error path was not tested. In particular, it lacked a test for exceptions other than `IOException` thrown by the dataStore `Flow`.
📊 **Coverage:** A new test case `catchIoException_rethrowsNonIoExceptions` was added which utilizes a custom `FatalErrorDataStore` designed to throw an `IllegalStateException` rather than an `IOException`. The test ensures that this non-IO exception is properly rethrown by the `safeData` flow, rather than being swallowed.
✨ **Result:** Improved test coverage and reliability of the `PreferencesRepository`.

---
*PR created automatically by Jules for task [18422151898355455753](https://jules.google.com/task/18422151898355455753) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test for the DataStore try-catch path in PreferencesRepository to verify that non-IOException errors from the data flow (e.g., IllegalStateException) are rethrown instead of swallowed. This improves confidence that only IO failures are handled silently.

<sup>Written for commit df69094a33d866a57ea025e9bf621cfa334106c0. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/534?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

