### PR TITLE
🧪 [Testing] Add Error Path Test for PreferencesRepository DataStore Write

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
@@ -14,6 +14,7 @@ import com.tajemniktv.tajsos.ui.SidebarMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import okio.IOException
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -41,6 +42,28 @@ class PreferencesRepositoryTest {
             awaitComplete()
         }
     }
+
+    @Test
+    fun updateData_throwsIoException_propagatesError() = runTest {
+        val dataStore = object : DataStore<Preferences> {
+            override val data: Flow<Preferences> = flowOf(emptyPreferences())
+
+            override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences {
+                throw IOException("Write failed")
+            }
+        }
+        val repository = PreferencesRepository(dataStore)
+
+        var exceptionThrown = false
+        try {
+            repository.updateSidebarMode(SidebarMode.COLLAPSED)
+        } catch (e: IOException) {
+            exceptionThrown = true
+        }
+
+        kotlin.test.assertTrue(exceptionThrown, "Expected IOException to be thrown")
+    }
+
 
 
     private class FakeDataStore : DataStore<Preferences> {


### PR DESCRIPTION
🎯 **What:**
Added a missing error path test for `PreferencesRepository.kt`. The test verifies that when the underlying `DataStore` throws an `IOException` during a write operation (e.g., `updateSidebarMode`), the exception is correctly propagated upwards rather than being swallowed or causing undefined behavior.

📊 **Coverage:**
* Added `updateData_throwsIoException_propagatesError` to `PreferencesRepositoryTest`.
* Specifically covers the failure path of `DataStore.updateData` for repository write methods.

✨ **Result:**
Improved testing reliability and coverage for the core preferences storage component, ensuring standard error handling cases for IO failures are deterministic.

---
*PR created automatically by Jules for task [16375852966442699108](https://jules.google.com/task/16375852966442699108) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a missing error-path test for `PreferencesRepository`. It verifies that when `DataStore.updateData` throws an `IOException` during a write (e.g., `updateSidebarMode`), the error is propagated, not swallowed.

<sup>Written for commit 9a57e2f44803a21f6c564e41280b6d9af513a974. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/538?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

