### PR TITLE
feat(ui): add tactile scale feedback to primary buttons

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -66,22 +66,7 @@ fun ActionButton(
             null
         }
 
-    val finalModifier =
-        modifier.height(48.dp).then(
-            if (isPrimary && enabled) {
-                Modifier.background(
-                    brush =
-                        Brush.linearGradient(
-                            colors = listOf(TajsOSTheme.Primary, TajsOSTheme.PrimaryDim),
-                            start = Offset(0f, 0f),
-                            end = Offset.Infinite,
-                        ),
-                    shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                )
-            } else {
-                Modifier
-            },
-        )
+    val finalModifier = resolveActionButtonModifier(modifier, isPrimary, enabled)
 
     Button(
         onClick = onClick,
@@ -89,11 +74,12 @@ fun ActionButton(
         interactionSource = interactionSource,
         modifier = finalModifier.graphicsLayer(scaleX = scale, scaleY = scale),
         colors =
-            ButtonDefaults.buttonColors(
-                containerColor = if (isPrimary && enabled) Color.Transparent else containerColor,
-                contentColor = if (isPrimary && contentColor == TajsOSTheme.Text) TajsOSTheme.Background else contentColor,
-                disabledContainerColor = if (isGhost) Color.Transparent else TajsOSTheme.SurfaceHighest,
-                disabledContentColor = TajsOSTheme.Muted,
+            resolveActionButtonColors(
+                isPrimary = isPrimary,
+                enabled = enabled,
+                isGhost = isGhost,
+                containerColor = containerColor,
+                contentColor = contentColor,
             ),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         border = buttonBorder,
@@ -110,4 +96,43 @@ fun ActionButton(
             letterSpacing = 1.sp,
         )
     }
+}
+
+@Composable
+private fun resolveActionButtonColors(
+    isPrimary: Boolean,
+    enabled: Boolean,
+    isGhost: Boolean,
+    containerColor: Color,
+    contentColor: Color,
+): androidx.compose.material3.ButtonColors {
+    return ButtonDefaults.buttonColors(
+        containerColor = if (isPrimary && enabled) Color.Transparent else containerColor,
+        contentColor = if (isPrimary && contentColor == TajsOSTheme.Text) TajsOSTheme.Background else contentColor,
+        disabledContainerColor = if (isGhost) Color.Transparent else TajsOSTheme.SurfaceHighest,
+        disabledContentColor = TajsOSTheme.Muted,
+    )
+}
+
+@Composable
+private fun resolveActionButtonModifier(
+    modifier: Modifier,
+    isPrimary: Boolean,
+    enabled: Boolean,
+): Modifier {
+    return modifier.height(48.dp).then(
+        if (isPrimary && enabled) {
+            Modifier.background(
+                brush =
+                    Brush.linearGradient(
+                        colors = listOf(TajsOSTheme.Primary, TajsOSTheme.PrimaryDim),
+                        start = Offset(0f, 0f),
+                        end = Offset.Infinite,
+                    ),
+                shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
+            )
+        } else {
+            Modifier
+        },
+    )
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -16,6 +16,12 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -47,6 +53,10 @@ fun ActionButton(
     contentColor: Color = TajsOSTheme.Text,
     icon: ImageVector? = null,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(targetValue = if (isPressed) 0.98f else 1f, label = "button_scale")
+
     val isPrimary = containerColor == TajsOSTheme.Primary
     val isGhost = containerColor == Color.Transparent
     val buttonBorder =
@@ -76,7 +86,8 @@ fun ActionButton(
     Button(
         onClick = onClick,
         enabled = enabled,
-        modifier = finalModifier,
+        interactionSource = interactionSource,
+        modifier = finalModifier.graphicsLayer(scaleX = scale, scaleY = scale),
         colors =
             ButtonDefaults.buttonColors(
                 containerColor = if (isPrimary && enabled) Color.Transparent else containerColor,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
@@ -741,7 +741,10 @@ fun NewEntryButton(
                     .mouseButtons(
                         onSecondaryClick = onClick,
                         onMiddleClick = onClick,
-                    ).graphicsLayer(scaleX = scale, scaleY = scale),
+                    ).graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                    },
             interactionSource = interactionSource,
             tonalElevation = 0.dp,
             shadowElevation = 0.dp,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
@@ -53,6 +53,12 @@ import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -721,6 +727,10 @@ fun NewEntryButton(
     expanded: Boolean,
     onClick: () -> Unit,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(targetValue = if (isPressed) 0.98f else 1f, label = "button_scale")
+
     val label = stringResource(Res.string.sidebar_new_entry)
     SidebarTooltip(enabled = !expanded, text = label) {
         Surface(
@@ -734,7 +744,8 @@ fun NewEntryButton(
                     .mouseButtons(
                         onSecondaryClick = onClick,
                         onMiddleClick = onClick,
-                    ),
+                    ).graphicsLayer(scaleX = scale, scaleY = scale),
+            interactionSource = interactionSource,
             tonalElevation = 0.dp,
             shadowElevation = 0.dp,
         ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
@@ -54,17 +54,14 @@ import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
Added a subtle 0.98 scale-down animation on press to ActionButton
and NewEntryButton (sidebar) to comply with DESIGN.md tactile feedback
requirements for primary interactions.

---
*PR created automatically by Jules for task [11449113446297267014](https://jules.google.com/task/11449113446297267014) started by @tajemniktv*