### PR TITLE
feat(ui): Add tactile feedback scale to 0.98 for ActionButton

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -4,6 +4,12 @@
 
 package com.tajemniktv.tajsos.ui.components
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -47,6 +53,9 @@ fun ActionButton(
     contentColor: Color = TajsOSTheme.Text,
     icon: ImageVector? = null,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(targetValue = if (isPressed) 0.98f else 1f, label = "buttonScale")
     val isPrimary = containerColor == TajsOSTheme.Primary
     val isGhost = containerColor == Color.Transparent
     val buttonBorder =
@@ -57,7 +66,12 @@ fun ActionButton(
         }
 
     val finalModifier =
-        modifier.height(48.dp).then(
+        modifier
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+            .height(48.dp).then(
             if (isPrimary && enabled) {
                 Modifier.background(
                     brush =
@@ -77,6 +91,7 @@ fun ActionButton(
         onClick = onClick,
         enabled = enabled,
         modifier = finalModifier,
+        interactionSource = interactionSource,
         colors =
             ButtonDefaults.buttonColors(
                 containerColor = if (isPrimary && enabled) Color.Transparent else containerColor,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -32,6 +33,43 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+
+@Composable
+private fun resolveButtonColors(
+    isPrimary: Boolean,
+    isGhost: Boolean,
+    enabled: Boolean,
+    containerColor: Color,
+    contentColor: Color,
+): ButtonColors = ButtonDefaults.buttonColors(
+    containerColor = if (isPrimary && enabled) Color.Transparent else containerColor,
+    contentColor = if (isPrimary && contentColor == TajsOSTheme.Text) TajsOSTheme.Background else contentColor,
+    disabledContainerColor = if (isGhost) Color.Transparent else TajsOSTheme.SurfaceHighest,
+    disabledContentColor = TajsOSTheme.Muted,
+)
+
+@Composable
+private fun resolveButtonBorder(isPrimary: Boolean, isGhost: Boolean) =
+    if (!isPrimary && !isGhost) {
+        androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.GhostBorder)
+    } else {
+        null
+    }
+
+@Composable
+private fun resolvePrimaryBackgroundModifier(isPrimary: Boolean, enabled: Boolean): Modifier =
+    if (isPrimary && enabled) {
+        Modifier.background(
+            brush = Brush.linearGradient(
+                colors = listOf(TajsOSTheme.Primary, TajsOSTheme.PrimaryDim),
+                start = Offset(0f, 0f),
+                end = Offset.Infinite,
+            ),
+            shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        )
+    } else {
+        Modifier
+    }
 
 /**
  * Renders a Material3 button with a fixed height, rounded corners, an optional leading icon, and an uppercase bold label.
@@ -56,14 +94,11 @@ fun ActionButton(
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val scale by animateFloatAsState(targetValue = if (isPressed) 0.98f else 1f, label = "buttonScale")
+
     val isPrimary = containerColor == TajsOSTheme.Primary
     val isGhost = containerColor == Color.Transparent
-    val buttonBorder =
-        if (!isPrimary && !isGhost) {
-            androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.GhostBorder)
-        } else {
-            null
-        }
+
+    val buttonBorder = resolveButtonBorder(isPrimary, isGhost)
 
     val finalModifier =
         modifier
@@ -71,34 +106,15 @@ fun ActionButton(
                 scaleX = scale
                 scaleY = scale
             }
-            .height(48.dp).then(
-            if (isPrimary && enabled) {
-                Modifier.background(
-                    brush =
-                        Brush.linearGradient(
-                            colors = listOf(TajsOSTheme.Primary, TajsOSTheme.PrimaryDim),
-                            start = Offset(0f, 0f),
-                            end = Offset.Infinite,
-                        ),
-                    shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                )
-            } else {
-                Modifier
-            },
-        )
+            .height(48.dp)
+            .then(resolvePrimaryBackgroundModifier(isPrimary, enabled))
 
     Button(
         onClick = onClick,
         enabled = enabled,
         modifier = finalModifier,
         interactionSource = interactionSource,
-        colors =
-            ButtonDefaults.buttonColors(
-                containerColor = if (isPrimary && enabled) Color.Transparent else containerColor,
-                contentColor = if (isPrimary && contentColor == TajsOSTheme.Text) TajsOSTheme.Background else contentColor,
-                disabledContainerColor = if (isGhost) Color.Transparent else TajsOSTheme.SurfaceHighest,
-                disabledContentColor = TajsOSTheme.Muted,
-            ),
+        colors = resolveButtonColors(isPrimary, isGhost, enabled, containerColor, contentColor),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         border = buttonBorder,
         contentPadding = PaddingValues(horizontal = 16.dp),

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,75 @@
+1. **Analyze Failure**:
+The CodeScene check failed because `ActionButton` function became a "Complex Method".
+Memory says: "To resolve CodeScene 'Complex Method' code health violations in Jetpack Compose UI components, extract nested conditional logic (e.g., resolving colors, borders, or backgrounds) into private `@Composable` helper functions."
+
+2. **Fix**:
+We can extract the logic for `buttonBorder`, `containerColor`, `contentColor` and the background gradient modifier into helper properties or functions. Or extract the `ButtonDefaults.buttonColors(...)` call into a `@Composable` helper function.
+
+Let's extract:
+```kotlin
+@Composable
+private fun resolveButtonColors(isPrimary: Boolean, isGhost: Boolean, enabled: Boolean, containerColor: Color, contentColor: Color) = ButtonDefaults.buttonColors(
+    containerColor = if (isPrimary && enabled) Color.Transparent else containerColor,
+    contentColor = if (isPrimary && contentColor == TajsOSTheme.Text) TajsOSTheme.Background else contentColor,
+    disabledContainerColor = if (isGhost) Color.Transparent else TajsOSTheme.SurfaceHighest,
+    disabledContentColor = TajsOSTheme.Muted,
+)
+
+@Composable
+private fun resolveButtonBorder(isPrimary: Boolean, isGhost: Boolean) = if (!isPrimary && !isGhost) {
+    androidx.compose.foundation.BorderStroke(1.dp, TajsOSTheme.GhostBorder)
+} else {
+    null
+}
+```
+Wait, we can just extract `resolveButtonColors` and `resolveButtonBorder` private helper functions outside `ActionButton`. And `resolvePrimaryBackgroundModifier`:
+
+```kotlin
+@Composable
+private fun resolvePrimaryBackgroundModifier(isPrimary: Boolean, enabled: Boolean): Modifier = if (isPrimary && enabled) {
+    Modifier.background(
+        brush = Brush.linearGradient(
+            colors = listOf(TajsOSTheme.Primary, TajsOSTheme.PrimaryDim),
+            start = Offset(0f, 0f),
+            end = Offset.Infinite,
+        ),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+    )
+} else {
+    Modifier
+}
+```
+
+Then `ActionButton` will be much simpler:
+```kotlin
+@Composable
+fun ActionButton( ... ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(targetValue = if (isPressed) 0.98f else 1f, label = "buttonScale")
+    val isPrimary = containerColor == TajsOSTheme.Primary
+    val isGhost = containerColor == Color.Transparent
+    val buttonBorder = resolveButtonBorder(isPrimary, isGhost)
+
+    val finalModifier = modifier
+        .graphicsLayer {
+            scaleX = scale
+            scaleY = scale
+        }
+        .height(48.dp)
+        .then(resolvePrimaryBackgroundModifier(isPrimary, enabled))
+
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = finalModifier,
+        interactionSource = interactionSource,
+        colors = resolveButtonColors(isPrimary, isGhost, enabled, containerColor, contentColor),
+        shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+        border = buttonBorder,
+        contentPadding = PaddingValues(horizontal = 16.dp),
+    ) {
+        ...
+    }
+}
+```


### PR DESCRIPTION
Implements the rule from DESIGN.md requiring tactile scale down to 0.98 on press for Button components. Focuses specifically on the custom `ActionButton`.

---
*PR created automatically by Jules for task [11833103564040025142](https://jules.google.com/task/11833103564040025142) started by @tajemniktv*