### PR TITLE
test: add missing coverage for main state dashboard calculators

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblersDashboardTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblersDashboardTest.kt
@@ -303,7 +303,7 @@ class MainStateAssemblersDashboardTest {
         val now = Clock.System.now().toEpochMilliseconds()
 
         // Critical project
-        val projectNodeBase = defaultNode(100, "project", "active").copy(projectId = null)
+        val projectNodeBase = defaultNode(100, "project", "active")
         val projectNode = createTestNodeWithPin(projectNodeBase)
 
         val criticalTaskBase = defaultNode(101, "task", "active").copy(

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblersDashboardTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblersDashboardTest.kt
@@ -296,4 +296,57 @@ class MainStateAssemblersDashboardTest {
 
         assertEquals(1, state.foundationalNotes.size)
     }
+
+    @Test
+    fun `buildDashboardUIState missing coverage for various nodes`() = runTest {
+        val repo = createRepo()
+        val now = Clock.System.now().toEpochMilliseconds()
+
+        // Critical project
+        val projectNodeBase = defaultNode(100, "project", "active").copy(projectId = null)
+        val projectNode = createTestNodeWithPin(projectNodeBase)
+
+        val criticalTaskBase = defaultNode(101, "task", "active").copy(
+            projectId = 100L,
+            isHardDeadline = true,
+            dueAt = now - 1000L
+        )
+        val criticalTask = createTestNodeWithPin(criticalTaskBase)
+
+        val neglectedTaskBase = defaultNode(102, "task", "active").copy(
+            projectId = 100L,
+            updatedAt = now - 15L * 24 * 60 * 60 * 1000L
+        )
+        val neglectedTask = createTestNodeWithPin(neglectedTaskBase)
+
+        // Archived this week
+        val archivedNodeBase = defaultNode(103, "task", "archived").copy(
+            archivedAt = now - 2 * 24 * 60 * 60 * 1000L
+        )
+        val archivedNode = createTestNodeWithPin(archivedNodeBase)
+
+        // Unresolved bureaucracy
+        val maintenanceNodeBase = defaultNode(104, "maintenance", "active").copy(
+            createdAt = now - 10 * 24 * 60 * 60 * 1000L
+        )
+        val maintenanceNode = createTestNodeWithPin(maintenanceNodeBase)
+
+        // Tiny victories
+        val doneNodeBase = defaultNode(105, "task", "done").copy(
+            completedAt = now - 1 * 24 * 60 * 60 * 1000L
+        )
+        val doneNode = createTestNodeWithPin(doneNodeBase)
+
+        val nodes = listOf(
+            projectNode, criticalTask, neglectedTask,
+            archivedNode, maintenanceNode, doneNode
+        )
+
+        val state = assembleState(repo, nodes)
+
+        assertEquals(1, state.criticalProjects.size)
+        assertEquals(1, state.archivedThisWeek.size)
+        assertEquals(1, state.unresolvedBureaucracy.size)
+        assertEquals(1, state.tinyVictories.size)
+    }
 }


### PR DESCRIPTION
This PR adds missing unit tests to `MainStateAssemblersDashboardTest.kt` to improve the test coverage of `MainStateAssemblers.kt`.

### Changes Made:
- Added a new test function `buildDashboardUIState missing coverage for various nodes`.
- The test verifies the correctness of node categorization and aggregation for the following edge case scenarios:
  - Critical projects (e.g., hard deadlines and neglected tasks).
  - Tasks archived within the current week.
  - Unresolved bureaucracy (maintenance tasks active for an extended period).
  - Tiny victories (recently completed tasks).

These additions improve the robustness and confidence in the state dashboard compilation logic, without modifying any production code.

---
*PR created automatically by Jules for task [11191641778746097291](https://jules.google.com/task/11191641778746097291) started by @tajemniktv*