### PR TITLE
🔒 Fix vulnerable hash algorithm for sync token authentication

### DIFF
--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -1,6 +1,9 @@
 package com.tajemniktv.tajsos
 
 import java.security.MessageDigest
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import java.security.SecureRandom
 
 import com.tajemniktv.tajsos.routes.healthRoutes
 import com.tajemniktv.tajsos.routes.syncRoutes
@@ -25,14 +28,19 @@ fun Application.module() {
     val expectedToken = environment.config.propertyOrNull("TAJSOS_SYNC_TOKEN")?.getString()
         ?: System.getenv("TAJSOS_SYNC_TOKEN")
         ?: error("TAJSOS_SYNC_TOKEN environment variable must be set")
-    val expectedTokenBytes = expectedToken.toByteArray(Charsets.UTF_8)
-    val expectedTokenHash = MessageDigest.getInstance("SHA-256").digest(expectedTokenBytes)
+
+    val salt = ByteArray(16)
+    SecureRandom().nextBytes(salt)
+    val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+    val spec = PBEKeySpec(expectedToken.toCharArray(), salt, 65536, 256)
+    val expectedTokenHash = factory.generateSecret(spec).encoded
 
     install(Authentication) {
         bearer("sync-auth") {
             authenticate { tokenCredential ->
+                val providedSpec = PBEKeySpec(tokenCredential.token.toCharArray(), salt, 65536, 256)
+                val providedTokenHash = factory.generateSecret(providedSpec).encoded
 
-                val providedTokenHash = MessageDigest.getInstance("SHA-256").digest(tokenCredential.token.toByteArray(Charsets.UTF_8))
                 if (MessageDigest.isEqual(providedTokenHash, expectedTokenHash)) {
                     UserIdPrincipal("sync-client")
                 } else {

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -39,19 +39,15 @@ fun Application.module() {
         spec.clearPassword()
     }
 
-    fun hashToken(token: String): ByteArray {
-        val tokenSpec = PBEKeySpec(token.toCharArray(), salt, 65536, 256)
-        return try {
-            factory.generateSecret(tokenSpec).encoded
-        } finally {
-            tokenSpec.clearPassword()
-        }
-    }
-
     install(Authentication) {
         bearer("sync-auth") {
             authenticate { tokenCredential ->
-                val providedTokenHash = hashToken(tokenCredential.token)
+                val providedSpec = PBEKeySpec(tokenCredential.token.toCharArray(), salt, 65536, 256)
+                val providedTokenHash = try {
+                    factory.generateSecret(providedSpec).encoded
+                } finally {
+                    providedSpec.clearPassword()
+                }
 
                 if (MessageDigest.isEqual(providedTokenHash, expectedTokenHash)) {
                     UserIdPrincipal("sync-client")

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -33,7 +33,11 @@ fun Application.module() {
     SecureRandom().nextBytes(salt)
     val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
     val spec = PBEKeySpec(expectedToken.toCharArray(), salt, 65536, 256)
-    val expectedTokenHash = factory.generateSecret(spec).encoded
+    val expectedTokenHash = try {
+        factory.generateSecret(spec).encoded
+    } finally {
+        spec.clearPassword()
+    }
 
     install(Authentication) {
         bearer("sync-auth") {

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -39,7 +39,11 @@ fun Application.module() {
         bearer("sync-auth") {
             authenticate { tokenCredential ->
                 val providedSpec = PBEKeySpec(tokenCredential.token.toCharArray(), salt, 65536, 256)
-                val providedTokenHash = factory.generateSecret(providedSpec).encoded
+                val providedTokenHash = try {
+                    factory.generateSecret(providedSpec).encoded
+                } finally {
+                    providedSpec.clearPassword()
+                }
 
                 if (MessageDigest.isEqual(providedTokenHash, expectedTokenHash)) {
                     UserIdPrincipal("sync-client")

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -42,12 +42,7 @@ fun Application.module() {
     install(Authentication) {
         bearer("sync-auth") {
             authenticate { tokenCredential ->
-                val providedSpec = PBEKeySpec(tokenCredential.token.toCharArray(), salt, 65536, 256)
-                val providedTokenHash = try {
-                    factory.generateSecret(providedSpec).encoded
-                } finally {
-                    providedSpec.clearPassword()
-                }
+                val providedTokenHash = hashToken(tokenCredential.token)
 
                 if (MessageDigest.isEqual(providedTokenHash, expectedTokenHash)) {
                     UserIdPrincipal("sync-client")

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -39,6 +39,15 @@ fun Application.module() {
         spec.clearPassword()
     }
 
+    fun hashToken(token: String): ByteArray {
+        val tokenSpec = PBEKeySpec(token.toCharArray(), salt, 65536, 256)
+        return try {
+            factory.generateSecret(tokenSpec).encoded
+        } finally {
+            tokenSpec.clearPassword()
+        }
+    }
+
     install(Authentication) {
         bearer("sync-auth") {
             authenticate { tokenCredential ->


### PR DESCRIPTION
🎯 **What:** The sync token authentication used SHA-256, a fast cryptographic hash function vulnerable to offline brute-force and dictionary attacks.
⚠️ **Risk:** If the hashed token value or database were ever exposed, an attacker could quickly crack the token using modern hardware, compromising sync authentication.
🛡️ **Solution:** Replaced SHA-256 with PBKDF2WithHmacSHA256, using a randomly generated 16-byte salt and 65,536 iterations. This significantly slows down the hashing process, defending against brute-force attacks while remaining compatible with Ktor's authentication mechanism.

---
*PR created automatically by Jules for task [79118127795780629](https://jules.google.com/task/79118127795780629) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened sync token authentication by replacing SHA‑256 with PBKDF2WithHmacSHA256 to resist offline brute‑force attacks. Uses a SecureRandom 16‑byte salt, 65,536 iterations, and a 256‑bit key; hashes both expected and provided tokens with the same salt, compares in constant time, clears both token char arrays, and still reads `TAJSOS_SYNC_TOKEN`.

<sup>Written for commit 30c88021b8ad707f9a6932756dc9fcdb5b5edf06. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/552?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

