### PR TITLE
🧪 [actionItems filter testing]

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesActionItemsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesActionItemsTest.kt
@@ -1,0 +1,86 @@
+package com.tajemniktv.tajsos.domain.lens
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.data.TagEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DomainLensQueriesActionItemsTest {
+    private fun createNode(
+        id: Long,
+        title: String,
+        content: String = "",
+        type: String = "task",
+        status: String = "active",
+        tags: List<String> = emptyList(),
+        maintenanceType: String? = null,
+        noteType: String? = null,
+        dueAt: Long? = null,
+        updatedAt: Long = 0L,
+    ): NodeWithPin {
+        return NodeWithPin(
+            node = NodeEntity(
+                id = id,
+                title = title,
+                content = content,
+                type = type,
+                status = status,
+                maintenanceType = maintenanceType,
+                noteType = noteType,
+                dueAt = dueAt,
+                updatedAt = updatedAt,
+            ),
+            pin = null,
+            tags = tags.mapIndexed { index, tag -> TagEntity(id = index.toLong(), name = tag, normalizedName = tag.lowercase()) }
+        )
+    }
+
+    @Test
+    fun financeActionItems_excludes_inactive_tasks() {
+        val activeFinanceTask = createNode(id = 1, title = "Pay tax", status = "active")
+        val doneFinanceTask = createNode(id = 2, title = "Pay rent", status = "done")
+        val archivedFinanceTask = createNode(id = 3, title = "Budget review", status = "archived")
+
+        val result = DomainLensQueries.financeActionItems(listOf(activeFinanceTask, doneFinanceTask, archivedFinanceTask))
+
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.id)
+    }
+
+    @Test
+    fun financeActionItems_excludes_non_task_items() {
+        val financeTask = createNode(id = 1, title = "Pay tax", type = "task")
+        val financeNote = createNode(id = 2, title = "Tax reference", type = "note")
+        val financeRecord = createNode(id = 3, title = "Paid tax today", type = "record")
+
+        val result = DomainLensQueries.financeActionItems(listOf(financeTask, financeNote, financeRecord))
+
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.id)
+    }
+
+    @Test
+    fun healthActionItems_excludes_inactive_tasks() {
+        val activeHealthTask = createNode(id = 1, title = "See doctor", status = "active")
+        val doneHealthTask = createNode(id = 2, title = "Take meds", status = "done")
+        val archivedHealthTask = createNode(id = 3, title = "Medical review", status = "archived")
+
+        val result = DomainLensQueries.healthActionItems(listOf(activeHealthTask, doneHealthTask, archivedHealthTask))
+
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.id)
+    }
+
+    @Test
+    fun healthActionItems_excludes_non_task_items() {
+        val healthTask = createNode(id = 1, title = "See doctor", type = "task")
+        val healthNote = createNode(id = 2, title = "Medical history", type = "note")
+        val healthRecord = createNode(id = 3, title = "Felt sick", type = "record")
+
+        val result = DomainLensQueries.healthActionItems(listOf(healthTask, healthNote, healthRecord))
+
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.id)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesActionItemsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesActionItemsTest.kt
@@ -44,8 +44,7 @@ class DomainLensQueriesActionItemsTest {
 
         val result = DomainLensQueries.financeActionItems(listOf(activeFinanceTask, doneFinanceTask, archivedFinanceTask))
 
-        assertEquals(1, result.size)
-        assertEquals(1L, result.first().node.id)
+        assertEquals(setOf(1L), result.map { it.node.id }.toSet())
     }
 
     @Test
@@ -56,8 +55,7 @@ class DomainLensQueriesActionItemsTest {
 
         val result = DomainLensQueries.financeActionItems(listOf(financeTask, financeNote, financeRecord))
 
-        assertEquals(1, result.size)
-        assertEquals(1L, result.first().node.id)
+        assertEquals(setOf(1L), result.map { it.node.id }.toSet())
     }
 
     @Test
