### PR TITLE
perf: Cache word count regex in NotesEditorPane

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -251,10 +251,15 @@ fun NotesEditorHeaderActions(
     }
 }
 
+/**
+ * Cached regex for splitting text into words by whitespace to avoid repeated instantiations during typing.
+ */
+private val WHITESPACE_REGEX = Regex("\\s+")
+
 private fun wordCount(content: String): Int =
     content
         .trim()
-        .split(Regex("\\s+"))
+        .split(WHITESPACE_REGEX)
         .filter { it.isNotBlank() }
         .size
         .let { max(0, it) }


### PR DESCRIPTION
This PR extracts the inline Regex used for word counting in NotesEditorPane to a top-level cached property to avoid repeated instantiations during text editing, improving performance.

---
*PR created automatically by Jules for task [11465071018418047209](https://jules.google.com/task/11465071018418047209) started by @tajemniktv*