### PR TITLE
feat: Add parsing for other Uri components in DeepLinkRequest

### DIFF
--- a/.agent/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/deeplinks-basic.md
+++ b/.agent/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/deeplinks-basic.md
@@ -140,7 +140,7 @@ class MainActivity : ComponentActivity() {
         // associate the target with the correct backstack key
         val key: NavKey = uri?.let {
             /** STEP 2. Parse requested deeplink */
-            val request = DeepLinkRequest(uri)
+            val request = DeepLinkRequest(intent.action, uri, intent.type)
             /** STEP 3. Compared requested with supported deeplink to find match*/
             val match = deepLinkPatterns.firstNotNullOfOrNull { pattern ->
                 DeepLinkMatcher(request, pattern).match()
@@ -477,7 +477,9 @@ import android.net.Uri
  * @param uri the target deeplink uri to link to
  */
 internal class DeepLinkRequest(
-    val uri: Uri
+    val action: String?,
+    val uri: Uri,
+    val mimeType: String?
 ) {
     /**
      * A list of path segments
@@ -493,7 +495,10 @@ internal class DeepLinkRequest(
         }
     }
 
-    // TODO add parsing for other Uri components, i.e. fragments, mimeType, action
+    /**
+     * The fragment of the URI
+     */
+    val fragment: String? = uri.fragment
 }
 ```
 
@@ -539,7 +544,9 @@ import java.io.Serializable
  */
 internal class DeepLinkPattern<T : NavKey>(
     val serializer: KSerializer<T>,
-    val uriPattern: Uri
+    val uriPattern: Uri,
+    val action: String? = null,
+    val mimeType: String? = null
 ) {
     /**
      * Help differentiate if a path segment is an argument or a static value
@@ -646,10 +653,16 @@ internal class DeepLinkMatcher<T : NavKey>(
     fun match(): DeepLinkMatchResult<T>? {
         if (request.uri.scheme != deepLinkPattern.uriPattern.scheme) return null
         if (!request.uri.authority.equals(deepLinkPattern.uriPattern.authority, ignoreCase = true)) return null
+        if (deepLinkPattern.action != null && request.action != deepLinkPattern.action) return null
+        if (deepLinkPattern.mimeType != null && request.mimeType != deepLinkPattern.mimeType) return null
+        if (deepLinkPattern.uriPattern.fragment != null && request.fragment != deepLinkPattern.uriPattern.fragment) return null
         if (request.pathSegments.size != deepLinkPattern.pathSegments.size) return null
         // exact match (url does not contain any arguments)
-        if (request.uri == deepLinkPattern.uriPattern)
+        if (request.uri == deepLinkPattern.uriPattern &&
+            request.action == deepLinkPattern.action &&
+            request.mimeType == deepLinkPattern.mimeType) {
             return DeepLinkMatchResult(deepLinkPattern.serializer, mapOf())
+        }
 
         val args = mutableMapOf<String, Any>()
         // match the path


### PR DESCRIPTION
Added parsing for fragment, mimeType, and action to DeepLinkRequest by updating its constructor and initialization, and removing the TODO comment.

Also updated DeepLinkPattern and DeepLinkMatcher to properly implement pattern matching for actions, mimeTypes, and fragment components.

---
*PR created automatically by Jules for task [17439160671367357105](https://jules.google.com/task/17439160671367357105) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extended deep link parsing and matching to include intent action, MIME type, and URI fragment. This enables precise routing and parity with Android intent data.

- **New Features**
  - DeepLinkRequest now takes action, uri, and mimeType; parses fragment.
  - DeepLinkPattern supports optional action and mimeType filters.
  - DeepLinkMatcher enforces action, mimeType, and fragment checks; exact-match logic updated.
  - Updated recipe to use the new constructor in the example.

- **Migration**
  - Replace DeepLinkRequest(uri) with DeepLinkRequest(intent.action, uri, intent.type).

<sup>Written for commit 8f33402c8b2cd49891dd316b03fd5529dda157a3. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/553?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

