### PR TITLE
fix(ui): diffuse dark mode shadows

### DIFF
--- a/website/src/components/landing/Hero.astro
+++ b/website/src/components/landing/Hero.astro
@@ -7,7 +7,7 @@ import { SITE } from '../../data/site';
   <div class="w-full lg:w-3/4 z-10">
     <div class="flex items-center gap-4 mb-12">
       <span
-        class="font-mono text-[10px] tracking-[0.5em] text-primary bg-surface-container-highest px-4 py-2 rounded-full shadow-[0_0_15px_rgba(186,158,255,0.1)] uppercase"
+        class="font-mono text-[10px] tracking-[0.5em] text-primary bg-surface-container-highest px-4 py-2 rounded-full shadow-[0_0_40px_rgba(186,158,255,0.1)] uppercase"
         >LOCAL_FIRST</span
       >
 
@@ -58,7 +58,7 @@ import { SITE } from '../../data/site';
         >
         </div>
         <div
-          class="absolute bottom-8 left-8 right-8 bg-surface-container-highest/90 p-6 rounded-xl shadow-[0_20px_40px_rgba(0,0,0,0.4)]"
+          class="absolute bottom-8 left-8 right-8 bg-surface-container-highest/90 p-6 rounded-xl shadow-[0_20px_50px_rgba(0,0,0,0.2)]"
         >
           <span
             class="font-mono text-[9px] text-primary block mb-3 tracking-[0.3em] uppercase"

--- a/website/src/components/landing/InstrumentPanel.astro
+++ b/website/src/components/landing/InstrumentPanel.astro
@@ -80,7 +80,7 @@
         >
         <div class="space-y-6">
           <div
-            class="bg-surface-container-highest p-6 rounded-3xl flex justify-between items-center shadow-[0_0_20px_rgba(192,140,247,0.15)]"
+            class="bg-surface-container-highest p-6 rounded-3xl flex justify-between items-center shadow-[0_0_50px_rgba(192,140,247,0.15)]"
           >
             <div>
               <p
@@ -118,7 +118,7 @@
         </div>
         <div class="w-full h-0.75 bg-secondary/10 overflow-hidden">
           <div
-            class="w-[75%] h-full bg-secondary shadow-[0_0_10px_rgba(200,140,247,0.5)]"
+            class="w-[75%] h-full bg-secondary shadow-[0_0_30px_rgba(200,140,247,0.5)]"
           >
           </div>
         </div>
@@ -192,7 +192,7 @@
           <div class="bg-secondary/40 h-[50%] rounded-t"></div>
           <div class="bg-secondary/60 h-[80%] rounded-t"></div>
           <div
-            class="bg-secondary h-[40%] rounded-t shadow-[0_0_15px_rgba(192,140,247,0.3)]"
+            class="bg-secondary h-[40%] rounded-t shadow-[0_0_40px_rgba(192,140,247,0.3)]"
           >
           </div>
           <div class="bg-secondary/70 h-[90%] rounded-t"></div>

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -32,8 +32,8 @@ const title = "Changelog";
 <div class="flex gap-1 items-end h-8">
 <div class="w-1 bg-zinc-800 h-2"></div>
 <div class="w-1 bg-zinc-800 h-4"></div>
-<div class="w-1 bg-primary h-6 shadow-[0_0_10px_#ba9eff]"></div>
-<div class="w-1 bg-primary h-5 shadow-[0_0_10px_#ba9eff]"></div>
+<div class="w-1 bg-primary h-6 shadow-[0_0_30px_#ba9eff]"></div>
+<div class="w-1 bg-primary h-5 shadow-[0_0_30px_#ba9eff]"></div>
 <div class="w-1 bg-zinc-800 h-3"></div>
 </div>
 </div>
@@ -53,7 +53,7 @@ const title = "Changelog";
 <div class="w-full h-12 flex items-center justify-between gap-1">
 <div class="flex-1 h-1 bg-primary/20 rounded-full"></div>
 <div class="flex-1 h-3 bg-primary/40 rounded-full"></div>
-<div class="flex-1 h-6 bg-primary rounded-full shadow-[0_0_15px_#ba9eff]"></div>
+<div class="flex-1 h-6 bg-primary rounded-full shadow-[0_0_40px_#ba9eff]"></div>
 <div class="flex-1 h-8 bg-primary-dim rounded-full"></div>
 <div class="flex-1 h-4 bg-primary/40 rounded-full"></div>
 <div class="flex-1 h-2 bg-primary/20 rounded-full"></div>