@@ -68,8 +66,7 @@ class DomainLensQueriesActionItemsTest {
 
         val result = DomainLensQueries.healthActionItems(listOf(activeHealthTask, doneHealthTask, archivedHealthTask))
 
-        assertEquals(1, result.size)
-        assertEquals(1L, result.first().node.id)
+        assertEquals(setOf(1L), result.map { it.node.id }.toSet())
     }
 
     @Test
@@ -80,7 +77,6 @@ class DomainLensQueriesActionItemsTest {
 
         val result = DomainLensQueries.healthActionItems(listOf(healthTask, healthNote, healthRecord))
 
-        assertEquals(1, result.size)
-        assertEquals(1L, result.first().node.id)
+        assertEquals(setOf(1L), result.map { it.node.id }.toSet())
     }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesActionItemsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesActionItemsTest.kt
@@ -1,57 +1,27 @@
 package com.tajemniktv.tajsos.domain.lens
 
-import com.tajemniktv.tajsos.data.NodeEntity
-import com.tajemniktv.tajsos.data.NodeWithPin
-import com.tajemniktv.tajsos.data.TagEntity
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DomainLensQueriesActionItemsTest {
-    private fun createNode(
-        id: Long,
-        title: String,
-        content: String = "",
-        type: String = "task",
-        status: String = "active",
-        tags: List<String> = emptyList(),
-        maintenanceType: String? = null,
-        noteType: String? = null,
-        dueAt: Long? = null,
-        updatedAt: Long = 0L,
-    ): NodeWithPin {
-        return NodeWithPin(
-            node = NodeEntity(
-                id = id,
-                title = title,
-                content = content,
-                type = type,
-                status = status,
-                maintenanceType = maintenanceType,
-                noteType = noteType,
-                dueAt = dueAt,
-                updatedAt = updatedAt,
-            ),
-            pin = null,
-            tags = tags.mapIndexed { index, tag -> TagEntity(id = index.toLong(), name = tag, normalizedName = tag.lowercase()) }
-        )
-    }
 
     @Test
     fun financeActionItems_excludes_inactive_tasks() {
-        val activeFinanceTask = createNode(id = 1, title = "Pay tax", status = "active")
-        val doneFinanceTask = createNode(id = 2, title = "Pay rent", status = "done")
-        val archivedFinanceTask = createNode(id = 3, title = "Budget review", status = "archived")
+        val activeFinanceTask = createTestNode(id = 1, title = "Pay tax", status = "active")
+        val doneFinanceTask = createTestNode(id = 2, title = "Pay rent", status = "done")
+        val archivedFinanceTask = createTestNode(id = 3, title = "Budget review", status = "archived")
+        val activeNonFinanceTask = createTestNode(id = 4, title = "Clean the house", status = "active")
 
-        val result = DomainLensQueries.financeActionItems(listOf(activeFinanceTask, doneFinanceTask, archivedFinanceTask))
+        val result = DomainLensQueries.financeActionItems(listOf(activeFinanceTask, doneFinanceTask, archivedFinanceTask, activeNonFinanceTask))
 
         assertEquals(setOf(1L), result.map { it.node.id }.toSet())
     }
 
     @Test
     fun financeActionItems_excludes_non_task_items() {
-        val financeTask = createNode(id = 1, title = "Pay tax", type = "task")
-        val financeNote = createNode(id = 2, title = "Tax reference", type = "note")
-        val financeRecord = createNode(id = 3, title = "Paid tax today", type = "record")
+        val financeTask = createTestNode(id = 1, title = "Pay tax", type = "task")
+        val financeNote = createTestNode(id = 2, title = "Tax reference", type = "note")
+        val financeRecord = createTestNode(id = 3, title = "Paid tax today", type = "record")
 
         val result = DomainLensQueries.financeActionItems(listOf(financeTask, financeNote, financeRecord))
 
@@ -60,20 +30,21 @@ class DomainLensQueriesActionItemsTest {
 
     @Test
     fun healthActionItems_excludes_inactive_tasks() {
-        val activeHealthTask = createNode(id = 1, title = "See doctor", status = "active")
-        val doneHealthTask = createNode(id = 2, title = "Take meds", status = "done")
-        val archivedHealthTask = createNode(id = 3, title = "Medical review", status = "archived")
+        val activeHealthTask = createTestNode(id = 1, title = "Pick up medication", status = "active", tags = listOf("medical"))
+        val doneHealthTask = createTestNode(id = 2, title = "See doctor", status = "done", tags = listOf("health"))
+        val archivedHealthTask = createTestNode(id = 3, title = "Therapy session", status = "archived", tags = listOf("health"))
+        val activeNonHealthTask = createTestNode(id = 4, title = "Buy groceries", status = "active")
 
-        val result = DomainLensQueries.healthActionItems(listOf(activeHealthTask, doneHealthTask, archivedHealthTask))
+        val result = DomainLensQueries.healthActionItems(listOf(activeHealthTask, doneHealthTask, archivedHealthTask, activeNonHealthTask))
 
         assertEquals(setOf(1L), result.map { it.node.id }.toSet())
     }
 
     @Test
     fun healthActionItems_excludes_non_task_items() {
-        val healthTask = createNode(id = 1, title = "See doctor", type = "task")
-        val healthNote = createNode(id = 2, title = "Medical history", type = "note")
-        val healthRecord = createNode(id = 3, title = "Felt sick", type = "record")
+        val healthTask = createTestNode(id = 1, title = "Pick up prescription", type = "task", tags = listOf("health"))
+        val healthNote = createTestNode(id = 2, title = "Medical history", type = "note", tags = listOf("health"))
+        val healthRecord = createTestNode(id = 3, title = "Symptom log", type = "record", tags = listOf("health"))
 
         val result = DomainLensQueries.healthActionItems(listOf(healthTask, healthNote, healthRecord))
 

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensTestFixtures.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensTestFixtures.kt
@@ -1,0 +1,34 @@
+package com.tajemniktv.tajsos.domain.lens
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.data.TagEntity
+
+internal fun createTestNode(
+    id: Long,
+    title: String,
+    content: String = "",
+    type: String = "task",
+    status: String = "active",
+    tags: List<String> = emptyList(),
+    maintenanceType: String? = null,
+    noteType: String? = null,
+    dueAt: Long? = null,
+    updatedAt: Long = 0L,
+): NodeWithPin =
+    NodeWithPin(
+        node =
+            NodeEntity(
+                id = id,
+                title = title,
+                content = content,
+                type = type,
+                status = status,
+                maintenanceType = maintenanceType,
+                noteType = noteType,
+                dueAt = dueAt,
+                updatedAt = updatedAt,
+            ),
+        pin = null,
+        tags = tags.mapIndexed { index, tag -> TagEntity(id = index.toLong(), name = tag, normalizedName = tag.lowercase()) },
+    )


### PR DESCRIPTION
🎯 **What:** Added tests for the filtering logic inside `DomainLensQueries.financeActionItems` and `DomainLensQueries.healthActionItems` that filters out inactive tasks and non-task items.
📊 **Coverage:** Specifically added tests that verify tasks with `status != "active"` and items with `ItemKind != TASK` are excluded from the returned results.
✨ **Result:** Improved test reliability and coverage, providing a safety net for future code modifications in DomainLensQueries filtering mechanism.

---
*PR created automatically by Jules for task [1785820046709297783](https://jules.google.com/task/1785820046709297783) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added unit tests for `DomainLensQueries.financeActionItems` and `DomainLensQueries.healthActionItems` to verify filtering. Ensures only active `task` items are returned and correctly scoped to finance/health, excluding inactive statuses, non-task types, and unrelated categories.

- **Refactors**
  - Extracted `createTestNode` to shared `DomainLensTestFixtures.kt` to remove duplication.
  - Added explicit health tags and active non-finance/non-health controls to harden category filtering.

<sup>Written for commit 351ef024559822024b2f52bbfb9e449742085e30. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/541?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

