### PR TITLE
fix: replace runCatching with explicit try-catch

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -417,9 +417,12 @@ class MainActivity : FragmentActivity() {
                     override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
                         super.onAuthenticationSucceeded(result)
                         val authCipher = result.cryptoObject?.cipher ?: return
-                        runCatching { authCipher.doFinal("auth".toByteArray()) }
-                            .onSuccess { viewModel.setAuthenticated(true) }
-                            .onFailure { Log.e(TAG, "Biometric crypto operation failed: ${it.javaClass.simpleName}") }
+                        try {
+                            authCipher.doFinal("auth".toByteArray())
+                            viewModel.setAuthenticated(true)
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Biometric crypto operation failed: ${e.javaClass.simpleName}")
+                        }
                     }
 
                     override fun onAuthenticationError(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardLayoutEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardLayoutEngine.kt
@@ -445,19 +445,23 @@ private fun normalizeBlocks(
 
 private fun parseLegacyBlockList(raw: String?): List<String> {
     if (raw.isNullOrBlank()) return emptyList()
-    return runCatching {
+    return try {
         dashboardJson.decodeFromString<List<String>>(
             raw,
         )
-    }.getOrElse { emptyList() }
+    } catch (e: Exception) {
+        emptyList()
+    }
 }
 
 private fun parseVersionedLayout(raw: String?): DashboardLayoutJsonV1? {
     if (raw.isNullOrBlank()) return null
-    return runCatching {
+    return try {
         dashboardJson
             .decodeFromString<DashboardLayoutJsonV1>(
                 raw,
             )
-    }.getOrNull()
+    } catch (e: Exception) {
+        null
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardLayoutEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardLayoutEngine.kt
@@ -102,10 +102,12 @@ fun buildFinanceDashboardPlan(
 
 private fun parseStructured(raw: String?): FinanceLayoutJsonV1? {
     if (raw.isNullOrBlank()) return null
-    return runCatching {
+    return try {
         financeLayoutJson
             .decodeFromString<FinanceLayoutJsonV1>(
                 raw,
             )
-    }.getOrNull()
+    } catch (e: Exception) {
+        null
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardLayoutEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardLayoutEngine.kt
@@ -92,5 +92,9 @@ fun buildStudyDashboardPlan(
 
 private fun parseStructured(raw: String?): StudyLayoutJsonV1? {
     if (raw.isNullOrBlank()) return null
-    return runCatching { studyLayoutJson.decodeFromString<StudyLayoutJsonV1>(raw) }.getOrNull()
+    return try {
+        studyLayoutJson.decodeFromString<StudyLayoutJsonV1>(raw)
+    } catch (e: Exception) {
+        null
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
@@ -547,9 +547,11 @@ private fun formatTime(epochMillis: Long): String {
 }
 
 private fun parseAttachmentMetadata(payload: String): Map<String, String> =
-    runCatching {
+    try {
         Json.parseToJsonElement(payload).jsonObject.mapValues { (_, value) -> value.jsonPrimitive.content }
-    }.getOrDefault(emptyMap())
+    } catch (e: Exception) {
+        emptyMap()
+    }
 
 private fun formatBytes(bytes: Long): String {
     if (bytes <= 0) return "0 B"

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
@@ -44,7 +44,7 @@ class IcsCalendarProvider(
     ): List<CalendarEventEntity> {
         val url = provider.url ?: return emptyList()
         if (!isValidHttpUrl(url)) return emptyList()
-        return runCatching {
+        return safeFetch(provider.id) {
             val response = client.get(url)
             if (response.status.value in 200..299) {
                 val icsContent = response.bodyAsText()
@@ -53,10 +53,7 @@ class IcsCalendarProvider(
             } else {
                 emptyList()
             }
-        }.onFailure { e ->
-            if (e is CancellationException) throw e
-            println("ICS fetch failed for providerId=${provider.id}: $e")
-        }.getOrDefault(emptyList())
+        } ?: emptyList()
     }
 
     /**
@@ -356,3 +353,13 @@ internal class IcsEventBuilder {
         }
     }
 }
+
+private inline fun <T> safeFetch(providerId: Long, block: () -> T): T? =
+    try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        println("ICS fetch failed for providerId=$providerId: $e")
+        null
+    }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
@@ -145,6 +145,9 @@ fun buildModeQueryProfile(
  */
 private fun decodeStringList(raw: String?): List<String> {
     if (raw.isNullOrBlank()) return emptyList()
-    return runCatching { modeProfileJson.decodeFromString<List<String>>(raw) }
-        .getOrElse { emptyList() }
+    return try {
+        modeProfileJson.decodeFromString<List<String>>(raw)
+    } catch (e: Exception) {
+        emptyList()
+    }
 }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
@@ -103,9 +103,11 @@ data class AreaMetadata(
  */
 fun NodeEntity.metadataEnvelopeOrNull(): NodeMetadataEnvelope? =
     metadataJson?.takeIf { it.isNotBlank() }?.let {
-        runCatching {
+        try {
             nodeMetadataJson.decodeFromString<NodeMetadataEnvelope>(it)
-        }.getOrNull()
+        } catch (e: Exception) {
+            null
+        }
     }
 
 /**


### PR DESCRIPTION
This pull request replaces generic `runCatching` blocks with specific `try-catch` structures across the codebase. `runCatching` catches all `Throwable`s, including critical JVM errors like `OutOfMemoryError`, which can hide fatal issues and leave the application in an unpredictable state. By explicitly targeting `Exception`, typical operational failures are handled gracefully while allowing fatal errors to crash the app cleanly as expected.

---
*PR created automatically by Jules for task [1101981553990321785](https://jules.google.com/task/1101981553990321785) started by @tajemniktv*