### PR TITLE
fix(ui): improve disabled action button styling

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -81,7 +81,7 @@ fun ActionButton(
             ButtonDefaults.buttonColors(
                 containerColor = if (isPrimary && enabled) Color.Transparent else containerColor,
                 contentColor = if (isPrimary && contentColor == TajsOSTheme.Text) TajsOSTheme.Background else contentColor,
-                disabledContainerColor = TajsOSTheme.SurfaceHighest,
+                disabledContainerColor = if (isGhost) Color.Transparent else TajsOSTheme.SurfaceHighest,
                 disabledContentColor = TajsOSTheme.Muted,
             ),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -81,6 +81,8 @@ fun ActionButton(
             ButtonDefaults.buttonColors(
                 containerColor = if (isPrimary && enabled) Color.Transparent else containerColor,
                 contentColor = if (isPrimary && contentColor == TajsOSTheme.Text) TajsOSTheme.Background else contentColor,
+                disabledContainerColor = TajsOSTheme.SurfaceHighest,
+                disabledContentColor = TajsOSTheme.Muted,
             ),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         border = buttonBorder,


### PR DESCRIPTION
🎯 **What:** Improved the UX of disabled `ActionButton`s by explicitly setting their `disabledContainerColor` and `disabledContentColor`.
💡 **Why:** Makes the app clearer and smoother for users by visually distinguishing inactive action buttons, following the platform's standard design language without changing the product direction.
✅ **Verification:** Verified by checking UI styles in code and running UI component tests.
✨ **Result:** Disabled action buttons now correctly look muted and unclickable.

---
*PR created automatically by Jules for task [16316607632516668370](https://jules.google.com/task/16316607632516668370) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `ActionButton` disabled colors: `disabledContainerColor = TajsOSTheme.SurfaceHighest` (transparent for `isGhost`) and `disabledContentColor = TajsOSTheme.Muted`.

<sup>Written for commit 08bbfeb6a3d3c357502ec5b5f8c33ea0304a2f52. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/542?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

