### PR TITLE
perf: cache regex instances to prevent recompilation in hot paths

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
@@ -190,6 +190,12 @@ internal data class IcsDateProperty(
  * by processing lines within a `BEGIN:VEVENT` and `END:VEVENT` block.
  */
 internal class IcsEventBuilder {
+
+    companion object {
+        /** Cached regex for extracting timezone ID from ICS properties to prevent recompilation. */
+        private val tzidRegex = Regex("TZID=([^;:]+)")
+    }
+
     internal var uid: String? = null
     internal var summary: String = "No Title"
     internal var description: String? = null
@@ -342,7 +348,7 @@ internal class IcsEventBuilder {
      */
     internal fun extractTimeZone(rawKey: String): TimeZone {
         val tzidMatch =
-            Regex("TZID=([^;:]+)").find(rawKey) ?: return TimeZone.currentSystemDefault()
+            tzidRegex.find(rawKey) ?: return TimeZone.currentSystemDefault()
         return try {
             TimeZone.of(tzidMatch.groupValues[1])
         } catch (e: IllegalArgumentException) {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/MainNodeSupport.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/MainNodeSupport.kt
@@ -30,6 +30,12 @@ class MainNodeSupport(
     private val currentNodes: () -> List<NodeWithPin>,
     private val currentTags: () -> List<TagEntity>
 ) {
+
+    companion object {
+        /** Cached regex for parsing wiki-style internal links to prevent recompilation. */
+        private val internalLinkRegex = Regex("\\[\\[(.*?)\\]\\]")
+    }
+
     /**
      * Inspects a node's primary content field, parses out explicitly defined internal links
      * structured like `[[Target Title]]` or `[[Target Title|Display Text]]`, and attempts
@@ -40,9 +46,8 @@ class MainNodeSupport(
     fun parseInternalLinks(nodeId: Long) {
         scope.launch {
             repository.getNodeById(nodeId)?.let { node ->
-                val regex = Regex("\\[\\[(.*?)\\]\\]")
                 val matches =
-                    regex
+                    internalLinkRegex
                         .findAll(node.content)
                         .map { match ->
                             val fullMatch = match.groupValues[1]

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
@@ -50,6 +50,12 @@ class NodeCommands(
     private val defaultNextStepLabel: () -> String = { "Next step" },
     private val defaultUntitledLabel: () -> String = { "Untitled" },
 ) {
+
+    companion object {
+        /** Cached regex for splitting markdown content by top-level headings to prevent recompilation. */
+        private val headingSplitRegex = Regex("(?=^# )", RegexOption.MULTILINE)
+    }
+
     /**
      * Automatically reviews the inbox and currently active task lists to identify items that have
      * been ignored or deferred multiple times (based on [cutoffDays]). It sweeps these stale items
@@ -472,7 +478,7 @@ class NodeCommands(
             repository.getNodeById(nodeId)?.let { node ->
                 val sections =
                     node.content
-                        .split(Regex("(?=^# )", RegexOption.MULTILINE))
+                        .split(headingSplitRegex)
                         .filter { it.isNotBlank() }
 
                 if (sections.size > 1) {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/ProtocolCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/ProtocolCommands.kt
@@ -41,6 +41,12 @@ class ProtocolCommands(
     private val protocolTemplates: () -> List<TransitionProtocolTemplate>,
     private val playbookTemplates: () -> List<PlaybookTemplate>,
 ) {
+
+    companion object {
+        /** Cached regex for replacing non-alphanumeric characters with underscores to prevent recompilation. */
+        private val nonAlphaNumericUnderscoreRegex = Regex("[^a-z0-9]+")
+    }
+
     /**
      * Executes or instantiates a specific transition protocol based on its label.
      *
@@ -218,7 +224,7 @@ class ProtocolCommands(
                                     key =
                                         cleanLabel
                                             .lowercase()
-                                            .replace(Regex("[^a-z0-9]+"), "_")
+                                            .replace(nonAlphaNumericUnderscoreRegex, "_")
                                             .trim('_'),
                                     label = cleanLabel,
                                     checklist = cleanChecklist,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpers.kt
@@ -16,6 +16,9 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Instant
 
+/** Cached regex for replacing non-alphanumeric characters with spaces to prevent recompilation. */
+private val nonAlphaNumericRegex = Regex("[^a-z0-9]+")
+
 /**
  * Normalizes a protocol or playbook label by converting it to lowercase,
  * replacing all non-alphanumeric characters with spaces, and trimming the result.
@@ -28,7 +31,7 @@ fun normalizeProtocolLabel(label: String): String =
     label
         .trim()
         .lowercase()
-        .replace(Regex("[^a-z0-9]+"), " ")
+        .replace(nonAlphaNumericRegex, " ")
         .trim()
 
 /**


### PR DESCRIPTION
Performance improvement: Inlining Regex instantiations in frequently called functions causes expensive recompilation on every invocation. This PR extracts these Regex instances into companion objects or top-level properties to cache them, reducing unnecessary overhead and improving performance.

---
*PR created automatically by Jules for task [2346164653550244103](https://jules.google.com/task/2346164653550244103) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache Kotlin `Regex` instances in hot paths to avoid recompilation on each call, cutting CPU overhead during parsing and ICS processing. Covers TZID extraction, wiki-style internal links, markdown heading splits, and non-alphanumeric replacements via cached properties in `IcsCalendarProvider.IcsEventBuilder`, `MainNodeSupport`, `NodeCommands`, `ProtocolCommands`, and `MainProtocolHelpers`.

<sup>Written for commit 82d9dff6496aa8a3b0670f6ab1a7abfbc86dc0c3. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/556?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

