### PR TITLE
🧪 [CalendarManager] Inject dependencies to increase testing reliability and coverage for syncAll

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
@@ -28,11 +28,8 @@ import kotlin.time.Duration.Companion.days
 class CalendarManager(
     private val repository: AppRepository,
     httpClient: HttpClient,
+    private val providers: List<CalendarProvider> = listOf(IcsCalendarProvider(httpClient)),
 ) {
-    private val providers =
-        listOf(
-            IcsCalendarProvider(httpClient),
-        )
 
     /**
      * Synchronizes local calendar events for all enabled calendar providers.

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.assertFalse
+import kotlin.time.Instant
 
 class CalendarManagerTest {
     private val fakeNodeDao = FakeNodeDao()
@@ -92,6 +93,76 @@ class CalendarManagerTest {
         userDao = fakeUserDao,
         medicationDao = fakeMedicationDao
     )
+
+
+    @Test
+    fun syncAll_withFakeProvider_deduplicatesByExternalIdAndFallsBackToTitleStartAt() = runTest {
+        val providerEntity = CalendarProviderEntity(
+            id = 1,
+            name = "Test FAKE",
+            type = "FAKE",
+            isEnabled = true
+        )
+        fakeCalendarProviderDao.providers.add(providerEntity)
+
+        val fakeProvider = object : CalendarProvider {
+            override val type: String = "FAKE"
+            override suspend fun fetchEvents(provider: CalendarProviderEntity, from: kotlin.time.Instant, to: kotlin.time.Instant): List<CalendarEventEntity> {
+                return listOf(
+                    CalendarEventEntity(providerId = 1, externalId = "uid1", title = "Event 1", startAt = 100, endAt = 200),
+                    CalendarEventEntity(providerId = 1, externalId = "uid1", title = "Event 1 Duplicate", startAt = 100, endAt = 200),
+                    CalendarEventEntity(providerId = 1, externalId = null, title = "Event 2", startAt = 300, endAt = 400),
+                    CalendarEventEntity(providerId = 1, externalId = null, title = "Event 2", startAt = 300, endAt = 400),
+                )
+            }
+        }
+
+        val mockEngine = MockEngine { respond("", HttpStatusCode.OK) }
+        val httpClient = HttpClient(mockEngine)
+        val manager = CalendarManager(repository, httpClient, listOf(fakeProvider))
+
+        manager.syncAll()
+
+        val events = fakeCalendarEventDao.events
+        assertEquals(2, events.size)
+        assertTrue(events.any { it.externalId == "uid1" && it.title == "Event 1" })
+        assertTrue(events.any { it.externalId == null && it.title == "Event 2" })
+    }
+
+    @Test
+    fun syncAll_clearsOldEventsAndInsertsNewOnesAndUpdatesSyncedAt() = runTest {
+        val providerEntity = CalendarProviderEntity(
+            id = 1,
+            name = "Test FAKE",
+            type = "FAKE",
+            isEnabled = true
+        )
+        fakeCalendarProviderDao.providers.add(providerEntity)
+
+        fakeCalendarEventDao.events.add(CalendarEventEntity(id = 99, providerId = 1, title = "Old Event", startAt = 0, endAt = 0))
+
+        val fakeProvider = object : CalendarProvider {
+            override val type: String = "FAKE"
+            override suspend fun fetchEvents(provider: CalendarProviderEntity, from: kotlin.time.Instant, to: kotlin.time.Instant): List<CalendarEventEntity> {
+                return listOf(
+                    CalendarEventEntity(providerId = 1, externalId = "new1", title = "New Event", startAt = 100, endAt = 200)
+                )
+            }
+        }
+
+        val mockEngine = MockEngine { respond("", HttpStatusCode.OK) }
+        val httpClient = HttpClient(mockEngine)
+        val manager = CalendarManager(repository, httpClient, listOf(fakeProvider))
+
+        manager.syncAll()
+
+        val events = fakeCalendarEventDao.events
+        assertEquals(1, events.size)
+        assertEquals("New Event", events.first().title)
+
+        val updatedProvider = fakeCalendarProviderDao.providers.first()
+        assertNotNull(updatedProvider.lastSyncedAt)
+    }
 
     @Test
     fun syncAll_withEnabledIcsProvider_fetchesAndSavesEvents() = runTest {


### PR DESCRIPTION
🎯 **What:** The previous testing of `CalendarManager.syncAll()` was difficult to test via unit tests because `IcsCalendarProvider` was hardcoded internally. The method lacked coverage for deduplication fallback mechanisms and clearing old events.
📊 **Coverage:** I refactored `CalendarManager` to accept a configurable list of `CalendarProvider` instances, falling back to a default list containing `IcsCalendarProvider` for backwards compatibility. I added unit tests to `CalendarManagerTest` that use fake `CalendarProvider` implementations (correctly overriding `fetchEvents` as determined during code review) to explicitly test:
- Deduplication of fetched events with identical `externalId`s.
- Deduplication of fetched events by falling back to `"${title}_${startAt}"` when `externalId` is null.
- Correct removal of old local events when new events are fetched for a provider.
- Proper update of the provider's `lastSyncedAt` timestamp.
✨ **Result:** Test coverage for `CalendarManager` is significantly increased. Tests accurately reflect proper `syncAll` behavior with correct fakes, making refactoring or updates to this class safer in the future.

---
*PR created automatically by Jules for task [2004976485336260357](https://jules.google.com/task/2004976485336260357) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injected calendar providers into CalendarManager so syncAll can be unit tested with fakes. Kept default behavior by falling back to `IcsCalendarProvider`, and added tests for dedup (externalId and title_startAt), clearing old events, and updating lastSyncedAt.

<sup>Written for commit d10cabdbbef3b26ca94ba23956a6b2311512bc97. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/540?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

