### PR TITLE
perf: optimize status filter parsing in FilterHelper

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/FilterHelper.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/FilterHelper.kt
@@ -71,7 +71,7 @@ object FilterHelper {
                 .toEpochMilliseconds()
         val dayMs = 24 * 60 * 60 * 1000L
 
-        val allowedStatuses = status?.split(",")?.map { it.trim() }?.toSet()
+        val allowedStatuses = status?.splitToSequence(",")?.map { it.trim() }?.filter { it.isNotEmpty() }?.toSet()
 
         val filtered =
             nodes

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/FilterHelper.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/FilterHelper.kt
@@ -71,6 +71,8 @@ object FilterHelper {
                 .toEpochMilliseconds()
         val dayMs = 24 * 60 * 60 * 1000L
 
+        val allowedStatuses = status?.split(",")?.map { it.trim() }?.toSet()
+
         val filtered =
             nodes
                 .filter { nodeWithPin ->
@@ -81,7 +83,7 @@ object FilterHelper {
 
                     // Allow mode/status filtering logic (comma separated status like "active,on_hold")
                     val matchesStatus =
-                        status == null || status.split(",").map { it.trim() }.contains(node.status)
+                        allowedStatuses == null || allowedStatuses.contains(node.status)
 
                     val matchesProject = projectId == null || node.projectId == projectId
                     val matchesArea = areaId == null || node.areaId == areaId


### PR DESCRIPTION
This pull request optimizes the status filtering in `FilterHelper`. Previously, it performed a `split`, `map`, and `contains` check directly inside the `nodes.filter` block, leading to repeated string allocations and list processing for every single node. The parsing step has now been hoisted out of the filter block and converted into an O(1) set lookup, significantly reducing overhead for large node collections.

---
*PR created automatically by Jules for task [1083704912258150060](https://jules.google.com/task/1083704912258150060) started by @tajemniktv*