### PR TITLE
feat(ui): Use min-h-dvh instead of min-h-screen

### DIFF
--- a/website/src/components/landing/Hero.astro
+++ b/website/src/components/landing/Hero.astro
@@ -3,7 +3,7 @@
 import { SITE } from '../../data/site';
 ---
 
-<section class="relative min-h-screen flex items-start mb-64">
+<section class="relative min-h-dvh flex items-start mb-64">
   <div class="w-full lg:w-3/4 z-10">
     <div class="flex items-center gap-4 mb-12">
       <span

--- a/website/src/pages/app.astro
+++ b/website/src/pages/app.astro
@@ -11,7 +11,7 @@ const title = "APP";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
 
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
 
 <!-- Header Section -->
 <header class="py-16 md:py-24 text-left relative overflow-hidden">

--- a/website/src/pages/architecture.astro
+++ b/website/src/pages/architecture.astro
@@ -11,7 +11,7 @@ const title = "ARCHITECTURE";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
 
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
 
 <!-- Section 1: Header -->
 <header class="relative flex flex-col md:flex-row justify-between items-end border-b border-outline-variant/20 pb-8">

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -11,7 +11,7 @@ const title = "Changelog";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
     
 <!-- Sidebar: System Vitals -->
 <aside class="col-span-3 flex flex-col gap-6">

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -12,7 +12,7 @@ const title = "FEATURES";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
 
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
 
     <header class="mb-16">
       <h1 class="text-5xl md:text-7xl font-headline font-bold tracking-tighter text-on-surface mb-6">

--- a/website/src/pages/local-first.astro
+++ b/website/src/pages/local-first.astro
@@ -11,7 +11,7 @@ const title = "LOCAL-FIRST";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
 
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
 
 <!-- Top Header Section -->
 <header class="mb-16 flex justify-between items-start">

--- a/website/src/pages/philosophy.astro
+++ b/website/src/pages/philosophy.astro
@@ -11,7 +11,7 @@ const title = "PHILOSOPHY";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
 
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
 
 <div class="grid grid-cols-12 gap-16">
 <!-- Main Content Area -->

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -11,7 +11,7 @@ const title = "PRICING";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen supports-[height:100dvh]:min-h-dvh">
     
 <!-- Hero Section -->
 <section class="mb-24 relative">

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -11,7 +11,7 @@ const title = "PRICING";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
     
 <!-- Hero Section -->
 <section class="mb-24 relative">

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -11,7 +11,7 @@ const title = "PRIVACY";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
     
 <!-- Hero Section: Neo-Editorial Asymmetry -->
 <section class="mb-32">

--- a/website/src/pages/security.astro
+++ b/website/src/pages/security.astro
@@ -11,7 +11,7 @@ const title = "SECURITY";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
     
 <!-- Hero Section -->
 <section class="relative grid grid-cols-1 lg:grid-cols-12 gap-12 items-start">

--- a/website/src/pages/status.astro
+++ b/website/src/pages/status.astro
@@ -11,7 +11,7 @@ const title = "SYSTEM STATUS";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
     
 <!-- Header Status Indicator -->
 <header class="flex flex-col md:flex-row justify-between items-start md:items-end gap-6">

--- a/website/src/pages/terms.astro
+++ b/website/src/pages/terms.astro
@@ -11,7 +11,7 @@ const title = "TERMS";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
     
 <!-- Hero Section -->
 <section class="grid grid-cols-12 gap-8 mb-32">

--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -12,7 +12,7 @@ const title = "WAITLIST";
   <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
   
   <Navbar />
-  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-screen">
+  <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
     
 <!-- Background Spatial Layering Decor -->
 <div class="absolute inset-0 overflow-hidden pointer-events-none">
@@ -118,7 +118,7 @@ const title = "WAITLIST";
     waitlistStatus.textContent = "Submitting...";
     waitlistStatus.classList.remove("hidden");
       waitlistStatus.className = "mt-4 text-sm text-primary font-mono bg-primary/10 px-4 py-2 rounded-lg border border-primary/20";
-    if (waitlistSubmit) waitlistSubmit.disabled = true;
+    if (waitlistSubmit) waitlistSubmit.setAttribute("disabled", "true");
     if (waitlistLoading) waitlistLoading.classList.remove("hidden");
     if (waitlistButtonText) waitlistButtonText.classList.add("invisible");
 
@@ -137,14 +137,14 @@ const title = "WAITLIST";
       waitlistStatus.textContent = "You are on the waitlist. We will contact you soon.";
       waitlistStatus.classList.remove("hidden");
       waitlistStatus.className = "mt-4 text-sm text-primary font-mono bg-primary/10 px-4 py-2 rounded-lg border border-primary/20";
-      if (waitlistSubmit) waitlistSubmit.disabled = false;
+      if (waitlistSubmit) waitlistSubmit.removeAttribute("disabled");
       if (waitlistLoading) waitlistLoading.classList.add("hidden");
       if (waitlistButtonText) waitlistButtonText.classList.remove("invisible");
     } catch {
       waitlistStatus.textContent = "Could not join the waitlist right now. Try again in a moment.";
       waitlistStatus.classList.remove("hidden");
       waitlistStatus.className = "mt-4 text-sm text-error font-mono bg-error/10 px-4 py-2 rounded-lg border border-error/20";
-      if (waitlistSubmit) waitlistSubmit.disabled = false;
+      if (waitlistSubmit) waitlistSubmit.removeAttribute("disabled");
       if (waitlistLoading) waitlistLoading.classList.add("hidden");
       if (waitlistButtonText) waitlistButtonText.classList.remove("invisible");
     }


### PR DESCRIPTION
Replaces all occurrences of `min-h-screen` with `min-h-dvh` to adhere to UI responsiveness guidelines on web environments, preventing layout cutoff on mobile browsers. It also fixes a TypeScript error on `waitlistSubmit.disabled` by safely utilizing `setAttribute` and `removeAttribute`.

---
*PR created automatically by Jules for task [8369048980999288075](https://jules.google.com/task/8369048980999288075) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches page containers to `min-h-dvh` to respect dynamic viewport height and prevent mobile layout cutoff. Adds a feature-query fallback on Pricing and fixes waitlist submit handling to clear a TS error and keep button/loading states in sync.

- **Refactors**
  - Replace `min-h-screen` with `min-h-dvh` across pages and the Hero; on Pricing, keep `min-h-screen` with `supports-[height:100dvh]:min-h-dvh` for safe fallback.

- **Bug Fixes**
  - Toggle the waitlist submit button via `setAttribute("disabled", "true")` and `removeAttribute("disabled")`, keeping status/loading text updates consistent.

<sup>Written for commit fd429aebbf3c588d65bfd60f42770303ed52374e. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/543?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

