### PR TITLE
🧹 [Reliability] Prevent runCatching from swallowing CancellationException in MainViewModel

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -4,6 +4,8 @@
 
 package com.tajemniktv.tajsos.ui
 
+import kotlin.coroutines.cancellation.CancellationException
+
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -2682,7 +2684,8 @@ class MainViewModel(
             val bundleResult =
                 runCatching {
                     Json.decodeFromString<ExportBundle>(content)
-                }.getOrNull()
+                }
+                    .onFailure { if (it is CancellationException) throw it }.getOrNull()
             if (bundleResult != null) {
                 val report = repository.importBundle(bundleResult)
                 return@withContext "Imported bundle: ${report.nodes} nodes, ${report.relations} relations, ${report.events} events."
@@ -2691,7 +2694,8 @@ class MainViewModel(
             val legacyResult =
                 runCatching {
                     Json.decodeFromString<ExportData>(content)
-                }.getOrNull()
+                }
+                    .onFailure { if (it is CancellationException) throw it }.getOrNull()
             if (legacyResult != null) {
                 val count = repository.importLegacyNodes(legacyResult.nodes)
                 return@withContext "Imported legacy export: $count nodes."

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2681,25 +2681,13 @@ class MainViewModel(
             val content = payload.trim()
             if (content.isBlank()) return@withContext "Import failed: empty payload."
 
-            val bundleResult = try {
-                Json.decodeFromString<ExportBundle>(content)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                null
-            }
+            val bundleResult = safeDecode { Json.decodeFromString<ExportBundle>(content) }
             if (bundleResult != null) {
                 val report = repository.importBundle(bundleResult)
                 return@withContext "Imported bundle: ${report.nodes} nodes, ${report.relations} relations, ${report.events} events."
             }
 
-            val legacyResult = try {
-                Json.decodeFromString<ExportData>(content)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                null
-            }
+            val legacyResult = safeDecode { Json.decodeFromString<ExportData>(content) }
             if (legacyResult != null) {
                 val count = repository.importLegacyNodes(legacyResult.nodes)
                 return@withContext "Imported legacy export: $count nodes."
@@ -2827,3 +2815,12 @@ class MainViewModel(
         decisionCommands.convertDecisionToTask(nodeId)
     }
 }
+
+private inline fun <T> safeDecode(block: () -> T): T? =
+    try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        null
+    }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2681,21 +2681,25 @@ class MainViewModel(
             val content = payload.trim()
             if (content.isBlank()) return@withContext "Import failed: empty payload."
 
-            val bundleResult =
-                runCatching {
-                    Json.decodeFromString<ExportBundle>(content)
-                }
-                    .onFailure { if (it is CancellationException) throw it }.getOrNull()
+            val bundleResult = try {
+                Json.decodeFromString<ExportBundle>(content)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                null
+            }
             if (bundleResult != null) {
                 val report = repository.importBundle(bundleResult)
                 return@withContext "Imported bundle: ${report.nodes} nodes, ${report.relations} relations, ${report.events} events."
             }
 
-            val legacyResult =
-                runCatching {
-                    Json.decodeFromString<ExportData>(content)
-                }
-                    .onFailure { if (it is CancellationException) throw it }.getOrNull()
+            val legacyResult = try {
+                Json.decodeFromString<ExportData>(content)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                null
+            }
             if (legacyResult != null) {
                 val count = repository.importLegacyNodes(legacyResult.nodes)
                 return@withContext "Imported legacy export: $count nodes."


### PR DESCRIPTION
🎯 **What:**
Appended `.onFailure { if (it is CancellationException) throw it }` to the `runCatching` blocks in `MainViewModel.kt`'s `importDataJson` suspend function.

💡 **Why:**
By default, `runCatching` catches all `Throwable` instances, including `CancellationException`. When used inside a `suspend` function, this can inadvertently swallow coroutine cancellation signals. If a user navigates away or cancels an import operation mid-flight, the coroutine would continue running in the background because the cancellation exception was masked. Explicitly checking for and re-throwing `CancellationException` preserves structured concurrency while still allowing standard JSON deserialization errors to return null safely.

✅ **Verification:**
Ran `./gradlew :shared:jvmTest` and verified that no existing logic or syntax broke due to this modification. Code review confirmed the changes are safe and correctly targeted.

✨ **Result:**
The application is more robust and predictable. Long-running JSON import operations can now be reliably canceled, preventing resource leaks or orphaned background tasks.

---
*PR created automatically by Jules for task [11823853741599787488](https://jules.google.com/task/11823853741599787488) started by @tajemniktv*