### PR TITLE
docs: add KDocs to key MainViewModel state functions

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -1062,7 +1062,7 @@ class MainViewModel(
     }
 
     /**
-     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
+     * Delegates to [ProtocolCommands] to launch a guided sequential workflow or checklist.
      *
      * @param protocolLabel The normalized identifier for the requested protocol.
      * @param source The origin surface triggering the protocol (e.g., "dashboard").
@@ -1460,7 +1460,7 @@ class MainViewModel(
 
     /**
      * Triages a raw open loop into a structured, actionable task.
-     * Applies default task metadata (e.g., active status) via [nodeCommands].
+     * Applies default task metadata (e.g., active status) via [NodeCommands].
      *
      * @param nodeId The unique identifier of the open loop node to convert.
      */
@@ -1470,7 +1470,7 @@ class MainViewModel(
 
     /**
      * Triages a raw open loop into a structured decision matrix.
-     * Updates the node type and initializes decision metadata via [nodeCommands].
+     * Updates the node type and initializes decision metadata via [NodeCommands].
      *
      * @param nodeId The unique identifier of the open loop node to convert.
      */
@@ -1480,7 +1480,7 @@ class MainViewModel(
 
     /**
      * Triages a raw open loop into a persistent knowledge note.
-     * Updates the node type and strips transient triage metadata via [nodeCommands].
+     * Updates the node type and strips transient triage metadata via [NodeCommands].
      *
      * @param nodeId The unique identifier of the open loop node to convert.
      */
@@ -1779,7 +1779,7 @@ class MainViewModel(
     }
 
     /**
-     * Executes end-of-month system maintenance scripts via [nodeCommands].
+     * Executes end-of-month system maintenance scripts via [NodeCommands].
      * This typically archives stale items, resets repeating structures, and generates monthly reflections.
      */
     fun runMonthlyReset() {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -415,6 +415,78 @@ class MainViewModel(
         syncCalendars()
     }
 
+    /**
+
+     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
+
+     * Updates the active mode preference in the underlying repository.
+
+     *
+
+     * @param modeId The unique identifier of the target mode.
+
+     */
+
+    /**
+
+     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
+
+     * Updates the active mode preference in the underlying repository.
+
+     *
+
+     * @param modeId The unique identifier of the target mode.
+
+     */
+
+    /**
+
+     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
+
+     * Updates the active mode preference in the underlying repository.
+
+     *
+
+     * @param modeId The unique identifier of the target mode.
+
+     */
+
+    /**
+
+     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
+
+     * Updates the active mode preference in the underlying repository.
+
+     *
+
+     * @param modeId The unique identifier of the target mode.
+
+     */
+
+    /**
+     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
+     * Updates the active mode preference in the underlying repository.
+     *
+     * @param modeId The unique identifier of the target mode.
+     */
+    /**
+     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
+     * Updates the active mode preference in the underlying repository.
+     *
+     * @param modeId The unique identifier of the target mode.
+     */
+    /**
+     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
+     * Updates the active mode preference in the underlying repository.
+     *
+     * @param modeId The unique identifier of the target mode.
+     */
+    /**
+     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
+     * Updates the active mode preference in the underlying repository.
+     *
+     * @param modeId The unique identifier of the target mode.
+     */
     fun switchMode(modeId: Long) {
         viewModelScope.launch {
             val mode = allModesRaw.value.find { it.id == modeId } ?: return@launch
@@ -1055,6 +1127,72 @@ class MainViewModel(
         }
     }
 
+    /**
+
+     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
+
+     *
+
+     * @param protocolLabel The normalized identifier for the requested protocol.
+
+     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
+
+     */
+
+    /**
+
+     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
+
+     *
+
+     * @param protocolLabel The normalized identifier for the requested protocol.
+
+     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
+
+     */
+
+    /**
+
+     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
+
+     *
+
+     * @param protocolLabel The normalized identifier for the requested protocol.
+
+     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
+
+     */
+
+    /**
+
+     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
+
+     *
+
+     * @param protocolLabel The normalized identifier for the requested protocol.
+
+     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
+
+     */
+
+    /**
+     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
+     *
+     * @param protocolLabel The normalized identifier for the requested protocol.
+     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
+     */
+    /**
+     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
+     *
+     * @param protocolLabel The normalized identifier for the requested protocol.
+     * @param source The origin surface triggering the protocol (e.g., "dashboard").
+     */
+    /**
+     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
+     *
+     * @param protocolLabel The normalized identifier for the requested protocol.
+     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
+     */
     fun triggerProtocol(
         protocolLabel: String,
         source: String = "dashboard", // NON-NLS
@@ -1446,18 +1584,293 @@ class MainViewModel(
         nodeCommands.updateOpenLoopType(node, openLoopType)
     }
 
+    /**
+
+     * Triages a raw open loop into a structured, actionable task.
+
+     * Applies default task metadata (e.g., active status) via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+
+     * Triages a raw open loop into a structured, actionable task.
+
+     * Applies default task metadata (e.g., active status) via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+
+     * Triages a raw open loop into a structured, actionable task.
+
+     * Applies default task metadata (e.g., active status) via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+
+     * Triages a raw open loop into a structured, actionable task.
+
+     * Applies default task metadata (e.g., active status) via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+     * Triages a raw open loop into a structured, actionable task.
+     * Applies default task metadata (e.g., active status) via [nodeCommands].
+     *
+     * @param nodeId The unique identifier of the open loop node to convert.
+     */
+    /**
+     * Triages a raw open loop into a structured, actionable task.
+     * Applies default task metadata (e.g., active status) via [nodeCommands].
+     *
+     * @param nodeId The unique identifier of the open loop node to convert.
+     */
+    /**
+     * Triages a raw open loop into a structured, actionable task.
+     * Applies default task metadata (e.g., active status) via [nodeCommands].
+     *
+     * @param nodeId The unique identifier of the open loop node to convert.
+     */
     fun convertOpenLoopToTask(nodeId: Long) {
         nodeCommands.convertOpenLoopToTask(nodeId)
     }
 
+    /**
+
+     * Triages a raw open loop into a structured decision matrix.
+
+     * Updates the node type and initializes decision metadata via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+
+     * Triages a raw open loop into a structured decision matrix.
+
+     * Updates the node type and initializes decision metadata via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+
+     * Triages a raw open loop into a structured decision matrix.
+
+     * Updates the node type and initializes decision metadata via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+
+     * Triages a raw open loop into a structured decision matrix.
+
+     * Updates the node type and initializes decision metadata via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+     * Triages a raw open loop into a structured decision matrix.
+     * Updates the node type and initializes decision metadata via [nodeCommands].
+     *
+     * @param nodeId The unique identifier of the open loop node to convert.
+     */
+    /**
+     * Triages a raw open loop into a structured decision matrix.
+     * Updates the node type and initializes decision metadata via [nodeCommands].
+     *
+     * @param nodeId The unique identifier of the open loop node to convert.
+     */
+    /**
+     * Triages a raw open loop into a structured decision matrix.
+     * Updates the node type and initializes decision metadata via [nodeCommands].
+     *
+     * @param nodeId The unique identifier of the open loop node to convert.
+     */
     fun convertOpenLoopToDecision(nodeId: Long) {
         nodeCommands.convertOpenLoopToDecision(nodeId)
     }
 
+    /**
+
+     * Triages a raw open loop into a persistent knowledge note.
+
+     * Updates the node type and strips transient triage metadata via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+
+     * Triages a raw open loop into a persistent knowledge note.
+
+     * Updates the node type and strips transient triage metadata via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+
+     * Triages a raw open loop into a persistent knowledge note.
+
+     * Updates the node type and strips transient triage metadata via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+
+     * Triages a raw open loop into a persistent knowledge note.
+
+     * Updates the node type and strips transient triage metadata via [nodeCommands].
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node to convert.
+
+     */
+
+    /**
+     * Triages a raw open loop into a persistent knowledge note.
+     * Updates the node type and strips transient triage metadata via [nodeCommands].
+     *
+     * @param nodeId The unique identifier of the open loop node to convert.
+     */
+    /**
+     * Triages a raw open loop into a persistent knowledge note.
+     * Updates the node type and strips transient triage metadata via [nodeCommands].
+     *
+     * @param nodeId The unique identifier of the open loop node to convert.
+     */
+    /**
+     * Triages a raw open loop into a persistent knowledge note.
+     * Updates the node type and strips transient triage metadata via [nodeCommands].
+     *
+     * @param nodeId The unique identifier of the open loop node to convert.
+     */
     fun convertOpenLoopToNote(nodeId: Long) {
         nodeCommands.convertOpenLoopToNote(nodeId)
     }
 
+    /**
+
+     * Closes an unprocessed captured item, optionally attaching a resolution note.
+
+     * Marks the loop as processed to remove it from triage surfaces.
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node.
+
+     * @param resolutionNote Optional text explaining how or why the loop was resolved.
+
+     */
+
+    /**
+
+     * Closes an unprocessed captured item, optionally attaching a resolution note.
+
+     * Marks the loop as processed to remove it from triage surfaces.
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node.
+
+     * @param resolutionNote Optional text explaining how or why the loop was resolved.
+
+     */
+
+    /**
+
+     * Closes an unprocessed captured item, optionally attaching a resolution note.
+
+     * Marks the loop as processed to remove it from triage surfaces.
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node.
+
+     * @param resolutionNote Optional text explaining how or why the loop was resolved.
+
+     */
+
+    /**
+
+     * Closes an unprocessed captured item, optionally attaching a resolution note.
+
+     * Marks the loop as processed to remove it from triage surfaces.
+
+     *
+
+     * @param nodeId The unique identifier of the open loop node.
+
+     * @param resolutionNote Optional text explaining how or why the loop was resolved.
+
+     */
+
+    /**
+     * Closes an unprocessed captured item, optionally attaching a resolution note.
+     * Marks the loop as processed to remove it from triage surfaces.
+     *
+     * @param nodeId The unique identifier of the open loop node.
+     * @param resolutionNote Optional text explaining how or why the loop was resolved.
+     */
+    /**
+     * Closes an unprocessed captured item, optionally attaching a resolution note.
+     * Marks the loop as processed to remove it from triage surfaces.
+     *
+     * @param nodeId The unique identifier of the open loop node.
+     * @param resolutionNote Optional text explaining how or why the loop was resolved.
+     */
+    /**
+     * Closes an unprocessed captured item, optionally attaching a resolution note.
+     * Marks the loop as processed to remove it from triage surfaces.
+     *
+     * @param nodeId The unique identifier of the open loop node.
+     * @param resolutionNote Optional text explaining how or why the loop was resolved.
+     */
     fun resolveOpenLoop(
         nodeId: Long,
         resolutionNote: String? = null,
@@ -1741,6 +2154,50 @@ class MainViewModel(
         relationshipCommands.markMustFindLater(node, enabled)
     }
 
+    /**
+
+     * Executes end-of-month system maintenance scripts via [nodeCommands].
+
+     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
+
+     */
+
+    /**
+
+     * Executes end-of-month system maintenance scripts via [nodeCommands].
+
+     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
+
+     */
+
+    /**
+
+     * Executes end-of-month system maintenance scripts via [nodeCommands].
+
+     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
+
+     */
+
+    /**
+
+     * Executes end-of-month system maintenance scripts via [nodeCommands].
+
+     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
+
+     */
+
+    /**
+     * Executes end-of-month system maintenance scripts via [nodeCommands].
+     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
+     */
+    /**
+     * Executes end-of-month system maintenance scripts via [nodeCommands].
+     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
+     */
+    /**
+     * Executes end-of-month system maintenance scripts via [nodeCommands].
+     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
+     */
     fun runMonthlyReset() {
         nodeCommands.runMonthlyReset()
     }
@@ -1887,6 +2344,72 @@ class MainViewModel(
 
     fun getMedicationsForEntry(trackEntryId: Long): Flow<List<TrackMedicationJoinEntity>> = repository.getTrackMedications(trackEntryId)
 
+    /**
+
+     * Initiates a tracked deep-work session for the specified node.
+
+     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
+
+     *
+
+     * @param nodeId The unique identifier of the node being focused on.
+
+     */
+
+    /**
+
+     * Initiates a tracked deep-work session for the specified node.
+
+     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
+
+     *
+
+     * @param nodeId The unique identifier of the node being focused on.
+
+     */
+
+    /**
+
+     * Initiates a tracked deep-work session for the specified node.
+
+     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
+
+     *
+
+     * @param nodeId The unique identifier of the node being focused on.
+
+     */
+
+    /**
+
+     * Initiates a tracked deep-work session for the specified node.
+
+     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
+
+     *
+
+     * @param nodeId The unique identifier of the node being focused on.
+
+     */
+
+    /**
+     * Initiates a tracked deep-work session for the specified node.
+     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
+     *
+     * @param nodeId The unique identifier of the node being focused on.
+     */
+    /**
+     * Initiates a tracked deep-work session for the specified node.
+     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
+     *
+     * @param nodeId The unique identifier of the node being focused on.
+     */
+    /**
+     * Initiates a tracked deep-work session for the specified node.
+     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
+     *
+     * @param nodeId The unique identifier of the node being focused on.
+     */
     fun startFocusSession(nodeId: Long) {
         viewModelScope.launch {
             if (activeSession.value == null) {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -416,72 +416,6 @@ class MainViewModel(
     }
 
     /**
-
-     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
-
-     * Updates the active mode preference in the underlying repository.
-
-     *
-
-     * @param modeId The unique identifier of the target mode.
-
-     */
-
-    /**
-
-     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
-
-     * Updates the active mode preference in the underlying repository.
-
-     *
-
-     * @param modeId The unique identifier of the target mode.
-
-     */
-
-    /**
-
-     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
-
-     * Updates the active mode preference in the underlying repository.
-
-     *
-
-     * @param modeId The unique identifier of the target mode.
-
-     */
-
-    /**
-
-     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
-
-     * Updates the active mode preference in the underlying repository.
-
-     *
-
-     * @param modeId The unique identifier of the target mode.
-
-     */
-
-    /**
-     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
-     * Updates the active mode preference in the underlying repository.
-     *
-     * @param modeId The unique identifier of the target mode.
-     */
-    /**
-     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
-     * Updates the active mode preference in the underlying repository.
-     *
-     * @param modeId The unique identifier of the target mode.
-     */
-    /**
-     * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
-     * Updates the active mode preference in the underlying repository.
-     *
-     * @param modeId The unique identifier of the target mode.
-     */
-    /**
      * Switches the global UI context to the specified mode, provided the mode's required pack is unlocked.
      * Updates the active mode preference in the underlying repository.
      *
@@ -1128,70 +1062,10 @@ class MainViewModel(
     }
 
     /**
-
-     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
-
-     *
-
-     * @param protocolLabel The normalized identifier for the requested protocol.
-
-     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
-
-     */
-
-    /**
-
-     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
-
-     *
-
-     * @param protocolLabel The normalized identifier for the requested protocol.
-
-     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
-
-     */
-
-    /**
-
-     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
-
-     *
-
-     * @param protocolLabel The normalized identifier for the requested protocol.
-
-     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
-
-     */
-
-    /**
-
-     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
-
-     *
-
-     * @param protocolLabel The normalized identifier for the requested protocol.
-
-     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
-
-     */
-
-    /**
-     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
-     *
-     * @param protocolLabel The normalized identifier for the requested protocol.
-     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
-     */
-    /**
      * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
      *
      * @param protocolLabel The normalized identifier for the requested protocol.
      * @param source The origin surface triggering the protocol (e.g., "dashboard").
-     */
-    /**
-     * Delegates to [protocolCommands] to launch a guided sequential workflow or checklist.
-     *
-     * @param protocolLabel The normalized identifier for the requested protocol.
-     * @param source The origin surface triggering the protocol (e.g., \"dashboard\").
      */
     fun triggerProtocol(
         protocolLabel: String,
@@ -1585,66 +1459,6 @@ class MainViewModel(
     }
 
     /**
-
-     * Triages a raw open loop into a structured, actionable task.
-
-     * Applies default task metadata (e.g., active status) via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-
-     * Triages a raw open loop into a structured, actionable task.
-
-     * Applies default task metadata (e.g., active status) via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-
-     * Triages a raw open loop into a structured, actionable task.
-
-     * Applies default task metadata (e.g., active status) via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-
-     * Triages a raw open loop into a structured, actionable task.
-
-     * Applies default task metadata (e.g., active status) via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-     * Triages a raw open loop into a structured, actionable task.
-     * Applies default task metadata (e.g., active status) via [nodeCommands].
-     *
-     * @param nodeId The unique identifier of the open loop node to convert.
-     */
-    /**
-     * Triages a raw open loop into a structured, actionable task.
-     * Applies default task metadata (e.g., active status) via [nodeCommands].
-     *
-     * @param nodeId The unique identifier of the open loop node to convert.
-     */
-    /**
      * Triages a raw open loop into a structured, actionable task.
      * Applies default task metadata (e.g., active status) via [nodeCommands].
      *
@@ -1654,66 +1468,6 @@ class MainViewModel(
         nodeCommands.convertOpenLoopToTask(nodeId)
     }
 
-    /**
-
-     * Triages a raw open loop into a structured decision matrix.
-
-     * Updates the node type and initializes decision metadata via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-
-     * Triages a raw open loop into a structured decision matrix.
-
-     * Updates the node type and initializes decision metadata via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-
-     * Triages a raw open loop into a structured decision matrix.
-
-     * Updates the node type and initializes decision metadata via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-
-     * Triages a raw open loop into a structured decision matrix.
-
-     * Updates the node type and initializes decision metadata via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-     * Triages a raw open loop into a structured decision matrix.
-     * Updates the node type and initializes decision metadata via [nodeCommands].
-     *
-     * @param nodeId The unique identifier of the open loop node to convert.
-     */
-    /**
-     * Triages a raw open loop into a structured decision matrix.
-     * Updates the node type and initializes decision metadata via [nodeCommands].
-     *
-     * @param nodeId The unique identifier of the open loop node to convert.
-     */
     /**
      * Triages a raw open loop into a structured decision matrix.
      * Updates the node type and initializes decision metadata via [nodeCommands].
@@ -1725,66 +1479,6 @@ class MainViewModel(
     }
 
     /**
-
-     * Triages a raw open loop into a persistent knowledge note.
-
-     * Updates the node type and strips transient triage metadata via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-
-     * Triages a raw open loop into a persistent knowledge note.
-
-     * Updates the node type and strips transient triage metadata via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-
-     * Triages a raw open loop into a persistent knowledge note.
-
-     * Updates the node type and strips transient triage metadata via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-
-     * Triages a raw open loop into a persistent knowledge note.
-
-     * Updates the node type and strips transient triage metadata via [nodeCommands].
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node to convert.
-
-     */
-
-    /**
-     * Triages a raw open loop into a persistent knowledge note.
-     * Updates the node type and strips transient triage metadata via [nodeCommands].
-     *
-     * @param nodeId The unique identifier of the open loop node to convert.
-     */
-    /**
-     * Triages a raw open loop into a persistent knowledge note.
-     * Updates the node type and strips transient triage metadata via [nodeCommands].
-     *
-     * @param nodeId The unique identifier of the open loop node to convert.
-     */
-    /**
      * Triages a raw open loop into a persistent knowledge note.
      * Updates the node type and strips transient triage metadata via [nodeCommands].
      *
@@ -1794,76 +1488,6 @@ class MainViewModel(
         nodeCommands.convertOpenLoopToNote(nodeId)
     }
 
-    /**
-
-     * Closes an unprocessed captured item, optionally attaching a resolution note.
-
-     * Marks the loop as processed to remove it from triage surfaces.
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node.
-
-     * @param resolutionNote Optional text explaining how or why the loop was resolved.
-
-     */
-
-    /**
-
-     * Closes an unprocessed captured item, optionally attaching a resolution note.
-
-     * Marks the loop as processed to remove it from triage surfaces.
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node.
-
-     * @param resolutionNote Optional text explaining how or why the loop was resolved.
-
-     */
-
-    /**
-
-     * Closes an unprocessed captured item, optionally attaching a resolution note.
-
-     * Marks the loop as processed to remove it from triage surfaces.
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node.
-
-     * @param resolutionNote Optional text explaining how or why the loop was resolved.
-
-     */
-
-    /**
-
-     * Closes an unprocessed captured item, optionally attaching a resolution note.
-
-     * Marks the loop as processed to remove it from triage surfaces.
-
-     *
-
-     * @param nodeId The unique identifier of the open loop node.
-
-     * @param resolutionNote Optional text explaining how or why the loop was resolved.
-
-     */
-
-    /**
-     * Closes an unprocessed captured item, optionally attaching a resolution note.
-     * Marks the loop as processed to remove it from triage surfaces.
-     *
-     * @param nodeId The unique identifier of the open loop node.
-     * @param resolutionNote Optional text explaining how or why the loop was resolved.
-     */
-    /**
-     * Closes an unprocessed captured item, optionally attaching a resolution note.
-     * Marks the loop as processed to remove it from triage surfaces.
-     *
-     * @param nodeId The unique identifier of the open loop node.
-     * @param resolutionNote Optional text explaining how or why the loop was resolved.
-     */
     /**
      * Closes an unprocessed captured item, optionally attaching a resolution note.
      * Marks the loop as processed to remove it from triage surfaces.
@@ -2155,46 +1779,6 @@ class MainViewModel(
     }
 
     /**
-
-     * Executes end-of-month system maintenance scripts via [nodeCommands].
-
-     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
-
-     */
-
-    /**
-
-     * Executes end-of-month system maintenance scripts via [nodeCommands].
-
-     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
-
-     */
-
-    /**
-
-     * Executes end-of-month system maintenance scripts via [nodeCommands].
-
-     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
-
-     */
-
-    /**
-
-     * Executes end-of-month system maintenance scripts via [nodeCommands].
-
-     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
-
-     */
-
-    /**
-     * Executes end-of-month system maintenance scripts via [nodeCommands].
-     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
-     */
-    /**
-     * Executes end-of-month system maintenance scripts via [nodeCommands].
-     * This typically archives stale items, resets repeating structures, and generates monthly reflections.
-     */
-    /**
      * Executes end-of-month system maintenance scripts via [nodeCommands].
      * This typically archives stale items, resets repeating structures, and generates monthly reflections.
      */
@@ -2344,66 +1928,6 @@ class MainViewModel(
 
     fun getMedicationsForEntry(trackEntryId: Long): Flow<List<TrackMedicationJoinEntity>> = repository.getTrackMedications(trackEntryId)
 
-    /**
-
-     * Initiates a tracked deep-work session for the specified node.
-
-     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
-
-     *
-
-     * @param nodeId The unique identifier of the node being focused on.
-
-     */
-
-    /**
-
-     * Initiates a tracked deep-work session for the specified node.
-
-     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
-
-     *
-
-     * @param nodeId The unique identifier of the node being focused on.
-
-     */
-
-    /**
-
-     * Initiates a tracked deep-work session for the specified node.
-
-     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
-
-     *
-
-     * @param nodeId The unique identifier of the node being focused on.
-
-     */
-
-    /**
-
-     * Initiates a tracked deep-work session for the specified node.
-
-     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
-
-     *
-
-     * @param nodeId The unique identifier of the node being focused on.
-
-     */
-
-    /**
-     * Initiates a tracked deep-work session for the specified node.
-     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
-     *
-     * @param nodeId The unique identifier of the node being focused on.
-     */
-    /**
-     * Initiates a tracked deep-work session for the specified node.
-     * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.
-     *
-     * @param nodeId The unique identifier of the node being focused on.
-     */
     /**
      * Initiates a tracked deep-work session for the specified node.
      * Creates and persists a new [FocusSessionEntity] to track duration and interruptions.


### PR DESCRIPTION
Added missing KDocs to several key undocumented public functions in `MainViewModel.kt` to improve code understanding and readability. These include functions for mode switching, protocol triggering, open loop resolution, focus sessions, and monthly reset scripts.

---
*PR created automatically by Jules for task [5802015303779251160](https://jules.google.com/task/5802015303779251160) started by @tajemniktv*