### PR TITLE
🧪 [test: Add error handling tests for SyncRoutes]

### DIFF
--- a/server/src/test/kotlin/com/tajemniktv/tajsos/ApplicationTest.kt
+++ b/server/src/test/kotlin/com/tajemniktv/tajsos/ApplicationTest.kt
@@ -269,4 +269,39 @@ class ApplicationTest {
 
         assertEquals(HttpStatusCode.UnsupportedMediaType, response.status)
     }
+
+    @Test
+    fun testSyncEndpoint_GenericException() = testApplication {
+        environment {
+            config = io.ktor.server.config.MapApplicationConfig(
+                "TAJSOS_SYNC_TOKEN" to "default-dev-token",
+                "ktor.application.version" to "1.0.0"
+            )
+        }
+        application {
+            module()
+        }
+        val clientWithNegotiation =
+            createClient {
+                install(ContentNegotiation) {
+                    json(
+                        Json {
+                            ignoreUnknownKeys = true
+                        }
+                    )
+                }
+            }
+
+        // We can trigger an error by sending completely invalid content for JSON serialization
+        val response = clientWithNegotiation.post("/sync") {
+            header(io.ktor.http.HttpHeaders.Authorization, "Bearer default-dev-token")
+            contentType(ContentType.Application.Json)
+            setBody("not-a-json-object-at-all")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        val bodyText = response.bodyAsText()
+        assertTrue(bodyText.contains("Invalid sync request payload"))
+    }
+
 }

--- a/server/src/test/kotlin/com/tajemniktv/tajsos/ApplicationTest.kt
+++ b/server/src/test/kotlin/com/tajemniktv/tajsos/ApplicationTest.kt
@@ -271,7 +271,7 @@ class ApplicationTest {
     }
 
     @Test
-    fun testSyncEndpoint_GenericException() = testApplication {
+    fun testSyncEndpoint_GenericException(): TestResult = testApplication {
         environment {
             config = io.ktor.server.config.MapApplicationConfig(
                 "TAJSOS_SYNC_TOKEN" to "default-dev-token",


### PR DESCRIPTION
🎯 **What:** The error handling path catching generic exceptions in `SyncRoutes.kt` was missing test coverage.
📊 **Coverage:** A test case has been added to verify that a malformed JSON payload (which causes an exception during deserialization) correctly results in a `400 Bad Request` with the message 'Invalid sync request payload'.
✨ **Result:** Increased test coverage and confidence in the API's robustness against malformed input.

---
*PR created automatically by Jules for task [1584022867496467744](https://jules.google.com/task/1584022867496467744) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Ktor test for the generic exception path in `SyncRoutes.kt`. Verifies that a non-JSON body sent to `/sync` returns 400 Bad Request and includes 'Invalid sync request payload'.

<sup>Written for commit 4f9c326f98d920c4a969162677087ea3e4ae72d8. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/551?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

