### PR TITLE
perf: Cache TimeZone.currentSystemDefault() in insights calculation

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -50,9 +50,11 @@ fun calculateInsights(
     tracks: List<TrackEntryEntity>,
     projects: List<NodeEntity>,
 ): InsightsData {
+    val sysZone = TimeZone.currentSystemDefault()
     val now = Clock.System.now().toEpochMilliseconds()
     val sevenDaysAgo = now - (7 * 24 * 60 * 60 * 1000L)
 
+    /** Cached system timezone for performance during iterations */
     val recentNodes = nodes.filter { it.node.createdAt >= sevenDaysAgo }
     val recentCompletions =
         nodes.filter {
@@ -73,7 +75,7 @@ fun calculateInsights(
         val hour =
             Instant
                 .fromEpochMilliseconds(it.startedAt)
-                .toLocalDateTime(TimeZone.currentSystemDefault())
+                .toLocalDateTime(sysZone)
                 .hour
         hourlyDistribution[hour]++
     }
@@ -85,7 +87,7 @@ fun calculateInsights(
         val hour =
             Instant
                 .fromEpochMilliseconds(it.node.completedAt ?: 0)
-                .toLocalDateTime(TimeZone.currentSystemDefault())
+                .toLocalDateTime(sysZone)
                 .hour
         completionHourlyDist[hour]++
     }
@@ -95,7 +97,7 @@ fun calculateInsights(
     val sevenDaysAgoDate =
         Instant
             .fromEpochMilliseconds(sevenDaysAgo)
-            .toLocalDateTime(TimeZone.currentSystemDefault())
+            .toLocalDateTime(sysZone)
             .date
     val recentTracks = tracks.filter { it.date >= sevenDaysAgoDate.toString() }
 
@@ -157,7 +159,7 @@ fun calculateInsights(
             .groupBy {
                 Instant
                     .fromEpochMilliseconds(it.startedAt)
-                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                    .toLocalDateTime(sysZone)
                     .date
             }.mapValues {
                 it.value
@@ -175,7 +177,7 @@ fun calculateInsights(
             .groupBy {
                 Instant
                     .fromEpochMilliseconds(it.node.completedAt ?: 0)
-                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                    .toLocalDateTime(sysZone)
                     .date
                     .toString()
             }.mapValues { it.value.size }
@@ -185,7 +187,7 @@ fun calculateInsights(
             .groupBy {
                 Instant
                     .fromEpochMilliseconds(it.node.createdAt)
-                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                    .toLocalDateTime(sysZone)
                     .date
                     .toString()
             }.mapValues { it.value.size }
@@ -195,7 +197,7 @@ fun calculateInsights(
             .groupBy {
                 Instant
                     .fromEpochMilliseconds(it.startedAt)
-                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                    .toLocalDateTime(sysZone)
                     .date
                     .toString()
             }.mapValues { it.value.sumOf { s -> s.durationSec } / 3600.0 }
@@ -271,7 +273,7 @@ fun calculateInsights(
                             val d =
                                 Instant
                                     .fromEpochMilliseconds(it.node.updatedAt)
-                                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                                    .toLocalDateTime(sysZone)
                                     .date
                                     .toString()
                             d == track.date && it.node.postponeCount > 0
@@ -318,7 +320,7 @@ fun calculateInsights(
             .map {
                 Instant
                     .fromEpochMilliseconds(it.node.createdAt)
-                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                    .toLocalDateTime(sysZone)
                     .hour
             }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -50,6 +50,7 @@ fun calculateInsights(
     tracks: List<TrackEntryEntity>,
     projects: List<NodeEntity>,
 ): InsightsData {
+    // Cached system timezone for performance during iterations
     val sysZone = TimeZone.currentSystemDefault()
     val now = Clock.System.now().toEpochMilliseconds()
     val sevenDaysAgo = now - (7 * 24 * 60 * 60 * 1000L)


### PR DESCRIPTION
🎯 **What:** Extracted `TimeZone.currentSystemDefault()` calls outside of loops in `MainSnapshotCalculators.kt`. Added a KDoc to clarify the optimization.
💡 **Why:** Getting the system default timezone is repeatedly called inside multiple `forEach`, `map`, and `filter` blocks in `calculateInsights`. Caching the timezone once at the beginning of the calculation function reduces redundant system calls and improves performance for large datasets without adding functional complexity.
✅ **Verification:** Verified by running `:shared:jvmTest --tests "MainSnapshotCalculatorsTest"` to ensure calculations still produce the correct values with the cached timezone.
✨ **Result:** Improved execution efficiency for insights calculations, maintaining functional correctness while reducing CPU overhead.

---
*PR created automatically by Jules for task [5089558233784946592](https://jules.google.com/task/5089558233784946592) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cached the system timezone in `calculateInsights` by computing `TimeZone.currentSystemDefault()` once and reusing it across loops, with a brief comment for clarity. This removes repeated lookups during iterations and speeds up insights calculation without changing results.

<sup>Written for commit be8f57835b44a969f8489389a822abcfce0c5ee5. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/547?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

