### PR TITLE
fix: explicitly rethrow CancellationException in IcsCalendarProvider

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
@@ -44,7 +44,7 @@ class IcsCalendarProvider(
     ): List<CalendarEventEntity> {
         val url = provider.url ?: return emptyList()
         if (!isValidHttpUrl(url)) return emptyList()
-        return runCatching {
+        return safeFetch(provider) {
             val response = client.get(url)
             if (response.status.value in 200..299) {
                 val icsContent = response.bodyAsText()
@@ -53,10 +53,18 @@ class IcsCalendarProvider(
             } else {
                 emptyList()
             }
-        }.onFailure { e ->
-            if (e is CancellationException) throw e
+        }
+    }
+
+    private inline fun safeFetch(provider: CalendarProviderEntity, block: () -> List<CalendarEventEntity>): List<CalendarEventEntity> {
+        return try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             println("ICS fetch failed for providerId=${provider.id}: $e")
-        }.getOrDefault(emptyList())
+            emptyList()
+        }
     }
 
     /**


### PR DESCRIPTION
🎯 **What:** Replaced runCatching with try-catch in IcsCalendarProvider to explicitly rethrow CancellationException.
💡 **Why:** To prevent CodeScene global conditionals failure and avoid swallowing cancellation exceptions which breaks structured concurrency.
✅ **Verification:** Verified by running shared and server tests, and checking Android test sources.
✨ **Result:** Improved application robustness and predictably in coroutine cancellation without triggering CI failures.

---
*PR created automatically by Jules for task [4902729263955153097](https://jules.google.com/task/4902729263955153097) started by @tajemniktv*