### PR TITLE
test: Add fallback edge case coverage for SavedViewEntity mapping

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -138,14 +138,11 @@ jobs:
         run: |
           ./gradlew \
             -Pandroid.builder.sdkDownload=true \
-            clean \
             :shared:compileKotlinJvm \
             :composeApp:compileKotlinJvm \
             :server:classes \
             :androidApp:assembleDebug \
             --stacktrace \
-            --no-daemon \
-            --no-build-cache
 
       - name: Perform CodeQL Analysis (java-kotlin)
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -138,12 +138,14 @@ jobs:
         run: |
           ./gradlew \
             -Pandroid.builder.sdkDownload=true \
+            clean \
             :shared:compileKotlinJvm \
             :composeApp:compileKotlinJvm \
             :server:classes \
             :androidApp:assembleDebug \
             --stacktrace \
-            --no-daemon
+            --no-daemon \
+            --no-build-cache
 
       - name: Perform CodeQL Analysis (java-kotlin)
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectMappingsFallbackTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectMappingsFallbackTest.kt
@@ -1,0 +1,66 @@
+package com.tajemniktv.tajsos.data
+
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertEquals
+
+class LifeObjectMappingsFallbackTest {
+    @Test
+    fun testSavedViewEntityToDefinition_invalid() {
+        // Contains invalid keys for enum mapping
+        val entity = SavedViewEntity(id = 1, name = "View", description = "Desc", lens = "invalid_lens", layout = "invalid_layout", rowDimension = "invalid_row", columnDimension = "invalid_col", measure = "invalid_measure", createdAt = 1000L, updatedAt = 2000L)
+        val sourceKinds = listOf(SavedViewSourceKindEntity(viewId = 1, itemKind = "invalid_kind"))
+        val filters = listOf(SavedViewFilterEntity(viewId = 1, fieldKey = "invalid_field", operatorKey = "invalid_op", value = "val", valueType = "invalid_type", position = 0))
+        val sorts = listOf(SavedViewSortEntity(viewId = 1, fieldKey = "invalid_field", direction = "invalid_dir", position = 0))
+        val visibleFields = listOf(SavedViewVisibleFieldEntity(viewId = 1, fieldKey = "invalid_field", position = 0))
+
+        val definition = entity.toDefinition(sourceKinds, filters, sorts, visibleFields)
+
+        // Defaults to OPERATE
+        assertEquals(SavedViewLens.OPERATE, definition.lens)
+        // Defaults to LIST
+        assertEquals(SavedViewLayout.LIST, definition.layout)
+
+        // Invalid source kind gets filtered out
+        assertEquals(0, definition.sourceKinds.size)
+        // Invalid filter fieldKey gets filtered out
+        assertEquals(0, definition.filters.size)
+        // Invalid sort fieldKey gets filtered out
+        assertEquals(0, definition.sorts.size)
+        // Invalid visible field gets filtered out
+        assertEquals(0, definition.visibleFields.size)
+
+        // Null fallbacks for dimensions
+        assertNull(definition.rowDimension)
+        assertNull(definition.columnDimension)
+        assertNull(definition.measure)
+    }
+
+    @Test
+    fun testSavedViewEntityToDefinition_partiallyInvalidFilterAndSort() {
+        val entity = SavedViewEntity(id = 1, name = "View", description = "Desc", lens = "operate", layout = "list", rowDimension = "kind", columnDimension = "status", measure = "count", createdAt = 1000L, updatedAt = 2000L)
+        val sourceKinds = emptyList<SavedViewSourceKindEntity>()
+
+        val filters = listOf(
+            // Invalid operator but valid fieldKey -> should be filtered out
+            SavedViewFilterEntity(viewId = 1, fieldKey = "status", operatorKey = "invalid_op", value = "val", valueType = "string", position = 0),
+            // Valid operator and fieldKey but invalid valueType -> falls back to STRING
+            SavedViewFilterEntity(viewId = 1, fieldKey = "kind", operatorKey = "equals", value = "val", valueType = "invalid_type", position = 1)
+        )
+
+        val sorts = listOf(
+            // Valid fieldKey but invalid direction -> falls back to ASCENDING
+            SavedViewSortEntity(viewId = 1, fieldKey = "title", direction = "invalid_dir", position = 0)
+        )
+
+        val definition = entity.toDefinition(sourceKinds, filters, sorts, emptyList())
+
+        assertEquals(1, definition.filters.size)
+        assertEquals(SavedViewFieldKey.KIND, definition.filters[0].fieldKey)
+        assertEquals(SavedViewValueType.STRING, definition.filters[0].valueType) // fallback
+
+        assertEquals(1, definition.sorts.size)
+        assertEquals(SavedViewFieldKey.TITLE, definition.sorts[0].fieldKey)
+        assertEquals(SavedViewSortDirection.ASCENDING, definition.sorts[0].direction) // fallback
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectMappingsFallbackTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectMappingsFallbackTest.kt
@@ -8,7 +8,18 @@ class LifeObjectMappingsFallbackTest {
     @Test
     fun testSavedViewEntityToDefinition_invalid() {
         // Contains invalid keys for enum mapping
-        val entity = SavedViewEntity(id = 1, name = "View", description = "Desc", lens = "invalid_lens", layout = "invalid_layout", rowDimension = "invalid_row", columnDimension = "invalid_col", measure = "invalid_measure", createdAt = 1000L, updatedAt = 2000L)
+        val entity = SavedViewEntity(
+            id = 1,
+            name = "View",
+            description = "Desc",
+            lens = "invalid_lens",
+            layout = "invalid_layout",
+            rowDimension = "invalid_row",
+            columnDimension = "invalid_col",
+            measure = "invalid_measure",
+            createdAt = 1000L,
+            updatedAt = 2000L
+        )
         val sourceKinds = listOf(SavedViewSourceKindEntity(viewId = 1, itemKind = "invalid_kind"))
         val filters = listOf(SavedViewFilterEntity(viewId = 1, fieldKey = "invalid_field", operatorKey = "invalid_op", value = "val", valueType = "invalid_type", position = 0))
         val sorts = listOf(SavedViewSortEntity(viewId = 1, fieldKey = "invalid_field", direction = "invalid_dir", position = 0))


### PR DESCRIPTION
Added missing test cases in `LifeObjectMappingsFallbackTest.kt` to cover `SavedViewEntity.toDefinition` fallback logic for missing enum keys.

---
*PR created automatically by Jules for task [11162917816289138774](https://jules.google.com/task/11162917816289138774) started by @tajemniktv*