@@ -84,7 +84,7 @@ const title = "Changelog";
 <div class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2">
 <div class="flex justify-between items-start">
 <span class="material-symbols-outlined text-xs text-primary">hub</span>
-<div class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse shadow-[0_0_5px_#ba9eff]"></div>
+<div class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse shadow-[0_0_20px_#ba9eff]"></div>
 </div>
 <span class="font-mono text-[9px] uppercase tracking-tighter">Sync_Node</span>
 </div>
@@ -98,7 +98,7 @@ const title = "Changelog";
 <div class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2">
 <div class="flex justify-between items-start">
 <span class="material-symbols-outlined text-xs text-primary">security</span>
-<div class="w-1.5 h-1.5 rounded-full bg-primary shadow-[0_0_5px_#ba9eff]"></div>
+<div class="w-1.5 h-1.5 rounded-full bg-primary shadow-[0_0_20px_#ba9eff]"></div>
 </div>
 <span class="font-mono text-[9px] uppercase tracking-tighter">Vault_Enc</span>
 </div>
@@ -114,7 +114,7 @@ const title = "Changelog";
 </aside>
 <!-- Main Center: Terminal Live Activity -->
 <section class="col-span-9 flex flex-col gap-4">
-<div class="bg-surface-container-lowest border border-outline-variant/10 rounded-3xl flex flex-col h-[750px] overflow-hidden terminal-glow shadow-2xl">
+<div class="bg-surface-container-lowest border border-outline-variant/10 rounded-3xl flex flex-col h-[750px] overflow-hidden terminal-glow shadow-[0_20px_50px_rgba(0,0,0,0.3)]">
 <!-- Terminal Header -->
 <div class="bg-surface-container-high px-6 py-3 flex justify-between items-center border-b border-outline-variant/5">
 <div class="flex items-center gap-4">

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -95,7 +95,7 @@ const title = "PRICING";
 <span>Multi-Kernel Synchronization</span>
 </li>
 </ul>
-<button class="w-full py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-label font-bold uppercase tracking-widest text-xs rounded-lg shadow-[0_0_20px_rgba(186,158,255,0.3)] hover:shadow-[0_0_30px_rgba(186,158,255,0.5)] transition-all">Inject Protocol</button>
+<button class="w-full py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-label font-bold uppercase tracking-widest text-xs rounded-lg shadow-[0_0_50px_rgba(186,158,255,0.3)] hover:shadow-[0_0_60px_rgba(186,158,255,0.5)] transition-all">Inject Protocol</button>
 </div>
 <!-- Tier 3: Transcend -->
 <div class="bg-surface-container-low glow-hover p-8 rounded-3xl flex flex-col transition-all duration-500">

--- a/website/src/pages/terms.astro
+++ b/website/src/pages/terms.astro
@@ -167,7 +167,7 @@ const title = "TERMS";
 <button class="flex-1 md:flex-none px-8 py-4 bg-surface-container-highest text-on-surface font-label text-sm font-bold rounded-xl border border-outline-variant/30 hover:bg-surface-variant transition-all">
                             Download Whitepaper
                         </button>
-<button class="flex-1 md:flex-none px-12 py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary font-label text-sm font-bold rounded-xl shadow-[0_0_20px_rgba(186,158,255,0.4)] active:scale-95 transition-all">
+<button class="flex-1 md:flex-none px-12 py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary font-label text-sm font-bold rounded-xl shadow-[0_0_50px_rgba(186,158,255,0.4)] active:scale-95 transition-all">
                             Accept Protocol
                         </button>
 </div>


### PR DESCRIPTION
🎯 **What:**
Modified hard-coded shadow utility classes across `InstrumentPanel.astro`, `Hero.astro`, `changelog.astro`, `pricing.astro`, and `terms.astro` to increase their blur radius (e.g., `shadow-[0_0_10px_...]` to `shadow-[0_0_30px_...]`) and in some cases, slightly lower opacity.

💡 **Why:**
To comply with the Design System Responsive Rules, which state: "Dark mode shadows stroke should be broad and diffused, never sharp."

✅ **Verification:**
Ran `git diff` to confirm shadow classes were updated without unintended side effects. Re-ran `npx astro check` and `npm run build` to verify there were no build issues. Used Playwright visual verification to ensure the page rendered correctly.

✨ **Result:**
A more cohesive and deeply layered dark mode aesthetic with properly diffused shadows.

---
*PR created automatically by Jules for task [5145058375212071451](https://jules.google.com/task/5145058375212071451) started by @tajemniktv*