### PR TITLE
🧪 [testing] Add tests for internal parseIpAddress function

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/ParseIpAddressTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/ParseIpAddressTest.kt
@@ -10,7 +10,7 @@ class ParseIpAddressTest {
     @Test
     fun testParseIpAddressValid() {
         // Basic IPv4
-        assertNotNull(parseIpAddress("192.168.1.1"))
+        assertEquals(IpAddress.Ipv4(0xC0A80101L), parseIpAddress("192.168.1.1"))
 
         // Basic IPv6
         assertNotNull(parseIpAddress("2001:db8::1"))
@@ -53,7 +53,7 @@ class ParseIpAddressTest {
         assertNull(parseIpAddress("[[2001:db8::1]]"))
 
         // Brackets with spaces inside them
-        // " [ 2001:db8::1 ] " -> trimmed to "[ 2001:db8::1 ]" -> "[ 2001:db8::1 ]"
+        // " [ 2001:db8::1 ] " -> trimmed to "[ 2001:db8::1 ]" -> brackets removed to " 2001:db8::1 "
         // Wait, removePrefix/Suffix removes them, but the inner spaces remain.
         // The implementation does a second `.trim()`:
         // host.trim().removePrefix("[").removeSuffix("]").trim()

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/ParseIpAddressTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/ParseIpAddressTest.kt
@@ -1,0 +1,63 @@
+package com.tajemniktv.tajsos.calendar
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ParseIpAddressTest {
+
+    @Test
+    fun testParseIpAddressValid() {
+        // Basic IPv4
+        assertNotNull(parseIpAddress("192.168.1.1"))
+
+        // Basic IPv6
+        assertNotNull(parseIpAddress("2001:db8::1"))
+
+        // Brackets around IPv6
+        assertNotNull(parseIpAddress("[2001:db8::1]"))
+
+        // Brackets around IPv4 (the implementation parses it as long as the contents are valid IPv4)
+        assertNotNull(parseIpAddress("[192.168.1.1]"))
+    }
+
+    @Test
+    fun testParseIpAddressWhitespaceAndBrackets() {
+        // Whitespace only
+        assertNotNull(parseIpAddress("  192.168.1.1  "))
+        assertNotNull(parseIpAddress("  2001:db8::1  "))
+
+        // Whitespace around brackets
+        assertNotNull(parseIpAddress("  [2001:db8::1]  "))
+        assertNotNull(parseIpAddress("\t[2001:db8::1]\n"))
+
+        // Unbalanced brackets
+        // Because of removePrefix("[") and removeSuffix("]"), unmatched brackets will just
+        // be removed if they are at the ends.
+        assertNotNull(parseIpAddress("[2001:db8::1"))
+        assertNotNull(parseIpAddress("2001:db8::1]"))
+
+        // If there are brackets INSIDE the string after trimming, parsing fails
+        assertNull(parseIpAddress("2001:db8:[:1]"))
+    }
+
+    @Test
+    fun testParseIpAddressInvalid() {
+        // Empty and completely invalid
+        assertNull(parseIpAddress(""))
+        assertNull(parseIpAddress("   "))
+        assertNull(parseIpAddress("not an ip"))
+
+        // Multiple brackets (removePrefix/removeSuffix only removes one)
+        assertNull(parseIpAddress("[[2001:db8::1]]"))
+
+        // Brackets with spaces inside them
+        // " [ 2001:db8::1 ] " -> trimmed to "[ 2001:db8::1 ]" -> "[ 2001:db8::1 ]"
+        // Wait, removePrefix/Suffix removes them, but the inner spaces remain.
+        // The implementation does a second `.trim()`:
+        // host.trim().removePrefix("[").removeSuffix("]").trim()
+        // So "[ 2001:db8::1 ]" -> " 2001:db8::1 " -> "2001:db8::1", which SHOULD parse successfully!
+        assertNotNull(parseIpAddress(" [ 2001:db8::1 ] "))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The internal `parseIpAddress` function lacked direct tests for its string cleaning logic (trimming, bracket removal) and how it delegates to `parseIpv4` and `parseIpv6`.
📊 **Coverage:** Added scenarios covering valid parsing of IPv4 and IPv6 strings, correctly removing `[` and `]` brackets, correct handling of preceding/trailing whitespaces, as well as testing rejection of completely invalid inputs or incorrectly formatted brackets.
✨ **Result:** Improved test coverage for `InetAddressParser.kt` ensuring that the string preprocessing in `parseIpAddress` behaves as intended without unexpectedly dropping characters or failing valid inputs.

---
*PR created automatically by Jules for task [12611174761342123683](https://jules.google.com/task/12611174761342123683) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add focused tests for the internal `parseIpAddress` function. They verify trimming (including spaces inside brackets), bracket handling (including unbalanced ends and bracketed IPv4), IPv4/IPv6 parsing with whitespace, and rejection of malformed inputs to improve `InetAddressParser` coverage and prevent regressions.

<sup>Written for commit 513015c8d7d1d83cd862e3d08cf964fb44e74e2c. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/537?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

