### PR TITLE
docs: Add KDocs for DomainRegistry and DomainDefinition

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/domain/DomainRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/domain/DomainRegistry.kt
@@ -10,7 +10,7 @@ import com.tajemniktv.tajsos.ui.Screen
 import org.jetbrains.compose.resources.StringResource
 
 /**
- * Defines a built-in domain definition used by navigation and domain modules.
+ * Represents a built-in domain used by navigation and domain modules.
  * This class represents a product-level lens over shared system data,
  * providing the required metadata (route, label, icon) for UI presentation.
  *
@@ -78,7 +78,7 @@ object DomainRegistry {
      * Retrieves the [DomainDefinition] whose base route matches the provided route string.
      * Extracts the base route from the given string by stripping out sub-paths and query parameters.
      *
-     * @param route The full navigation route string.
+     * @param route The full navigation route string, or null.
      * @return The matching [DomainDefinition], or null if the route does not match any domain.
      */
     fun byRoute(route: String?): DomainDefinition? {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/domain/DomainRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/domain/DomainRegistry.kt
@@ -10,7 +10,13 @@ import com.tajemniktv.tajsos.ui.Screen
 import org.jetbrains.compose.resources.StringResource
 
 /**
- * Built-in domain definition used by navigation and domain modules.
+ * Defines a built-in domain definition used by navigation and domain modules.
+ * This class represents a product-level lens over shared system data,
+ * providing the required metadata (route, label, icon) for UI presentation.
+ *
+ * @property kind The [DomainKind] enum value representing the specific domain.
+ * @property screen The [Screen] associated with this domain, determining navigation route and visual presentation.
+ * @property capabilities An optional set of capability strings defining specific features available within this domain.
  */
 data class DomainDefinition(
     val kind: DomainKind,
@@ -24,6 +30,10 @@ data class DomainDefinition(
 
 /**
  * Registry of first-class LifeOS domains.
+ *
+ * Provides lazy initialization and lookup for the predefined [DomainDefinition]s
+ * supported by TajsOS. It is utilized across the application to render domain-specific
+ * navigation options and resolve domains based on routes or [DomainKind].
  */
 object DomainRegistry {
     val definitions: List<DomainDefinition> by lazy {
@@ -51,10 +61,26 @@ object DomainRegistry {
         )
     }
 
+    /**
+     * A lazily initialized list of all [Screen]s associated with the defined domains.
+     */
     val screens: List<Screen> by lazy { definitions.map { it.screen } }
 
+    /**
+     * Retrieves the [DomainDefinition] corresponding to the given [DomainKind].
+     *
+     * @param kind The [DomainKind] to search for.
+     * @return The matching [DomainDefinition], or null if no such domain is defined.
+     */
     fun byKind(kind: DomainKind): DomainDefinition? = definitions.find { it.kind == kind }
 
+    /**
+     * Retrieves the [DomainDefinition] whose base route matches the provided route string.
+     * Extracts the base route from the given string by stripping out sub-paths and query parameters.
+     *
+     * @param route The full navigation route string.
+     * @return The matching [DomainDefinition], or null if the route does not match any domain.
+     */
     fun byRoute(route: String?): DomainDefinition? {
         if (route == null) return null
         val base = route.substringBefore('/').substringBefore('?')


### PR DESCRIPTION
Added missing KDocs to the DomainRegistry and DomainDefinition in the UI module. This documentation reduces onboarding friction by clarifying how the UI resolves and presents the various first-class domains.

---
*PR created automatically by Jules for task [3440602235398362680](https://jules.google.com/task/3440602235398362680) started by @tajemniktv*