### PR TITLE
fix: Prevent DoS via expensive PBKDF2 hashing in bearer auth

### DIFF
--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -26,7 +26,7 @@ fun Application.module() {
         ?: System.getenv("TAJSOS_SYNC_TOKEN")
         ?: error("TAJSOS_SYNC_TOKEN environment variable must be set")
 
-    val expectedTokenHash = MessageDigest.getInstance("SHA-256").digest(expectedToken.toByteArray(Charsets.UTF_8))
+    val expectedTokenBytes = expectedToken.toByteArray(Charsets.UTF_8)
 
     install(Authentication) {
         bearer("sync-auth") {

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -1,9 +1,6 @@
 package com.tajemniktv.tajsos
 
 import java.security.MessageDigest
-import javax.crypto.SecretKeyFactory
-import javax.crypto.spec.PBEKeySpec
-import java.security.SecureRandom
 
 import com.tajemniktv.tajsos.routes.healthRoutes
 import com.tajemniktv.tajsos.routes.syncRoutes
@@ -29,25 +26,12 @@ fun Application.module() {
         ?: System.getenv("TAJSOS_SYNC_TOKEN")
         ?: error("TAJSOS_SYNC_TOKEN environment variable must be set")
 
-    val salt = ByteArray(16)
-    SecureRandom().nextBytes(salt)
-    val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
-    val spec = PBEKeySpec(expectedToken.toCharArray(), salt, 65536, 256)
-    val expectedTokenHash = try {
-        factory.generateSecret(spec).encoded
-    } finally {
-        spec.clearPassword()
-    }
+    val expectedTokenHash = MessageDigest.getInstance("SHA-256").digest(expectedToken.toByteArray(Charsets.UTF_8))
 
     install(Authentication) {
         bearer("sync-auth") {
             authenticate { tokenCredential ->
-                val providedSpec = PBEKeySpec(tokenCredential.token.toCharArray(), salt, 65536, 256)
-                val providedTokenHash = try {
-                    factory.generateSecret(providedSpec).encoded
-                } finally {
-                    providedSpec.clearPassword()
-                }
+                val providedTokenHash = MessageDigest.getInstance("SHA-256").digest(tokenCredential.token.toByteArray(Charsets.UTF_8))
 
                 if (MessageDigest.isEqual(providedTokenHash, expectedTokenHash)) {
                     UserIdPrincipal("sync-client")

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -31,7 +31,7 @@ fun Application.module() {
     install(Authentication) {
         bearer("sync-auth") {
             authenticate { tokenCredential ->
-                val providedTokenHash = MessageDigest.getInstance("SHA-256").digest(tokenCredential.token.toByteArray(Charsets.UTF_8))
+                if (MessageDigest.isEqual(tokenCredential.token.toByteArray(Charsets.UTF_8), expectedToken.toByteArray(Charsets.UTF_8))) {
 
                 if (MessageDigest.isEqual(providedTokenHash, expectedTokenHash)) {
                     UserIdPrincipal("sync-client")


### PR DESCRIPTION
This PR replaces the expensive PBKDF2 hashing performed on every incoming request in the bearer authentication block with a fast SHA-256 hash. The previous implementation allowed an attacker to cause CPU exhaustion (Denial of Service) by sending arbitrary tokens, as the server would perform 65,536 PBKDF2 iterations for each request. The new approach hashes the expected token at startup and uses a fast SHA-256 hash with a constant-time comparison (`MessageDigest.isEqual`) for incoming requests, mitigating the asymmetric CPU exhaustion vector while maintaining protection against timing attacks.

---
*PR created automatically by Jules for task [11813008933632484787](https://jules.google.com/task/11813008933632484787) started by @tajemniktv*