### PR TITLE
🧪 [test: Add test coverage for SyncRoutes CancellationException handling]

### DIFF
--- a/server/src/test/kotlin/com/tajemniktv/tajsos/SyncCancellationTest.kt
+++ b/server/src/test/kotlin/com/tajemniktv/tajsos/SyncCancellationTest.kt
@@ -4,6 +4,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.request.ApplicationReceivePipeline

--- a/server/src/test/kotlin/com/tajemniktv/tajsos/SyncCancellationTest.kt
+++ b/server/src/test/kotlin/com/tajemniktv/tajsos/SyncCancellationTest.kt
@@ -68,7 +68,7 @@ class SyncCancellationTest {
         } catch (e: CancellationException) {
             assertTrue(true, "Successfully caught CancellationException")
         } catch (e: Exception) {
-            assertTrue(e.cause is CancellationException || e is CancellationException, "Successfully threw cancellation exception")
+            assertTrue(e.cause is CancellationException, "Successfully threw cancellation exception")
         }
     }
 }

--- a/server/src/test/kotlin/com/tajemniktv/tajsos/SyncCancellationTest.kt
+++ b/server/src/test/kotlin/com/tajemniktv/tajsos/SyncCancellationTest.kt
@@ -56,7 +56,7 @@ class SyncCancellationTest {
 
         try {
             val response = client.post("/sync") {
-                header(io.ktor.http.HttpHeaders.Authorization, "Bearer token")
+                header(HttpHeaders.Authorization, "Bearer token")
                 contentType(ContentType.Application.Json)
                 setBody("{\"lastSyncTime\": 0, \"items\": []}")
             }
@@ -66,9 +66,8 @@ class SyncCancellationTest {
             }
             fail("Expected CancellationException to be thrown, but received response: ${response.status}")
         } catch (e: CancellationException) {
-            assertTrue(true, "Successfully caught CancellationException")
+            // Test passed - CancellationException was properly propagated
         } catch (e: Exception) {
-            assertTrue(e.cause is CancellationException, "Successfully threw cancellation exception")
-        }
+            fail("Unexpected exception type: ${e::class.simpleName}. Expected CancellationException to be rethrown by SyncRoutes.")
     }
 }

--- a/server/src/test/kotlin/com/tajemniktv/tajsos/SyncCancellationTest.kt
+++ b/server/src/test/kotlin/com/tajemniktv/tajsos/SyncCancellationTest.kt
@@ -1,0 +1,73 @@
+package com.tajemniktv.tajsos
+
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.request.ApplicationReceivePipeline
+import io.ktor.server.application.call
+import io.ktor.server.request.uri
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.coroutines.CancellationException
+import io.ktor.server.application.install
+import io.ktor.server.routing.routing
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.UserIdPrincipal
+import io.ktor.server.auth.bearer
+import io.ktor.server.auth.authenticate
+import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.json.Json
+import com.tajemniktv.tajsos.routes.syncRoutes
+import io.ktor.client.statement.bodyAsText
+
+class SyncCancellationTest {
+    @Test
+    fun testSyncEndpoint_CancellationExceptionRethrown() = testApplication {
+        application {
+            install(ContentNegotiation) {
+                json(Json {
+                    prettyPrint = true
+                    isLenient = true
+                    ignoreUnknownKeys = true
+                })
+            }
+            install(Authentication) {
+                bearer("sync-auth") {
+                    authenticate { UserIdPrincipal("sync-client") }
+                }
+            }
+            routing {
+                syncRoutes()
+            }
+
+            receivePipeline.intercept(ApplicationReceivePipeline.Transform) {
+                if (call.request.uri == "/sync") {
+                    throw CancellationException("Simulated error in injected service/call pipeline")
+                }
+            }
+        }
+
+        try {
+            val response = client.post("/sync") {
+                header(io.ktor.http.HttpHeaders.Authorization, "Bearer token")
+                contentType(ContentType.Application.Json)
+                setBody("{\"lastSyncTime\": 0, \"items\": []}")
+            }
+
+            if (response.status == HttpStatusCode.BadRequest) {
+                fail("Received 400 Bad Request, CancellationException was swallowed by catch (e: Exception) block! Body: ${response.bodyAsText()}")
+            }
+            // If it succeeds with something other than 400, the catch block properly rethrew the error.
+        } catch (e: CancellationException) {
+            assertTrue(true, "Successfully caught CancellationException")
+        } catch (e: Exception) {
+            assertTrue(e.cause is CancellationException || e is CancellationException, "Successfully threw cancellation exception")
+        }
+    }
+}

--- a/server/src/test/kotlin/com/tajemniktv/tajsos/SyncCancellationTest.kt
+++ b/server/src/test/kotlin/com/tajemniktv/tajsos/SyncCancellationTest.kt
@@ -64,7 +64,7 @@ class SyncCancellationTest {
             if (response.status == HttpStatusCode.BadRequest) {
                 fail("Received 400 Bad Request, CancellationException was swallowed by catch (e: Exception) block! Body: ${response.bodyAsText()}")
             }
-            // If it succeeds with something other than 400, the catch block properly rethrew the error.
+            fail("Expected CancellationException to be thrown, but received response: ${response.status}")
         } catch (e: CancellationException) {
             assertTrue(true, "Successfully caught CancellationException")
         } catch (e: Exception) {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds test coverage to ensure that `CancellationException` thrown during request processing in `SyncRoutes` is correctly propagated to properly handle structural concurrency in coroutines, rather than being swallowed and mapped to a 400 Bad Request error.

📊 **Coverage:** What scenarios are now tested
A test was added that simulates a `CancellationException` occurring when parsing the request pipeline. The test verifies that the exception is successfully caught by `catch (e: CancellationException)` and rethrown without resulting in a `400 Bad Request`.

✨ **Result:** The improvement in test coverage
`SyncRoutes` cancellation error handling logic is now properly tested and ensures coroutines terminate gracefully without swallowing failures.

---
*PR created automatically by Jules for task [3311634429149488407](https://jules.google.com/task/3311634429149488407) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test that simulates a `CancellationException` from Ktor `ApplicationReceivePipeline` during `/sync` and verifies `SyncRoutes` rethrows it instead of returning 400. The test uses real `ContentNegotiation` and bearer `Authentication` to mirror the route setup and ensure coroutine cancellation propagates correctly.

<sup>Written for commit 94458c2ba9e1737519cdfb3b49487291c568ab9c. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/546?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

