### PR TITLE
perf: optimize heuristic matching performance in DomainLensQueries

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -254,30 +254,47 @@ object DomainLensQueries {
             .sortedByDescending { it.node.updatedAt }
 
     /**
-     * Common heuristic matching logic to avoid code duplication.
+     * Configuration class to group matching heuristics. This avoids having functions with many string/collection
+     * arguments, which can trigger code health violations.
      */
-    private fun matchesDomainSignal(
-        node: NodeWithPin,
-        maintenanceTypes: Set<String>,
-        tagMarkers: Set<String>,
-        titleKeywords: List<String>,
-        validNoteTypes: Set<String> = emptySet()
-    ): Boolean {
-        if (node.node.maintenanceType in maintenanceTypes) return true
+    private class DomainMatcher(
+        val maintenanceTypes: Set<String>,
+        val tagMarkers: Set<String>,
+        val titleKeywords: List<String>,
+        val validNoteTypes: Set<String> = emptySet()
+    ) {
+        fun matches(node: NodeWithPin): Boolean {
+            if (node.node.maintenanceType in maintenanceTypes) return true
 
-        val noteType = node.node.noteType
-        if (noteType != null && noteType in validNoteTypes) return true
+            val noteType = node.node.noteType
+            if (noteType != null && noteType in validNoteTypes) return true
 
-        if (node.tags.any { it.normalizedName in tagMarkers }) return true
+            if (node.tags.any { it.normalizedName in tagMarkers }) return true
 
-        val title = node.node.title.lowercase()
-        if (titleKeywords.any { keyword -> title.contains(keyword) }) return true
+            val title = node.node.title.lowercase()
+            if (titleKeywords.any { keyword -> title.contains(keyword) }) return true
 
-        val content = node.node.content.lowercase()
-        if (titleKeywords.any { keyword -> content.contains(keyword) }) return true
+            val content = node.node.content.lowercase()
+            if (titleKeywords.any { keyword -> content.contains(keyword) }) return true
 
-        return false
+            return false
+        }
     }
+
+    private val financeMatcher = DomainMatcher(
+        maintenanceTypes = financeMaintenanceTypes,
+        tagMarkers = financeTagMarkers,
+        titleKeywords = financeTitleKeywords
+    )
+
+    private val healthNoteTypes = setOf("reflection", "journal")
+
+    private val healthMatcher = DomainMatcher(
+        maintenanceTypes = healthMaintenanceTypes,
+        tagMarkers = healthTagMarkers,
+        titleKeywords = healthTitleKeywords,
+        validNoteTypes = healthNoteTypes
+    )
 
     /**
      * Determines whether a node implicitly belongs to the finance domain based on tags,
@@ -291,10 +308,7 @@ object DomainLensQueries {
      * if the user forgets to manually assign the finance domain. This heuristic-based logic
      * relies on implicit keyword matching to decouple domain categorization from explicit user action.
      */
-    private fun matchesFinanceSignal(node: NodeWithPin): Boolean =
-        matchesDomainSignal(node, financeMaintenanceTypes, financeTagMarkers, financeTitleKeywords)
-
-    private val healthNoteTypes = setOf("reflection", "journal")
+    private fun matchesFinanceSignal(node: NodeWithPin): Boolean = financeMatcher.matches(node)
 
     /**
      * Determines whether a node implicitly belongs to the health domain based on tags,
@@ -308,6 +322,5 @@ object DomainLensQueries {
      * if the user forgets to manually assign the health domain. This heuristic-based logic
      * relies on implicit keyword matching to decouple domain categorization from explicit user action.
      */
-    private fun matchesHealthSignal(node: NodeWithPin): Boolean =
-        matchesDomainSignal(node, healthMaintenanceTypes, healthTagMarkers, healthTitleKeywords, healthNoteTypes)
+    private fun matchesHealthSignal(node: NodeWithPin): Boolean = healthMatcher.matches(node)
 }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -258,8 +258,7 @@ object DomainLensQueries {
      * keywords in title/content, maintenance type, or note type (e.g., reference notes).
      *
      * Classification uses hardcoded marker constants ([financeTagMarkers],
-     * [financeTitleKeywords], and [financeMaintenanceTypes]) plus non-constant node-state
-     * checks such as reference-note matching (`noteType == "reference"`).
+     * [financeTitleKeywords], and [financeMaintenanceTypes]).
      *
      * Note: This intentionally bypasses explicit `ItemDomainEntity` database associations
      * to provide a zero-configuration experience, ensuring finance items are surfaced even
@@ -267,17 +266,19 @@ object DomainLensQueries {
      * relies on implicit keyword matching to decouple domain categorization from explicit user action.
      */
     private fun matchesFinanceSignal(node: NodeWithPin): Boolean {
+        if (node.node.maintenanceType in financeMaintenanceTypes) return true
+        if (node.tags.any { it.normalizedName in financeTagMarkers }) return true
+
         val title = node.node.title.lowercase()
+        if (financeTitleKeywords.any { keyword -> title.contains(keyword) }) return true
+
         val content = node.node.content.lowercase()
-        val hasFinanceTag = node.tags.any { it.normalizedName in financeTagMarkers }
-        val mentionsFinanceTitle = financeTitleKeywords.any { keyword -> title.contains(keyword) }
-        val mentionsFinanceContent =
-            financeTitleKeywords.any { keyword -> content.contains(keyword) }
-        val financeMaintenance = node.node.maintenanceType in financeMaintenanceTypes
-        val referenceFinanceNote =
-            node.node.noteType == "reference" && (mentionsFinanceTitle || hasFinanceTag)
-        return hasFinanceTag || mentionsFinanceTitle || mentionsFinanceContent || financeMaintenance || referenceFinanceNote
+        if (financeTitleKeywords.any { keyword -> content.contains(keyword) }) return true
+
+        return false
     }
+
+    private val healthNoteTypes = setOf("reflection", "journal")
 
     /**
      * Determines whether a node implicitly belongs to the health domain based on tags,
@@ -292,13 +293,16 @@ object DomainLensQueries {
      * relies on implicit keyword matching to decouple domain categorization from explicit user action.
      */
     private fun matchesHealthSignal(node: NodeWithPin): Boolean {
+        if (node.node.maintenanceType in healthMaintenanceTypes) return true
+        if (node.node.noteType in healthNoteTypes) return true
+        if (node.tags.any { it.normalizedName in healthTagMarkers }) return true
+
         val title = node.node.title.lowercase()
+        if (healthTitleKeywords.any { keyword -> title.contains(keyword) }) return true
+
         val content = node.node.content.lowercase()
-        val hasHealthTag = node.tags.any { it.normalizedName in healthTagMarkers }
-        val mentionsHealthTitle = healthTitleKeywords.any { keyword -> title.contains(keyword) }
-        val mentionsHealthContent = healthTitleKeywords.any { keyword -> content.contains(keyword) }
-        val healthNoteType = node.node.noteType in setOf("reflection", "journal")
-        val healthMaintenance = node.node.maintenanceType in healthMaintenanceTypes
-        return hasHealthTag || mentionsHealthTitle || mentionsHealthContent || healthMaintenance || healthNoteType
+        if (healthTitleKeywords.any { keyword -> content.contains(keyword) }) return true
+
+        return false
     }
 }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -254,6 +254,32 @@ object DomainLensQueries {
             .sortedByDescending { it.node.updatedAt }
 
     /**
+     * Common heuristic matching logic to avoid code duplication.
+     */
+    private fun matchesDomainSignal(
+        node: NodeWithPin,
+        maintenanceTypes: Set<String>,
+        tagMarkers: Set<String>,
+        titleKeywords: List<String>,
+        validNoteTypes: Set<String> = emptySet()
+    ): Boolean {
+        if (node.node.maintenanceType in maintenanceTypes) return true
+
+        val noteType = node.node.noteType
+        if (noteType != null && noteType in validNoteTypes) return true
+
+        if (node.tags.any { it.normalizedName in tagMarkers }) return true
+
+        val title = node.node.title.lowercase()
+        if (titleKeywords.any { keyword -> title.contains(keyword) }) return true
+
+        val content = node.node.content.lowercase()
+        if (titleKeywords.any { keyword -> content.contains(keyword) }) return true
+
+        return false
+    }
+
+    /**
      * Determines whether a node implicitly belongs to the finance domain based on tags,
      * keywords in title/content, maintenance type, or note type (e.g., reference notes).
      *
@@ -265,18 +291,8 @@ object DomainLensQueries {
      * if the user forgets to manually assign the finance domain. This heuristic-based logic
      * relies on implicit keyword matching to decouple domain categorization from explicit user action.
      */
-    private fun matchesFinanceSignal(node: NodeWithPin): Boolean {
-        if (node.node.maintenanceType in financeMaintenanceTypes) return true
-        if (node.tags.any { it.normalizedName in financeTagMarkers }) return true
-
-        val title = node.node.title.lowercase()
-        if (financeTitleKeywords.any { keyword -> title.contains(keyword) }) return true
-
-        val content = node.node.content.lowercase()
-        if (financeTitleKeywords.any { keyword -> content.contains(keyword) }) return true
-
-        return false
-    }
+    private fun matchesFinanceSignal(node: NodeWithPin): Boolean =
+        matchesDomainSignal(node, financeMaintenanceTypes, financeTagMarkers, financeTitleKeywords)
 
     private val healthNoteTypes = setOf("reflection", "journal")
 
@@ -292,17 +308,6 @@ object DomainLensQueries {
      * if the user forgets to manually assign the health domain. This heuristic-based logic
      * relies on implicit keyword matching to decouple domain categorization from explicit user action.
      */
-    private fun matchesHealthSignal(node: NodeWithPin): Boolean {
-        if (node.node.maintenanceType in healthMaintenanceTypes) return true
-        if (node.node.noteType in healthNoteTypes) return true
-        if (node.tags.any { it.normalizedName in healthTagMarkers }) return true
-
-        val title = node.node.title.lowercase()
-        if (healthTitleKeywords.any { keyword -> title.contains(keyword) }) return true
-
-        val content = node.node.content.lowercase()
-        if (healthTitleKeywords.any { keyword -> content.contains(keyword) }) return true
-
-        return false
-    }
+    private fun matchesHealthSignal(node: NodeWithPin): Boolean =
+        matchesDomainSignal(node, healthMaintenanceTypes, healthTagMarkers, healthTitleKeywords, healthNoteTypes)
 }


### PR DESCRIPTION
Optimized `matchesFinanceSignal` and `matchesHealthSignal` by adding early
returns and reordering checks. This avoids allocating new lowercase strings for
title and content if a match is found based on maintenance type or tags.
Additionally extracted a common set creation into a property.

---
*PR created automatically by Jules for task [9540860068328355960](https://jules.google.com/task/9540860068328355960) started by @tajemniktv*