### PR TITLE
🧪 [Add coverage for DomainLensQueries.healthActionItems]

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesHealthActionItemsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesHealthActionItemsTest.kt
@@ -1,0 +1,96 @@
+package com.tajemniktv.tajsos.domain.lens
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.data.TagEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DomainLensQueriesHealthActionItemsTest {
+
+    private fun createNode(
+        id: Long,
+        title: String,
+        content: String = "",
+        type: String = "task",
+        status: String = "active",
+        tags: List<String> = emptyList(),
+        maintenanceType: String? = null,
+        noteType: String? = null,
+        dueAt: Long? = null,
+        updatedAt: Long = 0L,
+    ): NodeWithPin {
+        return NodeWithPin(
+            node = NodeEntity(
+                id = id,
+                title = title,
+                content = content,
+                type = type,
+                status = status,
+                maintenanceType = maintenanceType,
+                noteType = noteType,
+                dueAt = dueAt,
+                updatedAt = updatedAt,
+            ),
+            pin = null,
+            tags = tags.mapIndexed { index, tag -> TagEntity(id = index.toLong(), name = tag, normalizedName = tag.lowercase()) }
+        )
+    }
+
+    @Test
+    fun healthActionItems_filters_for_tasks_only() {
+        val taskNode = createNode(id = 1, title = "see doctor", type = "task")
+        val noteNode = createNode(id = 2, title = "see doctor", type = "note")
+        val recordNode = createNode(id = 3, title = "see doctor", type = "record")
+        val projectNode = createNode(id = 4, title = "see doctor", type = "project")
+        val openLoopNode = createNode(id = 5, title = "see doctor", type = "open_loop")
+
+        val nodes = listOf(taskNode, noteNode, recordNode, projectNode, openLoopNode)
+
+        val result = DomainLensQueries.healthActionItems(nodes)
+
+        assertEquals(2, result.size)
+        assertTrue(result.any { it.node.id == 1L })
+        assertTrue(result.any { it.node.id == 5L })
+    }
+
+    @Test
+    fun healthActionItems_filters_for_active_status_only() {
+        val activeTask = createNode(id = 1, title = "see doctor", status = "active")
+        val completedTask = createNode(id = 2, title = "see doctor", status = "completed")
+        val archivedTask = createNode(id = 3, title = "see doctor", status = "archived")
+        val somedayTask = createNode(id = 4, title = "see doctor", status = "someday")
+
+        val nodes = listOf(activeTask, completedTask, archivedTask, somedayTask)
+
+        val result = DomainLensQueries.healthActionItems(nodes)
+
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.id)
+    }
+
+    @Test
+    fun healthActionItems_sorts_by_deadline_ascending_placing_nulls_last() {
+        val noDeadline = createNode(id = 1, title = "see doctor")
+        val farDeadline = createNode(id = 2, title = "see doctor", dueAt = 3000L)
+        val nearDeadline = createNode(id = 3, title = "see doctor", dueAt = 1000L)
+        val mediumDeadline = createNode(id = 4, title = "see doctor", dueAt = 2000L)
+
+        val nodes = listOf(noDeadline, farDeadline, nearDeadline, mediumDeadline)
+
+        val result = DomainLensQueries.healthActionItems(nodes)
+
+        assertEquals(4, result.size)
+        assertEquals(3L, result[0].node.id)
+        assertEquals(4L, result[1].node.id)
+        assertEquals(2L, result[2].node.id)
+        assertEquals(1L, result[3].node.id)
+    }
+
+    @Test
+    fun healthActionItems_handles_empty_list_correctly() {
+        val result = DomainLensQueries.healthActionItems(emptyList())
+        assertTrue(result.isEmpty())
+    }
+}


### PR DESCRIPTION
🎯 **What:** Adds missing unit tests for `DomainLensQueries.healthActionItems` to cover active status and task item filtering.
💡 **Why:** Ensures regressions aren't introduced in health action item filtering by validating core conditions directly (`isTaskItem()`, `status == "active"`).
✅ **Verification:** Verified by running new unit tests successfully (`./gradlew :shared:jvmTest --tests "*DomainLensQueriesHealthActionItemsTest*"`).
✨ **Result:** Improved test coverage for health items with 4 new dedicated test paths.

---
*PR created automatically by Jules for task [4199147670192355099](https://jules.google.com/task/4199147670192355099) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit tests for `DomainLensQueries.healthActionItems` covering filtering to task-like items and active status, deadline sorting (ascending with nulls last), and empty input handling. Improves coverage and guards against regressions in health action item logic.

<sup>Written for commit 406450bfc9cd25dcef2bb54bac7b9e92af566633. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/535?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

