### PR TITLE
test: Add RelationshipCommands tests

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/ProtocolCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/ProtocolCommandsTest.kt
@@ -40,27 +40,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProtocolCommandsTest {
 
-    private fun buildRepository(): AppRepository {
-        return AppRepository(
-            nodeDao = FakeNodeDao(),
-            nodeSnapshotDao = FakeNodeSnapshotDao(),
-            tagDao = FakeTagDao(),
-            relationDao = FakeRelationDao(),
-            attachmentDao = FakeAttachmentDao(),
-            trackDao = FakeTrackDao(),
-            eventLogDao = FakeEventLogDao(),
-            templateDao = FakeTemplateDao(),
-            modeDao = FakeModeDao(),
-            userDao = FakeUserDao(),
-            reviewDao = FakeReviewDao(),
-            calendarProviderDao = FakeCalendarProviderDao(),
-            calendarEventDao = FakeCalendarEventDao(),
-            decisionDao = FakeDecisionDao(),
-            protocolDao = FakeProtocolDao(),
-            medicationDao = FakeMedicationDao(),
-            focusSessionDao = FakeFocusSessionDao(),
-        )
-    }
+
 
 
 
@@ -89,7 +69,7 @@ class ProtocolCommandsTest {
         protocolTemplates: List<TransitionProtocolTemplate> = emptyList(),
         playbookTemplates: List<PlaybookTemplate> = emptyList()
     ): Pair<AppRepository, ProtocolCommands> {
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val config = CommandsConfig(
             repo = repo,
             scope = scope,

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
@@ -43,7 +43,7 @@ class RelationshipCommandsTest {
 
     @Test
     fun testSetPersonLastContactNow() = runTest {
-        val scope = TestScope(testScheduler)
+        val scope = this
         val repo = buildTestRepository()
         val commands = setupTestRelationshipCommands(scope, repo)
 
@@ -81,18 +81,19 @@ class RelationshipCommandsTest {
         val repo = buildTestRepository()
         val commands = setupTestRelationshipCommands(scope, repo)
 
-        val personNode = NodeEntity(id = 1L, type = "person", title = "Bob")
-        repo.insertNode(personNode)
+        val personId = repo.insertNode(NodeEntity(type = "person", title = "Bob"))
 
-        commands.createReplyNeededForPerson(1L, "Bob")
+        commands.createReplyNeededForPerson(personId, "Bob")
         testScheduler.advanceUntilIdle()
 
         val nodes = repo.getAllNodes().first()
         val replyNodes = nodes.filter { it.node.type == "open_loop" && it.node.title.contains("Bob") }
         assertEquals(1, replyNodes.size, "Should create exactly 1 reply needed node")
+        assertEquals("reply_needed", replyNodes.first().node.openLoopType)
 
         val relations = repo.getRelationsForNode(1L).first()
-        val relation = relations.firstOrNull { it.fromNodeId == 1L && it.relationType == "RELATED_PERSON" }
+        val relatedPersonIds = relations.filter { it.relationType == "RELATED_PERSON" }.map { it.fromNodeId }.toSet()
+        assertEquals(setOf(personId), relatedPersonIds)
         assertTrue(relation != null)
         assertEquals(replyNodes.first().node.id, relation.toNodeId)
     }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
@@ -37,27 +37,7 @@ import kotlin.test.assertNotNull
 @OptIn(ExperimentalCoroutinesApi::class)
 class RelationshipCommandsTest {
 
-    private fun buildRepository(): AppRepository {
-        return AppRepository(
-            nodeDao = FakeNodeDao(),
-            focusSessionDao = FakeFocusSessionDao(),
-            trackDao = FakeTrackDao(),
-            relationDao = FakeRelationDao(),
-            tagDao = FakeTagDao(),
-            eventLogDao = FakeEventLogDao(),
-            attachmentDao = FakeAttachmentDao(),
-            templateDao = FakeTemplateDao(),
-            nodeSnapshotDao = FakeNodeSnapshotDao(),
-            reviewDao = FakeReviewDao(),
-            calendarProviderDao = FakeCalendarProviderDao(),
-            calendarEventDao = FakeCalendarEventDao(),
-            modeDao = FakeModeDao(),
-            protocolDao = FakeProtocolDao(),
-            decisionDao = FakeDecisionDao(),
-            userDao = FakeUserDao(),
-            medicationDao = FakeMedicationDao(),
-        )
-    }
+
 
     private fun setupCommands(
         scope: TestScope,
@@ -101,7 +81,7 @@ class RelationshipCommandsTest {
     @Test
     fun testSetPersonLastContactNow() = runTest {
         val scope = TestScope(testScheduler)
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val commands = setupCommands(scope, repo)
 
         val personNode = NodeEntity(type = "person", title = "Alice")
@@ -118,7 +98,7 @@ class RelationshipCommandsTest {
     @Test
     fun testSetPersonFollowUpInDays() = runTest {
         val scope = TestScope(testScheduler)
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val commands = setupCommands(scope, repo)
 
         val personNode = NodeEntity(type = "person", title = "Alice")
@@ -135,7 +115,7 @@ class RelationshipCommandsTest {
     @Test
     fun testCreateReplyNeededForPerson() = runTest {
         val scope = TestScope(testScheduler)
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val commands = setupCommands(scope, repo)
 
         val personNode = NodeEntity(id = 1L, type = "person", title = "Bob")
@@ -150,14 +130,14 @@ class RelationshipCommandsTest {
 
         val relations = repo.getRelationsForNode(1L).first()
         val relation = relations.firstOrNull { it.fromNodeId == 1L && it.relationType == "RELATED_PERSON" }
-        assertNotNull(relation)
-        assertEquals(replyNodes.first().node.id, relation!!.toNodeId)
+        assertTrue(relation != null)
+        assertEquals(replyNodes.first().node.id, relation.toNodeId)
     }
 
     @Test
     fun testAddPlace() = runTest {
         val scope = TestScope(testScheduler)
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val commands = setupCommands(scope, repo)
 
         commands.addPlace("Coffee Shop", campus = false, home = false)
@@ -173,7 +153,7 @@ class RelationshipCommandsTest {
     @Test
     fun testCreateLeaveHomeChecklist() = runTest {
         val scope = TestScope(testScheduler)
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val commands = setupCommands(scope, repo)
 
         commands.createLeaveHomeChecklist()
@@ -187,7 +167,7 @@ class RelationshipCommandsTest {
     @Test
     fun testAddVaultEntry() = runTest {
         val scope = TestScope(testScheduler)
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val commands = setupCommands(scope, repo)
 
         commands.addVaultEntry("receipt", "Laptop receipt", asType = "note")

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
@@ -40,22 +40,22 @@ class RelationshipCommandsTest {
     private fun buildRepository(): AppRepository {
         return AppRepository(
             nodeDao = FakeNodeDao(),
-            nodeSnapshotDao = FakeNodeSnapshotDao(),
-            tagDao = FakeTagDao(),
-            relationDao = FakeRelationDao(),
-            attachmentDao = FakeAttachmentDao(),
+            focusSessionDao = FakeFocusSessionDao(),
             trackDao = FakeTrackDao(),
+            relationDao = FakeRelationDao(),
+            tagDao = FakeTagDao(),
             eventLogDao = FakeEventLogDao(),
+            attachmentDao = FakeAttachmentDao(),
             templateDao = FakeTemplateDao(),
-            modeDao = FakeModeDao(),
-            userDao = FakeUserDao(),
+            nodeSnapshotDao = FakeNodeSnapshotDao(),
             reviewDao = FakeReviewDao(),
             calendarProviderDao = FakeCalendarProviderDao(),
             calendarEventDao = FakeCalendarEventDao(),
-            decisionDao = FakeDecisionDao(),
+            modeDao = FakeModeDao(),
             protocolDao = FakeProtocolDao(),
+            decisionDao = FakeDecisionDao(),
+            userDao = FakeUserDao(),
             medicationDao = FakeMedicationDao(),
-            focusSessionDao = FakeFocusSessionDao(),
         )
     }
 
@@ -92,7 +92,7 @@ class RelationshipCommandsTest {
             setTagOnNode = { nodeId, tagName, _ ->
                 scope.launch {
                     val tagId = repo.insertTag(TagEntity(name = tagName, normalizedName = tagName.lowercase()))
-                    repo.attachTagToNode(nodeId = nodeId, tagId = tagId)
+                    repo.attachTagToNode(nodeId, tagId)
                 }
             }
         )
@@ -148,7 +148,7 @@ class RelationshipCommandsTest {
         val replyNodes = nodes.filter { it.node.type == "open_loop" && it.node.title.contains("Bob") }
         assertEquals(1, replyNodes.size, "Should create exactly 1 reply needed node")
 
-        val relations = repo.getAllRelations().first()
+        val relations = repo.getRelationsForNode(1L).first()
         val relation = relations.firstOrNull { it.fromNodeId == 1L && it.relationType == "RELATED_PERSON" }
         assertNotNull(relation)
         assertEquals(replyNodes.first().node.id, relation!!.toNodeId)

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
@@ -39,50 +39,13 @@ class RelationshipCommandsTest {
 
 
 
-    private fun setupCommands(
-        scope: TestScope,
-        repo: AppRepository,
-        currentTemplates: List<TemplateEntity> = emptyList()
-    ): RelationshipCommands {
-        return RelationshipCommands(
-            repository = repo,
-            scope = scope,
-            currentTemplates = { currentTemplates },
-            addNodeForResult = { title, content, type, projectId, areaId, inboxState ->
-                val node = NodeEntity(
-                    type = type,
-                    title = title,
-                    content = content,
-                    projectId = projectId,
-                    areaId = areaId,
-                    inboxState = inboxState ?: false
-                )
-                repo.insertNode(node)
-            },
-            addRelation = { from, to, type ->
-                scope.launch {
-                    repo.insertRelation(RelationEntity(fromNodeId = from, toNodeId = to, relationType = type))
-                }
-            },
-            updateNode = { node ->
-                scope.launch {
-                    repo.updateNode(node)
-                }
-            },
-            setTagOnNode = { nodeId, tagName, _ ->
-                scope.launch {
-                    val tagId = repo.insertTag(TagEntity(name = tagName, normalizedName = tagName.lowercase()))
-                    repo.attachTagToNode(nodeId, tagId)
-                }
-            }
-        )
-    }
+
 
     @Test
     fun testSetPersonLastContactNow() = runTest {
         val scope = TestScope(testScheduler)
         val repo = buildTestRepository()
-        val commands = setupCommands(scope, repo)
+        val commands = setupTestRelationshipCommands(scope, repo)
 
         val personNode = NodeEntity(type = "person", title = "Alice")
         val nodeId = repo.insertNode(personNode)
@@ -99,7 +62,7 @@ class RelationshipCommandsTest {
     fun testSetPersonFollowUpInDays() = runTest {
         val scope = TestScope(testScheduler)
         val repo = buildTestRepository()
-        val commands = setupCommands(scope, repo)
+        val commands = setupTestRelationshipCommands(scope, repo)
 
         val personNode = NodeEntity(type = "person", title = "Alice")
         val nodeId = repo.insertNode(personNode)
@@ -116,7 +79,7 @@ class RelationshipCommandsTest {
     fun testCreateReplyNeededForPerson() = runTest {
         val scope = TestScope(testScheduler)
         val repo = buildTestRepository()
-        val commands = setupCommands(scope, repo)
+        val commands = setupTestRelationshipCommands(scope, repo)
 
         val personNode = NodeEntity(id = 1L, type = "person", title = "Bob")
         repo.insertNode(personNode)
@@ -138,7 +101,7 @@ class RelationshipCommandsTest {
     fun testAddPlace() = runTest {
         val scope = TestScope(testScheduler)
         val repo = buildTestRepository()
-        val commands = setupCommands(scope, repo)
+        val commands = setupTestRelationshipCommands(scope, repo)
 
         commands.addPlace("Coffee Shop", campus = false, home = false)
         testScheduler.advanceUntilIdle()
@@ -154,7 +117,7 @@ class RelationshipCommandsTest {
     fun testCreateLeaveHomeChecklist() = runTest {
         val scope = TestScope(testScheduler)
         val repo = buildTestRepository()
-        val commands = setupCommands(scope, repo)
+        val commands = setupTestRelationshipCommands(scope, repo)
 
         commands.createLeaveHomeChecklist()
         testScheduler.advanceUntilIdle()
@@ -168,7 +131,7 @@ class RelationshipCommandsTest {
     fun testAddVaultEntry() = runTest {
         val scope = TestScope(testScheduler)
         val repo = buildTestRepository()
-        val commands = setupCommands(scope, repo)
+        val commands = setupTestRelationshipCommands(scope, repo)
 
         commands.addVaultEntry("receipt", "Laptop receipt", asType = "note")
         testScheduler.advanceUntilIdle()
@@ -180,4 +143,45 @@ class RelationshipCommandsTest {
         assertEquals("reference", vaultNodes.first().node.noteType)
     }
 
+}
+
+
+
+internal fun setupTestRelationshipCommands(
+    scope: TestScope,
+    repo: AppRepository,
+    currentTemplates: List<TemplateEntity> = emptyList()
+): RelationshipCommands {
+    return RelationshipCommands(
+        repository = repo,
+        scope = scope,
+        currentTemplates = { currentTemplates },
+        addNodeForResult = { title, content, type, projectId, areaId, inboxState ->
+            val node = NodeEntity(
+                type = type,
+                title = title,
+                content = content,
+                projectId = projectId,
+                areaId = areaId,
+                inboxState = inboxState ?: false
+            )
+            repo.insertNode(node)
+        },
+        addRelation = { from, to, type ->
+            scope.launch {
+                repo.insertRelation(RelationEntity(fromNodeId = from, toNodeId = to, relationType = type))
+            }
+        },
+        updateNode = { node ->
+            scope.launch {
+                repo.updateNode(node)
+            }
+        },
+        setTagOnNode = { nodeId, tagName, _ ->
+            scope.launch {
+                val tagId = repo.insertTag(TagEntity(name = tagName, normalizedName = tagName.lowercase()))
+                repo.attachTagToNode(nodeId, tagId)
+            }
+        }
+    )
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
@@ -1,0 +1,203 @@
+package com.tajemniktv.tajsos.ui.main.actions
+
+import com.tajemniktv.tajsos.data.AppRepository
+import com.tajemniktv.tajsos.data.FakeAttachmentDao
+import com.tajemniktv.tajsos.data.FakeCalendarEventDao
+import com.tajemniktv.tajsos.data.FakeCalendarProviderDao
+import com.tajemniktv.tajsos.data.FakeDecisionDao
+import com.tajemniktv.tajsos.data.FakeEventLogDao
+import com.tajemniktv.tajsos.data.FakeFocusSessionDao
+import com.tajemniktv.tajsos.data.FakeMedicationDao
+import com.tajemniktv.tajsos.data.FakeModeDao
+import com.tajemniktv.tajsos.data.FakeNodeDao
+import com.tajemniktv.tajsos.data.FakeNodeSnapshotDao
+import com.tajemniktv.tajsos.data.FakeProtocolDao
+import com.tajemniktv.tajsos.data.FakeRelationDao
+import com.tajemniktv.tajsos.data.FakeReviewDao
+import com.tajemniktv.tajsos.data.FakeTagDao
+import com.tajemniktv.tajsos.data.FakeTemplateDao
+import com.tajemniktv.tajsos.data.FakeTrackDao
+import com.tajemniktv.tajsos.data.FakeUserDao
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeTagEntity
+import com.tajemniktv.tajsos.data.RelationEntity
+import com.tajemniktv.tajsos.data.TagEntity
+import com.tajemniktv.tajsos.data.TemplateEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RelationshipCommandsTest {
+
+    private fun buildRepository(): AppRepository {
+        return AppRepository(
+            nodeDao = FakeNodeDao(),
+            nodeSnapshotDao = FakeNodeSnapshotDao(),
+            tagDao = FakeTagDao(),
+            relationDao = FakeRelationDao(),
+            attachmentDao = FakeAttachmentDao(),
+            trackDao = FakeTrackDao(),
+            eventLogDao = FakeEventLogDao(),
+            templateDao = FakeTemplateDao(),
+            modeDao = FakeModeDao(),
+            userDao = FakeUserDao(),
+            reviewDao = FakeReviewDao(),
+            calendarProviderDao = FakeCalendarProviderDao(),
+            calendarEventDao = FakeCalendarEventDao(),
+            decisionDao = FakeDecisionDao(),
+            protocolDao = FakeProtocolDao(),
+            medicationDao = FakeMedicationDao(),
+            focusSessionDao = FakeFocusSessionDao(),
+        )
+    }
+
+    private fun setupCommands(
+        scope: TestScope,
+        repo: AppRepository,
+        currentTemplates: List<TemplateEntity> = emptyList()
+    ): RelationshipCommands {
+        return RelationshipCommands(
+            repository = repo,
+            scope = scope,
+            currentTemplates = { currentTemplates },
+            addNodeForResult = { title, content, type, projectId, areaId, inboxState ->
+                val node = NodeEntity(
+                    type = type,
+                    title = title,
+                    content = content,
+                    projectId = projectId,
+                    areaId = areaId,
+                    inboxState = inboxState ?: false
+                )
+                repo.insertNode(node)
+            },
+            addRelation = { from, to, type ->
+                scope.launch {
+                    repo.insertRelation(RelationEntity(fromNodeId = from, toNodeId = to, relationType = type))
+                }
+            },
+            updateNode = { node ->
+                scope.launch {
+                    repo.updateNode(node)
+                }
+            },
+            setTagOnNode = { nodeId, tagName, _ ->
+                scope.launch {
+                    val tagId = repo.insertTag(TagEntity(name = tagName, normalizedName = tagName.lowercase()))
+                    repo.attachTagToNode(nodeId = nodeId, tagId = tagId)
+                }
+            }
+        )
+    }
+
+    @Test
+    fun testSetPersonLastContactNow() = runTest {
+        val scope = TestScope(testScheduler)
+        val repo = buildRepository()
+        val commands = setupCommands(scope, repo)
+
+        val personNode = NodeEntity(type = "person", title = "Alice")
+        val nodeId = repo.insertNode(personNode)
+        val initialNode = repo.getNodeById(nodeId)!!
+
+        commands.setPersonLastContactNow(initialNode)
+        testScheduler.advanceUntilIdle()
+
+        val updatedNode = repo.getNodeById(nodeId)!!
+        assertNotNull(updatedNode.lastContactAt)
+    }
+
+    @Test
+    fun testSetPersonFollowUpInDays() = runTest {
+        val scope = TestScope(testScheduler)
+        val repo = buildRepository()
+        val commands = setupCommands(scope, repo)
+
+        val personNode = NodeEntity(type = "person", title = "Alice")
+        val nodeId = repo.insertNode(personNode)
+        val initialNode = repo.getNodeById(nodeId)!!
+
+        commands.setPersonFollowUpInDays(initialNode, 7)
+        testScheduler.advanceUntilIdle()
+
+        val updatedNode = repo.getNodeById(nodeId)!!
+        assertNotNull(updatedNode.dueAt)
+    }
+
+    @Test
+    fun testCreateReplyNeededForPerson() = runTest {
+        val scope = TestScope(testScheduler)
+        val repo = buildRepository()
+        val commands = setupCommands(scope, repo)
+
+        val personNode = NodeEntity(id = 1L, type = "person", title = "Bob")
+        repo.insertNode(personNode)
+
+        commands.createReplyNeededForPerson(1L, "Bob")
+        testScheduler.advanceUntilIdle()
+
+        val nodes = repo.getAllNodes().first()
+        val replyNodes = nodes.filter { it.node.type == "open_loop" && it.node.title.contains("Bob") }
+        assertEquals(1, replyNodes.size, "Should create exactly 1 reply needed node")
+
+        val relations = repo.getAllRelations().first()
+        val relation = relations.firstOrNull { it.fromNodeId == 1L && it.relationType == "RELATED_PERSON" }
+        assertNotNull(relation)
+        assertEquals(replyNodes.first().node.id, relation!!.toNodeId)
+    }
+
+    @Test
+    fun testAddPlace() = runTest {
+        val scope = TestScope(testScheduler)
+        val repo = buildRepository()
+        val commands = setupCommands(scope, repo)
+
+        commands.addPlace("Coffee Shop", campus = false, home = false)
+        testScheduler.advanceUntilIdle()
+
+        val nodes = repo.getAllNodes().first()
+        val placeNodes = nodes.filter { it.node.type == "place" }
+        assertEquals(1, placeNodes.size)
+        assertEquals("Coffee Shop", placeNodes.first().node.title)
+        assertEquals("out_of_home", placeNodes.first().node.locationContext)
+    }
+
+    @Test
+    fun testCreateLeaveHomeChecklist() = runTest {
+        val scope = TestScope(testScheduler)
+        val repo = buildRepository()
+        val commands = setupCommands(scope, repo)
+
+        commands.createLeaveHomeChecklist()
+        testScheduler.advanceUntilIdle()
+
+        val nodes = repo.getAllNodes().first()
+        val checkListNodes = nodes.filter { it.node.type == "protocol" && it.node.noteType == "logistics" }
+        assertEquals(1, checkListNodes.size)
+    }
+
+    @Test
+    fun testAddVaultEntry() = runTest {
+        val scope = TestScope(testScheduler)
+        val repo = buildRepository()
+        val commands = setupCommands(scope, repo)
+
+        commands.addVaultEntry("receipt", "Laptop receipt", asType = "note")
+        testScheduler.advanceUntilIdle()
+
+        val nodes = repo.getAllNodes().first()
+        val vaultNodes = nodes.filter { it.node.title == "Laptop receipt" }
+        assertEquals(1, vaultNodes.size)
+        assertEquals("note", vaultNodes.first().node.type)
+        assertEquals("reference", vaultNodes.first().node.noteType)
+    }
+
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/StudentCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/StudentCommandsTest.kt
@@ -38,31 +38,11 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class StudentCommandsTest {
 
-    private fun buildRepository(): AppRepository {
-        return AppRepository(
-            nodeDao = FakeNodeDao(),
-            nodeSnapshotDao = FakeNodeSnapshotDao(),
-            tagDao = FakeTagDao(),
-            relationDao = FakeRelationDao(),
-            attachmentDao = FakeAttachmentDao(),
-            trackDao = FakeTrackDao(),
-            eventLogDao = FakeEventLogDao(),
-            templateDao = FakeTemplateDao(),
-            modeDao = FakeModeDao(),
-            userDao = FakeUserDao(),
-            reviewDao = FakeReviewDao(),
-            calendarProviderDao = FakeCalendarProviderDao(),
-            calendarEventDao = FakeCalendarEventDao(),
-            decisionDao = FakeDecisionDao(),
-            protocolDao = FakeProtocolDao(),
-            medicationDao = FakeMedicationDao(),
-            focusSessionDao = FakeFocusSessionDao(),
-        )
-    }
+
 
     @Test
     fun testSetReadingProgress_clampsValues() = runTest {
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val scope = TestScope(testScheduler)
 
         val node = NodeEntity(id = 1, type = "reading", title = "Book")
@@ -104,7 +84,7 @@ class StudentCommandsTest {
 
     @Test
     fun testSetTopicMastery_clampsValuesAndSetsTopic() = runTest {
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val scope = TestScope(testScheduler)
 
         val node = NodeEntity(id = 1, type = "topic", title = "Math")
@@ -141,7 +121,7 @@ class StudentCommandsTest {
 
     @Test
     fun testSetStudentCourse() = runTest {
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val scope = TestScope(testScheduler)
 
         val node = NodeEntity(id = 1, type = "assignment", title = "Homework")
@@ -175,7 +155,7 @@ class StudentCommandsTest {
 
     @Test
     fun testToggleFlashcardCandidate() = runTest {
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val scope = TestScope(testScheduler)
 
         val node = NodeEntity(id = 1, type = "note", title = "Biology Note")
@@ -217,7 +197,7 @@ class StudentCommandsTest {
 
     @Test
     fun testToggleRevisitBeforeExam() = runTest {
-        val repo = buildRepository()
+        val repo = buildTestRepository()
         val scope = TestScope(testScheduler)
 
         val node = NodeEntity(id = 1, type = "note", title = "History Note")

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/TestAppRepositoryFactory.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/TestAppRepositoryFactory.kt
@@ -1,0 +1,42 @@
+package com.tajemniktv.tajsos.ui.main.actions
+
+import com.tajemniktv.tajsos.data.AppRepository
+import com.tajemniktv.tajsos.data.FakeAttachmentDao
+import com.tajemniktv.tajsos.data.FakeCalendarEventDao
+import com.tajemniktv.tajsos.data.FakeCalendarProviderDao
+import com.tajemniktv.tajsos.data.FakeDecisionDao
+import com.tajemniktv.tajsos.data.FakeEventLogDao
+import com.tajemniktv.tajsos.data.FakeFocusSessionDao
+import com.tajemniktv.tajsos.data.FakeMedicationDao
+import com.tajemniktv.tajsos.data.FakeModeDao
+import com.tajemniktv.tajsos.data.FakeNodeDao
+import com.tajemniktv.tajsos.data.FakeNodeSnapshotDao
+import com.tajemniktv.tajsos.data.FakeProtocolDao
+import com.tajemniktv.tajsos.data.FakeRelationDao
+import com.tajemniktv.tajsos.data.FakeReviewDao
+import com.tajemniktv.tajsos.data.FakeTagDao
+import com.tajemniktv.tajsos.data.FakeTemplateDao
+import com.tajemniktv.tajsos.data.FakeTrackDao
+import com.tajemniktv.tajsos.data.FakeUserDao
+
+internal fun buildTestRepository(): AppRepository {
+    return AppRepository(
+        nodeDao = FakeNodeDao(),
+        nodeSnapshotDao = FakeNodeSnapshotDao(),
+        tagDao = FakeTagDao(),
+        relationDao = FakeRelationDao(),
+        attachmentDao = FakeAttachmentDao(),
+        trackDao = FakeTrackDao(),
+        eventLogDao = FakeEventLogDao(),
+        templateDao = FakeTemplateDao(),
+        modeDao = FakeModeDao(),
+        userDao = FakeUserDao(),
+        reviewDao = FakeReviewDao(),
+        calendarProviderDao = FakeCalendarProviderDao(),
+        calendarEventDao = FakeCalendarEventDao(),
+        decisionDao = FakeDecisionDao(),
+        protocolDao = FakeProtocolDao(),
+        medicationDao = FakeMedicationDao(),
+        focusSessionDao = FakeFocusSessionDao(),
+    )
+}


### PR DESCRIPTION
Adds unit tests for RelationshipCommands testing different interactions like adding persons, places, and check lists to close the test coverage gap.

---
*PR created automatically by Jules for task [10494531679688824889](https://jules.google.com/task/10494531679688824889) started by @tajemniktv*