### PR TITLE
🧪 Add missing sorting test for healthKnowledgeItems

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
@@ -88,16 +88,15 @@ class DomainLensQueriesEdgeTest {
 
     @Test
     fun healthKnowledgeItems_filters_by_active_status_and_knowledge_type() {
-        val activeJournal = createNode(1, "Health log", status = "active", type = "note", noteType = "journal")
+        val activeJournal = createNode(1, "Health log", type = "note", noteType = "journal")
         val inactiveJournal = createNode(2, "Old log", status = "archived", type = "note", noteType = "journal")
-        val activeTask = createNode(3, "Health task", status = "active", type = "task", content = "see doctor")
-        val unrelatedActiveJournal = createNode(4, "Daily log", status = "active", type = "note", noteType = "reference")
+        val activeTask = createNode(3, "Health task", content = "see doctor")
+        val unrelatedActiveNote = createNode(4, "Daily log", type = "note", noteType = "reference")
 
-        val allNodes = listOf(activeJournal, inactiveJournal, activeTask, unrelatedActiveJournal)
+        val allNodes = listOf(activeJournal, inactiveJournal, activeTask, unrelatedActiveNote)
 
         val result = DomainLensQueries.healthKnowledgeItems(allNodes)
-        assertEquals(1, result.size)
-        assertEquals(1L, result.first().node.id)
+        assertEquals(setOf(1L), result.map { it.node.id }.toSet())
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesEdgeTest.kt
@@ -87,6 +87,30 @@ class DomainLensQueriesEdgeTest {
     }
 
     @Test
+    fun healthKnowledgeItems_filters_by_active_status_and_knowledge_type() {
+        val activeJournal = createNode(1, "Health log", status = "active", type = "note", noteType = "journal")
+        val inactiveJournal = createNode(2, "Old log", status = "archived", type = "note", noteType = "journal")
+        val activeTask = createNode(3, "Health task", status = "active", type = "task", content = "see doctor")
+        val unrelatedActiveJournal = createNode(4, "Daily log", status = "active", type = "note", noteType = "reference")
+
+        val allNodes = listOf(activeJournal, inactiveJournal, activeTask, unrelatedActiveJournal)
+
+        val result = DomainLensQueries.healthKnowledgeItems(allNodes)
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.id)
+    }
+
+    @Test
+    fun sorting_healthKnowledgeItems_sorts_by_updatedAt_descending() {
+        val oldNote = createNode(1, "Health log", updatedAt = 100L, type = "note", noteType = "journal")
+        val newNote = createNode(2, "Health log", updatedAt = 300L, type = "note", noteType = "journal")
+        val medNote = createNode(3, "Health log", updatedAt = 200L, type = "note", noteType = "journal")
+
+        val result = DomainLensQueries.healthKnowledgeItems(listOf(oldNote, newNote, medNote))
+        assertEquals(listOf(2L, 3L, 1L), result.map { it.node.id })
+    }
+
+    @Test
     fun sorting_financeKnowledgeItems_sorts_by_updatedAt_descending() {
         val oldNote = createNode(1, "Finance rules", updatedAt = 100L, type = "note")
         val newNote = createNode(2, "Finance updates", updatedAt = 300L, type = "note")


### PR DESCRIPTION
🎯 **What:** Added missing testing coverage for `DomainLensQueries.healthKnowledgeItems`.
📊 **Coverage:** The test ensures that returned nodes are correctly filtered by status and knowledge type, and that they are correctly sorted by their `updatedAt` property in descending order, putting most recently updated items first. 
✨ **Result:** Increased test coverage and confidence in the sorting and filtering behavior of the health lens knowledge query.

---
*PR created automatically by Jules for task [14026663244306021409](https://jules.google.com/task/14026663244306021409) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `DomainLensQueries.healthKnowledgeItems` to ensure it returns only active journal notes and sorts by `updatedAt` descending. Covers filtering out archived items, non-journal notes, and tasks to prevent regressions.

<sup>Written for commit 5c4acfb5647cee1b9a85b5342fd934e83204c967. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/539?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

