### PR TITLE
test: Enhance test coverage for edge cases in calendar and domain queries

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserNegativeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserNegativeTest.kt
@@ -55,5 +55,8 @@ class InetAddressParserNegativeTest {
         assertNull(parseIpAddress("12345::"), "Should reject segment with length > 4 on left")
         assertNull(parseIpAddress("1:2:3:4:5:6:7:8::1"), "Should reject left parsed out of bounds")
         assertNull(parseIpAddress("1::2:3:4:5:6:7:8:9"), "Should reject right parsed out of bounds")
+
+        // newly added negative edge case
+        assertNull(parseIpAddress("0:0:0:0:0:0:0:0:0"), "Should reject >8 segments even if all 0")
     }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
@@ -6,6 +6,7 @@ import com.tajemniktv.tajsos.data.TagEntity
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 class DomainLensQueriesMatchesSignalTest {
     private fun createNode(
@@ -173,4 +174,21 @@ class DomainLensQueriesMatchesSignalTest {
         assertDomainQueryResult(listOf(1L, 2L), result)
     }
 
+    @Test
+    fun financeActionItems_matches_maintenance_and_content() {
+        val node1 = createNode(1, "title", "content bill text", "task")
+        val node2 = createNode(2, "title", "content", "task", maintenanceType = "subscription")
+
+        val result = DomainLensQueries.financeActionItems(listOf(node1, node2))
+        assertDomainQueryResult(listOf(1L, 2L), result)
+    }
+
+    @Test
+    fun healthActionItems_matches_maintenance_and_content() {
+        val node1 = createNode(1, "title", "content prescription here", "task")
+        val node2 = createNode(2, "title", "content", "task", maintenanceType = "med_refill")
+
+        val result = DomainLensQueries.healthActionItems(listOf(node1, node2))
+        assertDomainQueryResult(listOf(1L, 2L), result)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
@@ -6,7 +6,6 @@ import com.tajemniktv.tajsos.data.TagEntity
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.test.assertFalse
 
 class DomainLensQueriesMatchesSignalTest {
     private fun createNode(
@@ -175,7 +174,7 @@ class DomainLensQueriesMatchesSignalTest {
     }
 
     @Test
-    fun financeActionItems_matches_maintenance_and_content() {
+    fun financeActionItems_matches_maintenance_or_content_separately() {
         val node1 = createNode(1, "title", "content bill text", "task")
         val node2 = createNode(2, "title", "content", "task", maintenanceType = "subscription")
 
@@ -184,7 +183,7 @@ class DomainLensQueriesMatchesSignalTest {
     }
 
     @Test
-    fun healthActionItems_matches_maintenance_and_content() {
+    fun healthActionItems_matches_maintenance_or_content_separately() {
         val node1 = createNode(1, "title", "content prescription here", "task")
         val node2 = createNode(2, "title", "content", "task", maintenanceType = "med_refill")
 

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
@@ -25,6 +25,13 @@ class FilterHelperMatchesQueryEdgeTest {
     }
 
     @Test
+    fun testMatchesQuery_hashtagSearch_empty() {
+        val node1 = buildTestNode(1, "title", "content", tags = listOf("tag1"))
+        assertFalse(FilterHelper.matchesQuery(node1, "#"))
+        assertFalse(FilterHelper.matchesQuery(node1, "#   "))
+    }
+
+    @Test
     fun testMatchesQuery_normalSearch() {
         val nodeTitle = buildTestNode(1, "my title", "content")
         val nodeContent = buildTestNode(2, "other", "my content")


### PR DESCRIPTION
This PR improves test coverage for edge cases across the codebase, including:\n- Additional negative tests for IPv6 parsing in `InetAddressParserNegativeTest.kt`.\n- Empty hashtag search tests in `FilterHelperMatchesQueryEdgeTest.kt`.\n- Implicit combination signal tests for maintenance types and content in `DomainLensQueriesMatchesSignalTest.kt`.

---
*PR created automatically by Jules for task [16890577886485079013](https://jules.google.com/task/16890577886485079013) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand test coverage for edge cases in calendar and domain queries. Adds a negative IPv6 case for addresses with >8 segments (including all-zero variants), rejects empty hashtag searches like "#" and whitespace-only, and verifies finance/health action items match via content or maintenance type independently.

<sup>Written for commit 98f9e63ab01d3c58651a3cec3289321d5b2a1e1b. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/548?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

