### PR TITLE
docs: document core snapshot calculators and dashboard state

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
@@ -18,6 +18,7 @@ private fun currentEpochMillis(): Long =
  * Raw capture inbox entry stored before the system commits to a semantic item type.
  *
  * This is the primary "capture fast, structure later" primitive for the new LifeOS model.
+ * Represents a raw capture entry inside the inbox before being structured or triaged.
  */
 @Entity(
     tableName = "inbox_entries",
@@ -131,6 +132,11 @@ data class RecordFacetEntity(
         Index(value = ["domainKey"]),
     ],
 )
+/**
+ * Represents the cross-cutting assignment of a shared item to a first-class LifeOS domain.
+ * NOTE: Current design prefers implicit categorization via `DomainLensQueries`,
+ * but explicit database associations are preserved here for overrides and future expansion.
+ */
 @Serializable
 data class ItemDomainEntity(
     val itemId: Long,
@@ -148,6 +154,10 @@ data class ItemDomainEntity(
     tableName = "rich_content_documents",
     indices = [Index(value = ["updatedAt"])],
 )
+/**
+ * Stores long-form structured content (such as markdown bodies or embedded objects)
+ * alongside a parent Node without bloating the primary generic node table.
+ */
 @Serializable
 data class RichContentDocumentEntity(
     @PrimaryKey val itemId: Long,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -304,7 +304,7 @@ fun calculateInsights(
             0.0
         }
 
-    // Insight Cards Logic (Roadmap Section 7)
+    // Insight Cards Logic
     val mostPostponedAreaId =
         nodes
             .mapNotNull { item ->
@@ -363,7 +363,7 @@ fun calculateInsights(
             !hasRecentActivity
         }
 
-    // Advanced Insight Concepts (Roadmap Section 7)
+    // Advanced Insight Concepts
     val projectEntropy =
         projects.associate { project ->
             val projectNodes =
@@ -729,16 +729,6 @@ fun calculateOpenLoopsSnapshot(
 }
 
 /**
- * Calculates a qualitative urgency string for an open loop.
- *
- * It checks the item's deadline and staleness metrics against the current time to classify
- * its urgency (e.g., "critical", "high", "medium", "low").
- *
- * @param node The node entity representing the open loop.
- * @param now The current epoch timestamp in milliseconds.
- * @return A string identifier representing the calculated urgency level.
- */
-/**
  * Calculates the urgency identifier for an open loop based on due dates and staleness.
  * Assumes items are more urgent if due within the next 24 hours or stale for 14+ days.
  *
@@ -802,13 +792,6 @@ fun openLoopDecayScore(
     ).coerceIn(0, 100)
 }
 
-/**
- * Evaluates active tasks tagged with maintenance parameters (e.g., "recurring", "chore")
- * and calculates their specific due dates and overdue statuses to generate a [MaintenanceSnapshot].
- *
- * @param tasks A comprehensive list of all non-archived task nodes.
- * @return A [MaintenanceSnapshot] summarizing the user's administrative and routine debt.
- */
 /**
  * Evaluates all active maintenance nodes (chores, administration, subscriptions)
  * and calculates their specific due dates and overdue statuses to generate a [MaintenanceSnapshot].
@@ -925,16 +908,6 @@ fun calculateMaintenanceSnapshot(nodes: List<NodeWithPin>): com.tajemniktv.tajso
     )
 }
 
-/**
- * Calculates a qualitative urgency string for a maintenance item.
- *
- * Evaluates the item's deadline or overdue timestamp against the current time,
- * combined with its specific maintenance type, to classify its urgency.
- *
- * @param node The node entity representing the maintenance task.
- * @param now The current epoch timestamp in milliseconds.
- * @return A string identifier representing the calculated urgency level.
- */
 /**
  * Determines the string-based urgency level for a given maintenance item.
  * Uses predefined "criticalTypes" such as bills or prescriptions to escalate urgency compared to routine chores.

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -738,6 +738,14 @@ fun calculateOpenLoopsSnapshot(
  * @param now The current epoch timestamp in milliseconds.
  * @return A string identifier representing the calculated urgency level.
  */
+/**
+ * Calculates the urgency identifier for an open loop based on due dates and staleness.
+ * Assumes items are more urgent if due within the next 24 hours or stale for 14+ days.
+ *
+ * @param node The [NodeEntity] representing the open loop.
+ * @param now The current epoch timestamp in milliseconds.
+ * @return A string identifier representing the calculated urgency level.
+ */
 fun openLoopUrgency(
     node: NodeEntity,
     now: Long,
@@ -799,6 +807,13 @@ fun openLoopDecayScore(
  * and calculates their specific due dates and overdue statuses to generate a [MaintenanceSnapshot].
  *
  * @param tasks A comprehensive list of all non-archived task nodes.
+ * @return A [MaintenanceSnapshot] summarizing the user's administrative and routine debt.
+ */
+/**
+ * Evaluates all active maintenance nodes (chores, administration, subscriptions)
+ * and calculates their specific due dates and overdue statuses to generate a [MaintenanceSnapshot].
+ *
+ * @param nodes The complete list of active nodes in the system.
  * @return A [MaintenanceSnapshot] summarizing the user's administrative and routine debt.
  */
 fun calculateMaintenanceSnapshot(nodes: List<NodeWithPin>): com.tajemniktv.tajsos.ui.MaintenanceSnapshot {
@@ -919,6 +934,14 @@ fun calculateMaintenanceSnapshot(nodes: List<NodeWithPin>): com.tajemniktv.tajso
  * @param node The node entity representing the maintenance task.
  * @param now The current epoch timestamp in milliseconds.
  * @return A string identifier representing the calculated urgency level.
+ */
+/**
+ * Determines the string-based urgency level for a given maintenance item.
+ * Uses predefined "criticalTypes" such as bills or prescriptions to escalate urgency compared to routine chores.
+ *
+ * @param node The [NodeEntity] representing the maintenance chore.
+ * @param now The current epoch timestamp in milliseconds.
+ * @return A string identifier indicating the calculated urgency level.
  */
 fun maintenanceUrgency(
     node: NodeEntity,
@@ -1065,6 +1088,12 @@ fun calculateTimeArchitectureSnapshot(
     )
 }
 
+/**
+ * Computes the string representation (YYYY-MM-DD) of the first day of the following calendar month,
+ * used for monthly resets and long-term planning horizons.
+ *
+ * @return The calculated next monthly reset date.
+ */
 fun nextMonthlyResetDate(): String {
     val now = Clock.System.now()
     val zone = TimeZone.currentSystemDefault()
@@ -1073,6 +1102,14 @@ fun nextMonthlyResetDate(): String {
     return nextReset.toString()
 }
 
+/**
+ * Evaluates all person-anchored nodes and their explicitly assigned relational events
+ * to generate a [RelationshipSnapshot]. Assesses when someone was last contacted and calculates follow-up pressure.
+ *
+ * @param nodes The complete list of active nodes in the system.
+ * @param relations The complete list of relational edges tying nodes together.
+ * @return A structured [RelationshipSnapshot] describing the health of active tracked relationships.
+ */
 fun calculateRelationshipSnapshot(
     nodes: List<NodeWithPin>,
     relations: List<RelationEntity>,
@@ -1248,6 +1285,15 @@ fun calculateRelationshipSnapshot(
     )
 }
 
+/**
+ * Evaluates all tasks and entities tied to physical locations (e.g., errands, travel, local chores).
+ * Maps tasks to places to generate a [PhysicalLogisticsSnapshot] enabling batched execution.
+ *
+ * @param nodes The complete list of active nodes in the system.
+ * @param relations Relational edges to map tasks to their location nodes.
+ * @param templates A list of system templates (e.g., packing lists, trip templates).
+ * @return A [PhysicalLogisticsSnapshot] categorizing tasks and items by physical place.
+ */
 fun calculatePhysicalLogisticsSnapshot(
     nodes: List<NodeWithPin>,
     relations: List<RelationEntity>,
@@ -1476,6 +1522,14 @@ fun calculatePhysicalLogisticsSnapshot(
     )
 }
 
+/**
+ * Aggregates all knowledge nodes marked as operating principles, rules, or core philosophies
+ * to generate a [PersonalRulesSnapshot].
+ *
+ * @param nodes The complete list of active nodes in the system.
+ * @param relations Relational edges linking rules to specific protocols or playbooks.
+ * @return A structured [PersonalRulesSnapshot].
+ */
 fun calculatePersonalRulesSnapshot(
     nodes: List<NodeWithPin>,
     relations: List<RelationEntity>,
@@ -1545,6 +1599,13 @@ fun calculatePersonalRulesSnapshot(
     )
 }
 
+/**
+ * Separates long-term, read-later, or specific informational nodes into curated "Vaults".
+ * Identifies quotes, incubations, highlights, and forgotten notes to form a [VaultsSnapshot].
+ *
+ * @param nodes The complete list of active nodes in the system.
+ * @return A [VaultsSnapshot] organizing knowledge items into distinct collections.
+ */
 fun calculateVaultsSnapshot(nodes: List<NodeWithPin>): VaultsSnapshot {
     val active = nodes.filter { it.node.status == "active" }
 
@@ -1873,6 +1934,16 @@ fun calculateCapacitySnapshot(
     )
 }
 
+/**
+ * Aggregates core behavioral metrics, area balances, and key habits to compute a user's
+ * "LifeOS Signature", representing their overarching systemic operational health.
+ *
+ * @param modes All available modes.
+ * @param areaHealth Calculated area health snapshot.
+ * @param relations Relational mapping data.
+ * @param nodes The complete list of active nodes in the system.
+ * @return A compiled [LifeOSSignatureSnapshot] detailing system coherence.
+ */
 fun calculateLifeOSSignatureSnapshot(
     modes: List<ModeEntity>,
     areaHealth: com.tajemniktv.tajsos.ui.AreaHealthSnapshot,
@@ -2003,6 +2074,14 @@ fun calculateLifeOSSignatureSnapshot(
     )
 }
 
+/**
+ * Evaluates the user's "Second Brain" knowledge layer, summarizing their captured notes,
+ * highlights, and resources.
+ *
+ * @param nodes The complete list of active nodes in the system.
+ * @param relations Relational mapping data.
+ * @return A compiled [LifeOSSecondBrainSnapshot] representing knowledge capture health.
+ */
 fun calculateLifeOSSecondBrainSnapshot(
     nodes: List<NodeWithPin>,
     relations: List<RelationEntity>,
@@ -2211,6 +2290,17 @@ fun calculateLifeOSSecondBrainSnapshot(
     )
 }
 
+/**
+ * Combines active projects, time architectures, and structural commitments into a unified view
+ * of the user's forward-looking direction and trajectory.
+ *
+ * @param distinction The calculated second brain snapshot.
+ * @param signature The calculated lifeOS signature.
+ * @param nodes The complete list of active nodes in the system.
+ * @param projects A curated list of projects.
+ * @param areas A curated list of areas.
+ * @return A compiled [CombinedDirectionSnapshot] summarizing the user's vector.
+ */
 fun calculateCombinedDirectionSnapshot(
     distinction: LifeOSSecondBrainSnapshot,
     signature: LifeOSSignatureSnapshot,
@@ -2335,6 +2425,16 @@ fun calculateCombinedDirectionSnapshot(
     )
 }
 
+/**
+ * Evaluates major life shifts or transitions by assessing critical path nodes, significant events,
+ * and recent large-scale accomplishments.
+ *
+ * @param distinction The calculated second brain snapshot.
+ * @param signature The calculated lifeOS signature.
+ * @param nodes The complete list of active nodes in the system.
+ * @param relations Relational mapping data.
+ * @return A compiled [CoreLifeOSShiftSnapshot] highlighting pivotal changes.
+ */
 fun calculateCoreLifeOSShiftSnapshot(
     distinction: LifeOSSecondBrainSnapshot,
     signature: LifeOSSignatureSnapshot,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -1940,7 +1940,15 @@ fun calculateCapacitySnapshot(
  *
  * @param modes All available modes.
  * @param areaHealth Calculated area health snapshot.
- * @param relations Relational mapping data.
+ * @param openLoops The calculated open loops snapshot.
+ * @param pendingDecisions A list of pending decisions.
+ * @param maintenance The calculated maintenance snapshot.
+ * @param relationships The calculated relationship snapshot.
+ * @param vaults The calculated vaults snapshot.
+ * @param capacity The calculated capacity snapshot.
+ * @param playbooks The calculated playbook snapshot.
+ * @param currentMode The currently active focus mode.
+ * @param trackEntries A list of track entries.
  * @param nodes The complete list of active nodes in the system.
  * @return A compiled [LifeOSSignatureSnapshot] detailing system coherence.
  */
@@ -2080,6 +2088,16 @@ fun calculateLifeOSSignatureSnapshot(
  *
  * @param nodes The complete list of active nodes in the system.
  * @param relations Relational mapping data.
+ * @param dashboard The current dashboard UI state.
+ * @param areaHealth The calculated area health snapshot.
+ * @param openLoops The calculated open loops snapshot.
+ * @param maintenance The calculated maintenance snapshot.
+ * @param capacity The calculated capacity snapshot.
+ * @param protocols The calculated transition protocols snapshot.
+ * @param playbooks The calculated playbook snapshot.
+ * @param currentMode The currently active focus mode.
+ * @param signature The calculated lifeOS signature.
+ * @param vaults The calculated vaults snapshot.
  * @return A compiled [LifeOSSecondBrainSnapshot] representing knowledge capture health.
  */
 fun calculateLifeOSSecondBrainSnapshot(
@@ -2296,9 +2314,13 @@ fun calculateLifeOSSecondBrainSnapshot(
  *
  * @param distinction The calculated second brain snapshot.
  * @param signature The calculated lifeOS signature.
- * @param nodes The complete list of active nodes in the system.
- * @param projects A curated list of projects.
- * @param areas A curated list of areas.
+ * @param dashboard The current dashboard UI state.
+ * @param logistics The calculated physical logistics snapshot.
+ * @param capacity The calculated capacity snapshot.
+ * @param relationships The calculated relationship snapshot.
+ * @param protocols The calculated transition protocols snapshot.
+ * @param maintenance The calculated maintenance snapshot.
+ * @param openLoops The calculated open loops snapshot.
  * @return A compiled [CombinedDirectionSnapshot] summarizing the user's vector.
  */
 fun calculateCombinedDirectionSnapshot(
@@ -2431,8 +2453,15 @@ fun calculateCombinedDirectionSnapshot(
  *
  * @param distinction The calculated second brain snapshot.
  * @param signature The calculated lifeOS signature.
- * @param nodes The complete list of active nodes in the system.
- * @param relations Relational mapping data.
+ * @param direction The calculated combined direction snapshot.
+ * @param dashboard The current dashboard UI state.
+ * @param time The calculated time architecture snapshot.
+ * @param areaHealth The calculated area health snapshot.
+ * @param openLoops The calculated open loops snapshot.
+ * @param maintenance The calculated maintenance snapshot.
+ * @param protocols The calculated transition protocols snapshot.
+ * @param capacity The calculated capacity snapshot.
+ * @param currentMode The currently active focus mode.
  * @return A compiled [CoreLifeOSShiftSnapshot] highlighting pivotal changes.
  */
 fun calculateCoreLifeOSShiftSnapshot(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/state/MainDashboardState.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/state/MainDashboardState.kt
@@ -169,7 +169,7 @@ data class AreaHealthSnapshot(
 )
 
 /**
- * A data class representing a specific unresolved work item and its calculated urgency.
+ * Represents the current status and calculated urgency of an unresolved open loop item.
  *
  * @param node The [NodeWithPin] wrapper for the unresolved item.
  * @param urgency A calculated string representing how critical the loop is (e.g., "high", "low").
@@ -215,7 +215,7 @@ data class OpenLoopsSnapshot(
 )
 
 /**
- * A data class representing a routine or maintenance task, tracking its recurrence and overdue status.
+ * Represents a routine maintenance chore alongside its specific recurrence and urgency state.
  *
  * @param node The [NodeWithPin] wrapper for the maintenance task.
  * @param urgency A string representing how critical it is to complete the task (e.g., "critical").
@@ -259,7 +259,7 @@ data class MaintenanceSnapshot(
 )
 
 /**
- * A data class representing a node (often an event or deadline) mapped to a specific future countdown.
+ * Represents an upcoming event or deadline specifically mapped for countdown visualization.
  *
  * @param node The [NodeWithPin] wrapper.
  * @param daysLeft The calculated number of days remaining until the node's target date.
@@ -270,7 +270,7 @@ data class TimeCountdownItem(
 )
 
 /**
- * A data class describing the current phase of an active project.
+ * Represents a structural project combined with its active temporal or strategic phase.
  *
  * @param project The parent [NodeEntity] representing the project.
  * @param isActivePhase True if the project is currently in an active execution phase.


### PR DESCRIPTION
This PR adds comprehensive KDoc documentation to core UI state generation functions in MainSnapshotCalculators.kt, state structures in MainDashboardState.kt, and primary entities in LifeObjectEntities.kt to reduce onboarding friction and clarify complex business rules regarding urgency and state derivation.

---
*PR created automatically by Jules for task [819001332055524923](https://jules.google.com/task/819001332055524923) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds focused KDoc to `MainSnapshotCalculators.kt`, `MainDashboardState.kt`, and `LifeObjectEntities.kt` to clarify urgency scoring, due/stale thresholds, and how each snapshot is derived. This makes business rules explicit, reduces onboarding friction, and supports clearer testing and future changes.

<sup>Written for commit 1790305f354f77e7b0f3e56517643a07d4c557e8. Summary will update on new commits. <a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/560?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

