### PR TITLE
🧪 Add test for DomainLensQueries financeKnowledgeItems

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
@@ -107,4 +107,18 @@ class DomainLensQueriesEdgeTest {
         assertEquals(setOf(1L, 2L), result.map { it.node.id }.toSet())
     }
 
+
+    @Test
+    fun financeKnowledgeItems_filters_non_knowledge_and_inactive_items() {
+        val activeNote = createNode(1, "Finance budget", type = "note", status = "active")
+        val activeRecord = createNode(2, "Finance log", type = "record", status = "active")
+        val inactiveNote = createNode(3, "Finance rules", type = "note", status = "archived")
+        val activeTask = createNode(4, "Finance task", type = "task", status = "active")
+
+        val result = DomainLensQueries.financeKnowledgeItems(listOf(activeNote, activeRecord, inactiveNote, activeTask))
+
+        assertEquals(2, result.size)
+        assertEquals(setOf(1L, 2L), result.map { it.node.id }.toSet())
+    }
+
 }


### PR DESCRIPTION
🎯 **What:** Added missing edge case testing for `DomainLensQueries.financeKnowledgeItems` to ensure inactive items and non-knowledge items (like tasks) are filtered out properly.
📊 **Coverage:** Covered filtering of inactive notes and active non-knowledge types (like tasks). Verified that both notes and records are properly considered as knowledge items.
✨ **Result:** Improved test reliability for `financeKnowledgeItems` by explicitly validating its type and status filtering heuristics.

---
*PR created automatically by Jules for task [5140216013551623277](https://jules.google.com/task/5140216013551623277) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an edge-case test for `DomainLensQueries.financeKnowledgeItems` to ensure it filters out inactive items and non-knowledge types (like tasks), returning only active notes and records.

<sup>Written for commit cec508634e62e7f6a15415bcaec26e724d8b3b45. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/536?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

