### PR TITLE
feat(ui): add tactile scale feedback to ActionButton

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -47,6 +49,7 @@ fun ActionButton(
     contentColor: Color = TajsOSTheme.Text,
     icon: ImageVector? = null,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     val isPrimary = containerColor == TajsOSTheme.Primary
     val isGhost = containerColor == Color.Transparent
     val buttonBorder =
@@ -57,7 +60,7 @@ fun ActionButton(
         }
 
     val finalModifier =
-        modifier.height(48.dp).then(
+        modifier.height(48.dp).tactileScale(interactionSource).then(
             if (isPrimary && enabled) {
                 Modifier.background(
                     brush =
@@ -87,6 +90,7 @@ fun ActionButton(
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         border = buttonBorder,
         contentPadding = PaddingValues(horizontal = 16.dp),
+        interactionSource = interactionSource,
     ) {
         if (icon != null) {
             Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp))

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/TactileComponents.kt
@@ -43,6 +43,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -320,5 +325,22 @@ fun TactileOutlinedTextField(
             shape = shape,
             colors = colors,
         )
+    }
+}
+
+@Composable
+fun Modifier.tactileScale(
+    interactionSource: InteractionSource,
+    minScale: Float = 0.98f,
+): Modifier {
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) minScale else 1f,
+        animationSpec = spring(stiffness = 180f, dampingRatio = 0.8f),
+        label = "tactile_scale_animation"
+    )
+    return this.graphicsLayer {
+        scaleX = scale
+        scaleY = scale
     }
 }


### PR DESCRIPTION
Added tactile scale feedback to `ActionButton` to match `DESIGN.md` specifications.

- Extracted a reusable `tactileScale` extension modifier in `TactileComponents.kt` that observes `interactionSource` and applies the designated spring physics.
- Injected `MutableInteractionSource` into `ActionButton` and wired it into both the `Button` and the scaling modifier.

---
*PR created automatically by Jules for task [5669961274306776762](https://jules.google.com/task/5669961274306776762) started by @tajemniktv*