### PR TITLE
chore: format website codebase using biome and prettier

### DIFF
--- a/website/biome.json
+++ b/website/biome.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"includes": ["**", "!!**/dist", "!!**/*.css", "!!**/*.astro"]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/website/biome.json
+++ b/website/biome.json
@@ -6,11 +6,11 @@
 		"useIgnoreFile": true
 	},
 	"files": {
-		"includes": ["**", "!!**/dist", "!!**/*.css", "!!**/*.astro"]
+		"ignore": ["**/dist/**", "**/*.css", "**/*.astro"]
 	},
 	"formatter": {
 		"enabled": true,
-		"indentStyle": "tab"
+		"indentStyle": "space"
 	},
 	"linter": {
 		"enabled": true,

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -29,6 +29,9 @@
         "typescript": "^6.0.3",
         "vite": "^8.0.14"
       },
+      "devDependencies": {
+        "prettier-plugin-astro": "^0.14.1"
+      },
       "engines": {
         "node": ">=22"
       }
@@ -6846,6 +6849,21 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+      "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.9.1",
+        "prettier": "^3.0.0",
+        "sass-formatter": "^0.7.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -7348,6 +7366,23 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
     },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/sass-formatter": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
+      "integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -7700,6 +7735,16 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "s.color": "0.0.15"
       }
     },
     "node_modules/supports-color": {

--- a/website/package.json
+++ b/website/package.json
@@ -36,5 +36,8 @@
   },
   "overrides": {
     "vite": "$vite"
+  },
+  "devDependencies": {
+    "prettier-plugin-astro": "^0.14.1"
   }
 }

--- a/website/src/components/MarkdownContent.astro
+++ b/website/src/components/MarkdownContent.astro
@@ -1,11 +1,12 @@
 ---
-import BlogMarkdownContent from 'starlight-blog/components/MarkdownContent.astro';
-import VideosMarkdownContent from 'starlight-videos/components/MarkdownContent.astro';
+import BlogMarkdownContent from "starlight-blog/components/MarkdownContent.astro";
+import VideosMarkdownContent from "starlight-videos/components/MarkdownContent.astro";
 
 const props = Astro.props;
 ---
+
 <VideosMarkdownContent {...props}>
-    <BlogMarkdownContent {...props}>
-        <slot />
-    </BlogMarkdownContent>
+  <BlogMarkdownContent {...props}>
+    <slot />
+  </BlogMarkdownContent>
 </VideosMarkdownContent>

--- a/website/src/components/landing/CTA.astro
+++ b/website/src/components/landing/CTA.astro
@@ -1,6 +1,6 @@
 ---
 // src/components/landing/CTA.astro
-import { SITE } from '../../data/site';
+import { SITE } from "../../data/site";
 ---
 
 <section
@@ -28,17 +28,20 @@ import { SITE } from '../../data/site';
       cognitive network and offload the chaos.
     </p>
     <div class="flex flex-col md:flex-row items-center justify-center gap-16">
-      <a href={`${import.meta.env.BASE_URL}${SITE.waitlistUrl}`}
+      <a
+        href={`${import.meta.env.BASE_URL}${SITE.waitlistUrl}`}
         class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-mono font-bold px-20 py-10 rounded-xl text-xl uppercase tracking-[0.2em] hover:scale-105 transition-all hover:opacity-90 block"
       >
         [ Join Waitlist ]
       </a>
-      <a href={`${import.meta.env.BASE_URL}pricing`}
+      <a
+        href={`${import.meta.env.BASE_URL}pricing`}
         class="font-mono font-bold uppercase tracking-[0.3em] text-[12px] text-on-surface-variant hover:text-primary transition-colors flex items-center gap-6 group"
       >
         VIEW_PRICING
         <span
-          aria-hidden="true" class="material-symbols-outlined group-hover:translate-x-4 transition-transform text-3xl"
+          aria-hidden="true"
+          class="material-symbols-outlined group-hover:translate-x-4 transition-transform text-3xl"
           data-icon="arrow_right_alt">arrow_right_alt</span
         >
       </a>

--- a/website/src/components/landing/Footer.astro
+++ b/website/src/components/landing/Footer.astro
@@ -1,6 +1,6 @@
 ---
 // src/components/landing/Footer.astro
-import { SITE, FOOTER_LINKS } from '../../data/site';
+import { SITE, FOOTER_LINKS } from "../../data/site";
 ---
 
 <footer class="w-full bg-surface-container-low py-24 px-12">
@@ -20,14 +20,23 @@ import { SITE, FOOTER_LINKS } from '../../data/site';
       </p>
     </div>
     <div class="grid grid-cols-2 md:grid-cols-3 gap-x-24 gap-y-8">
-      {Object.entries(FOOTER_LINKS).map(([group, links]) => (
-        <div class="flex flex-col gap-4">
-          <span class="font-mono text-[10px] text-primary mb-2 tracking-widest">{group.toUpperCase()}</span>
-          {links.map(link => (
-            <a class="font-mono text-[10px] tracking-widest uppercase text-on-surface-variant/60 hover:text-primary transition-colors min-h-[48px] flex items-center" href={`${import.meta.env.BASE_URL}${link.href}`}>{link.label}</a>
-          ))}
-        </div>
-      ))}
+      {
+        Object.entries(FOOTER_LINKS).map(([group, links]) => (
+          <div class="flex flex-col gap-4">
+            <span class="font-mono text-[10px] text-primary mb-2 tracking-widest">
+              {group.toUpperCase()}
+            </span>
+            {links.map((link) => (
+              <a
+                class="font-mono text-[10px] tracking-widest uppercase text-on-surface-variant/60 hover:text-primary transition-colors min-h-[48px] flex items-center"
+                href={`${import.meta.env.BASE_URL}${link.href}`}
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        ))
+      }
     </div>
   </div>
 </footer>

--- a/website/src/components/landing/Hero.astro
+++ b/website/src/components/landing/Hero.astro
@@ -1,6 +1,6 @@
 ---
 // src/components/landing/Hero.astro
-import { SITE } from '../../data/site';
+import { SITE } from "../../data/site";
 ---
 
 <section class="relative min-h-dvh flex items-start mb-64">
@@ -10,7 +10,6 @@ import { SITE } from '../../data/site';
         class="font-mono text-[10px] tracking-[0.5em] text-primary bg-surface-container-highest px-4 py-2 rounded-full shadow-[0_0_40px_rgba(186,158,255,0.1)] uppercase"
         >LOCAL_FIRST</span
       >
-
     </div>
     <h1
       class="font-headline text-[clamp(5rem,15vw,12rem)] leading-[0.8] font-bold tracking-tighter uppercase text-on-surface"
@@ -30,12 +29,14 @@ import { SITE } from '../../data/site';
         Bridge the gap between biological thought and digital execution.
       </p>
       <div class="flex flex-col gap-6 pt-4">
-        <a href={`${import.meta.env.BASE_URL}${SITE.waitlistUrl}`}
+        <a
+          href={`${import.meta.env.BASE_URL}${SITE.waitlistUrl}`}
           class="w-fit bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-mono font-bold px-10 py-6 rounded-xl text-sm uppercase tracking-[0.2em] hover:opacity-90 transition-all"
         >
           [ Join_Waitlist ]
         </a>
-        <a href={`${import.meta.env.BASE_URL}architecture`}
+        <a
+          href={`${import.meta.env.BASE_URL}architecture`}
           class="w-fit font-mono font-bold uppercase tracking-widest text-[11px] text-on-surface-variant/60 hover:text-primary transition-colors bg-surface-container-low px-4 py-2 min-h-[48px] flex items-center justify-center rounded-xl"
         >
           Architecture

--- a/website/src/components/landing/InstrumentPanel.astro
+++ b/website/src/components/landing/InstrumentPanel.astro
@@ -30,7 +30,8 @@
           </div>
         </div>
         <span
-          aria-hidden="true" class="material-symbols-outlined text-primary/20 text-6xl"
+          aria-hidden="true"
+          class="material-symbols-outlined text-primary/20 text-6xl"
           data-icon="sensors">sensors</span
         >
       </div>
@@ -47,7 +48,9 @@
           friction, total retention for neural offloading.
         </p>
       </div>
-      <div class="mt-20 grid grid-cols-1 md:grid-cols-3 bg-surface-container-highest/20 rounded-xl p-6">
+      <div
+        class="mt-20 grid grid-cols-1 md:grid-cols-3 bg-surface-container-highest/20 rounded-xl p-6"
+      >
         <div>
           <span
             class="block font-mono text-[9px] text-on-surface-variant mb-2 uppercase tracking-widest"
@@ -64,7 +67,8 @@
         </div>
         <div class="flex justify-end items-center">
           <span
-            aria-hidden="true" class="material-symbols-outlined text-primary group-hover:translate-x-4 transition-transform text-4xl"
+            aria-hidden="true"
+            class="material-symbols-outlined text-primary group-hover:translate-x-4 transition-transform text-4xl"
             data-icon="arrow_forward">arrow_forward</span
           >
         </div>
@@ -91,7 +95,8 @@
               <p class="font-headline font-bold text-xl">Buy Groceries</p>
             </div>
             <span
-              aria-hidden="true" class="material-symbols-outlined text-secondary animate-pulse"
+              aria-hidden="true"
+              class="material-symbols-outlined text-secondary animate-pulse"
               data-icon="downloading">downloading</span
             >
           </div>
@@ -148,7 +153,8 @@
           <div class="h-0.5 w-12 bg-on-primary-fixed/40"></div>
         </div>
         <span
-          aria-hidden="true" class="material-symbols-outlined text-8xl opacity-30"
+          aria-hidden="true"
+          class="material-symbols-outlined text-8xl opacity-30"
           data-icon="bolt"
           style="font-variation-settings: 'FILL' 1;">bolt</span
         >

--- a/website/src/components/landing/Navbar.astro
+++ b/website/src/components/landing/Navbar.astro
@@ -1,11 +1,9 @@
 ---
 // src/components/landing/Navbar.astro
-import { SITE, NAV_LINKS } from '../../data/site';
+import { SITE, NAV_LINKS } from "../../data/site";
 ---
 
-<nav
-  class="fixed top-0 w-full z-100 bg-surface-container-low/60"
->
+<nav class="fixed top-0 w-full z-100 bg-surface-container-low/60">
   <div
     class="flex justify-between items-center w-full px-8 py-4 max-w-400 mx-auto"
   >
@@ -21,12 +19,16 @@ import { SITE, NAV_LINKS } from '../../data/site';
       >
     </a>
     <div class="hidden md:flex gap-12">
-      {NAV_LINKS.map(link => (
-        <a
-          class="font-mono text-[10px] tracking-widest uppercase font-bold text-on-surface-variant hover:text-on-surface transition-colors min-h-[48px] flex items-center px-2"
-          href={`${import.meta.env.BASE_URL}${link.href}`}>{link.label}</a
-        >
-      ))}
+      {
+        NAV_LINKS.map((link) => (
+          <a
+            class="font-mono text-[10px] tracking-widest uppercase font-bold text-on-surface-variant hover:text-on-surface transition-colors min-h-[48px] flex items-center px-2"
+            href={`${import.meta.env.BASE_URL}${link.href}`}
+          >
+            {link.label}
+          </a>
+        ))
+      }
     </div>
     <div class="flex items-center gap-6">
       <div class="flex gap-4">
@@ -42,7 +44,9 @@ import { SITE, NAV_LINKS } from '../../data/site';
           data-icon="account_circle">account_circle</button
         >
       </div>
-      <a href={`${import.meta.env.BASE_URL}${SITE.waitlistUrl}`} aria-label="Join Waitlist"
+      <a
+        href={`${import.meta.env.BASE_URL}${SITE.waitlistUrl}`}
+        aria-label="Join Waitlist"
         class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-mono font-bold px-6 min-h-[48px] flex items-center justify-center rounded-xl text-[10px] tracking-widest uppercase hover:opacity-90 transition-all"
         >JOIN WAITLIST</a
       >

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -1,20 +1,20 @@
-import { defineCollection } from 'astro:content';
-import { z } from 'astro/zod';
-import { docsLoader } from '@astrojs/starlight/loaders';
-import { docsSchema } from '@astrojs/starlight/schema';
-import { blogSchema } from 'starlight-blog/schema';
-import { videosSchema } from 'starlight-videos/schemas';
+import { defineCollection } from "astro:content";
+import { docsLoader } from "@astrojs/starlight/loaders";
+import { docsSchema } from "@astrojs/starlight/schema";
+import { z } from "astro/zod";
+import { blogSchema } from "starlight-blog/schema";
+import { videosSchema } from "starlight-videos/schemas";
 
 export const collections = {
-    docs: defineCollection({
-        loader: docsLoader(),
-        schema: docsSchema({
-            extend: (context) => {
-                return z.object({
-                    ...blogSchema(context).shape,
-                    ...videosSchema.shape
-                });
-            }
-        })
-    }),
+	docs: defineCollection({
+		loader: docsLoader(),
+		schema: docsSchema({
+			extend: (context) => {
+				return z.object({
+					...blogSchema(context).shape,
+					...videosSchema.shape,
+				});
+			},
+		}),
+	}),
 };

--- a/website/src/data/features.ts
+++ b/website/src/data/features.ts
@@ -1,44 +1,44 @@
 export type Feature = {
-  icon: string;
-  title: string;
-  description: string;
+	icon: string;
+	title: string;
+	description: string;
 };
 
 export const FEATURES: readonly Feature[] = [
-  {
-    icon: "inbox",
-    title: "Inbox Captures",
-    description:
-      "Fast intake before forced classification. Capture thoughts, tasks, and notes instantly without worrying about where they belong right now.",
-  },
-  {
-    icon: "check_circle",
-    title: "Tasks for Execution",
-    description:
-      "Manage your execution layer. Tasks are first-class citizens connected to projects and areas, helping you focus on what matters now.",
-  },
-  {
-    icon: "sticky_note_2",
-    title: "Notes for Knowledge",
-    description:
-      "Durable knowledge and reference. Create rich text documents that link to tasks and projects, forming your personal knowledge base.",
-  },
-  {
-    icon: "history",
-    title: "Chronological Records",
-    description:
-      "Logs, reflections, and observations stored chronologically to build a timeline of your life and projects over time.",
-  },
-  {
-    icon: "account_tree",
-    title: "Projects & Areas",
-    description:
-      "Group items by outcomes (Projects) or ongoing responsibilities (Areas) to keep different domains organized without isolated silos.",
-  },
-  {
-    icon: "hub",
-    title: "Relations & Tags",
-    description:
-      "Relations, schedules, and tags act as shared layers across the system, tying tasks to notes to records seamlessly.",
-  },
+	{
+		icon: "inbox",
+		title: "Inbox Captures",
+		description:
+			"Fast intake before forced classification. Capture thoughts, tasks, and notes instantly without worrying about where they belong right now.",
+	},
+	{
+		icon: "check_circle",
+		title: "Tasks for Execution",
+		description:
+			"Manage your execution layer. Tasks are first-class citizens connected to projects and areas, helping you focus on what matters now.",
+	},
+	{
+		icon: "sticky_note_2",
+		title: "Notes for Knowledge",
+		description:
+			"Durable knowledge and reference. Create rich text documents that link to tasks and projects, forming your personal knowledge base.",
+	},
+	{
+		icon: "history",
+		title: "Chronological Records",
+		description:
+			"Logs, reflections, and observations stored chronologically to build a timeline of your life and projects over time.",
+	},
+	{
+		icon: "account_tree",
+		title: "Projects & Areas",
+		description:
+			"Group items by outcomes (Projects) or ongoing responsibilities (Areas) to keep different domains organized without isolated silos.",
+	},
+	{
+		icon: "hub",
+		title: "Relations & Tags",
+		description:
+			"Relations, schedules, and tags act as shared layers across the system, tying tasks to notes to records seamlessly.",
+	},
 ];

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -1,34 +1,35 @@
 export const SITE = {
-  title: "TajsOS",
-  titlePrimary: "Tajs",
-  titleHighlight: "OS",
-  description: "A cognitive operating system designed to curate chaos into clarity.",
-  copyright: "© 2026 TajsOS. All systems nominal and all rights reserved.",
-  statusText: "System Access Granted",
-  waitlistUrl: "waitlist",
-  appUrl: "app",
-  docsUrl: "overview",
+	title: "TajsOS",
+	titlePrimary: "Tajs",
+	titleHighlight: "OS",
+	description:
+		"A cognitive operating system designed to curate chaos into clarity.",
+	copyright: "© 2026 TajsOS. All systems nominal and all rights reserved.",
+	statusText: "System Access Granted",
+	waitlistUrl: "waitlist",
+	appUrl: "app",
+	docsUrl: "overview",
 } as const;
 
 export const NAV_LINKS = [
-  { label: "DOCS", href: SITE.docsUrl },
-  { label: "APP", href: SITE.appUrl },
-  { label: "LOCAL-FIRST", href: "local-first" },
-  { label: "FEATURES", href: "features" },
-  { label: "ARCHITECTURE", href: "architecture" },
+	{ label: "DOCS", href: SITE.docsUrl },
+	{ label: "APP", href: SITE.appUrl },
+	{ label: "LOCAL-FIRST", href: "local-first" },
+	{ label: "FEATURES", href: "features" },
+	{ label: "ARCHITECTURE", href: "architecture" },
 ] as const;
 
 export const FOOTER_LINKS = {
-  protocols: [
-    { label: "Privacy", href: "privacy" },
-    { label: "Security", href: "security" },
-  ],
-  network: [
-    { label: "Terms", href: "terms" },
-    { label: "System Status", href: "status" },
-  ],
-  documentation: [
-    { label: "Philosophy", href: "philosophy" },
-    { label: "Changelog", href: "changelog" },
-  ],
+	protocols: [
+		{ label: "Privacy", href: "privacy" },
+		{ label: "Security", href: "security" },
+	],
+	network: [
+		{ label: "Terms", href: "terms" },
+		{ label: "System Status", href: "status" },
+	],
+	documentation: [
+		{ label: "Philosophy", href: "philosophy" },
+		{ label: "Changelog", href: "changelog" },
+	],
 } as const;

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -14,7 +14,11 @@ const pageTitle = title ? `TajsOS | ${title}` : "TajsOS | The Neural Interface";
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/png" href={`${import.meta.env.BASE_URL}favicon.png`} />
+    <link
+      rel="icon"
+      type="image/png"
+      href={`${import.meta.env.BASE_URL}favicon.png`}
+    />
     <meta name="generator" content={Astro.generator} />
     <title>{pageTitle}</title>
 

--- a/website/src/pages/api/waitlist.ts
+++ b/website/src/pages/api/waitlist.ts
@@ -3,40 +3,40 @@ import type { APIRoute } from "astro";
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export const GET: APIRoute = async () =>
-  new Response(
-    JSON.stringify({ ok: false, error: "Method not allowed. Use POST." }),
-    { status: 405, headers: { "Content-Type": "application/json" } },
-  );
+	new Response(
+		JSON.stringify({ ok: false, error: "Method not allowed. Use POST." }),
+		{ status: 405, headers: { "Content-Type": "application/json" } },
+	);
 
 export const POST: APIRoute = async ({ request }) => {
-  let payload: unknown;
+	let payload: unknown;
 
-  try {
-    payload = await request.json();
-  } catch {
-    return new Response(
-      JSON.stringify({ ok: false, error: "Invalid JSON payload." }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
-  }
+	try {
+		payload = await request.json();
+	} catch {
+		return new Response(
+			JSON.stringify({ ok: false, error: "Invalid JSON payload." }),
+			{ status: 400, headers: { "Content-Type": "application/json" } },
+		);
+	}
 
-  const email =
-    typeof payload === "object" &&
-    payload !== null &&
-    "email" in payload &&
-    typeof (payload as { email: unknown }).email === "string"
-      ? (payload as { email: string }).email.trim()
-      : "";
+	const email =
+		typeof payload === "object" &&
+		payload !== null &&
+		"email" in payload &&
+		typeof (payload as { email: unknown }).email === "string"
+			? (payload as { email: string }).email.trim()
+			: "";
 
-  if (!emailPattern.test(email)) {
-    return new Response(
-      JSON.stringify({ ok: false, error: "Invalid email address." }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
-  }
+	if (!emailPattern.test(email)) {
+		return new Response(
+			JSON.stringify({ ok: false, error: "Invalid email address." }),
+			{ status: 400, headers: { "Content-Type": "application/json" } },
+		);
+	}
 
-  return new Response(
-    JSON.stringify({ ok: true }),
-    { status: 200, headers: { "Content-Type": "application/json" } },
-  );
+	return new Response(JSON.stringify({ ok: true }), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
 };

--- a/website/src/pages/app.astro
+++ b/website/src/pages/app.astro
@@ -1,43 +1,66 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
 
 const title = "APP";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
 
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
+    <!-- Header Section -->
+    <header class="py-16 md:py-24 text-left relative overflow-hidden">
+      <div
+        class="absolute -left-24 top-0 w-96 h-96 bg-primary-dim/10 rounded-full"
+      >
+      </div>
+      <h1
+        class="font-headline text-5xl md:text-8xl font-bold tracking-tighter uppercase leading-none neon-glow-primary"
+      >
+        APP<br /><span class="text-primary-dim">OVERVIEW</span>
+      </h1>
+      <div
+        class="mt-8 flex flex-col md:flex-row md:items-end justify-between gap-6"
+      >
+        <p
+          class="font-body text-on-surface-variant max-w-xl text-lg leading-relaxed"
+        >
+          TajsOS offers a unified dashboard bringing your tasks, notes,
+          projects, and areas into one cohesive environment designed for
+          execution and insight.
+        </p>
+        <div class="flex gap-4">
+          <div
+            class="px-4 py-2 bg-surface-container-high border border-outline-variant/20 rounded-lg flex items-center gap-3"
+          >
+            <span class="w-2 h-2 rounded-full bg-primary animate-pulse"></span>
+            <span
+              class="font-mono text-[10px] uppercase tracking-widest text-primary"
+              >UI V1.0</span
+            >
+          </div>
+        </div>
+      </div>
+    </header>
 
-<!-- Header Section -->
-<header class="py-16 md:py-24 text-left relative overflow-hidden">
-<div class="absolute -left-24 top-0 w-96 h-96 bg-primary-dim/10 rounded-full"></div>
-<h1 class="font-headline text-5xl md:text-8xl font-bold tracking-tighter uppercase leading-none neon-glow-primary">
-                APP<br/><span class="text-primary-dim">OVERVIEW</span>
-</h1>
-<div class="mt-8 flex flex-col md:flex-row md:items-end justify-between gap-6">
-<p class="font-body text-on-surface-variant max-w-xl text-lg leading-relaxed">
-                    TajsOS offers a unified dashboard bringing your tasks, notes, projects, and areas into one cohesive environment designed for execution and insight.
-                </p>
-<div class="flex gap-4">
-<div class="px-4 py-2 bg-surface-container-high border border-outline-variant/20 rounded-lg flex items-center gap-3">
-<span class="w-2 h-2 rounded-full bg-primary animate-pulse"></span>
-<span class="font-mono text-[10px] uppercase tracking-widest text-primary">UI V1.0</span>
-</div>
-</div>
-</div>
-</header>
-
-<section class="mb-32">
-  <div class="w-full aspect-[16/9] bg-surface-container-low rounded-2xl overflow-hidden border border-outline-variant/10 relative">
-    <img src={`${import.meta.env.BASE_URL}images/app-screenshot.png`} alt="TajsOS Dashboard" class="w-full h-full object-cover">
-  </div>
-</section>
-
+    <section class="mb-32">
+      <div
+        class="w-full aspect-[16/9] bg-surface-container-low rounded-2xl overflow-hidden border border-outline-variant/10 relative"
+      >
+        <img
+          src={`${import.meta.env.BASE_URL}images/app-screenshot.png`}
+          alt="TajsOS Dashboard"
+          class="w-full h-full object-cover"
+        />
+      </div>
+    </section>
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/architecture.astro
+++ b/website/src/pages/architecture.astro
@@ -1,72 +1,95 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
 
 const title = "ARCHITECTURE";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
 
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
+    <!-- Section 1: Header -->
+    <header
+      class="relative flex flex-col md:flex-row justify-between items-end border-b border-outline-variant/20 pb-8"
+    >
+      <div class="space-y-2">
+        <div
+          class="flex items-center space-x-3 text-primary font-mono text-sm tracking-widest uppercase"
+        >
+          <span class="w-2 h-2 bg-primary rounded-full animate-pulse"></span>
+          <span>Tech Stack</span>
+        </div>
+        <h1
+          class="font-headline text-6xl font-bold tracking-tighter uppercase leading-none"
+        >
+          ARCHITECTURE <span
+            class="text-outline-variant tracking-normal font-light">//</span
+          > OVERVIEW
+        </h1>
+      </div>
+    </header>
 
-<!-- Section 1: Header -->
-<header class="relative flex flex-col md:flex-row justify-between items-end border-b border-outline-variant/20 pb-8">
-<div class="space-y-2">
-<div class="flex items-center space-x-3 text-primary font-mono text-sm tracking-widest uppercase">
-<span class="w-2 h-2 bg-primary rounded-full animate-pulse"></span>
-<span>Tech Stack</span>
-</div>
-<h1 class="font-headline text-6xl font-bold tracking-tighter uppercase leading-none">
-                    ARCHITECTURE <span class="text-outline-variant tracking-normal font-light">//</span> OVERVIEW
-                </h1>
-</div>
-</header>
+    <section
+      class="max-w-4xl text-lg text-on-surface-variant leading-relaxed space-y-6 mt-16"
+    >
+      <h2 class="text-3xl font-bold font-headline mb-6 text-on-surface">
+        The Tech Stack
+      </h2>
+      <p>
+        TajsOS is built using modern Kotlin Multiplatform (KMP) tools, designed
+        for high performance, local-first capabilities, and cross-platform
+        consistency.
+      </p>
 
-<section class="max-w-4xl text-lg text-on-surface-variant leading-relaxed space-y-6 mt-16">
-  <h2 class="text-3xl font-bold font-headline mb-6 text-on-surface">The Tech Stack</h2>
-  <p>
-    TajsOS is built using modern Kotlin Multiplatform (KMP) tools, designed for high performance, local-first capabilities, and cross-platform consistency.
-  </p>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mt-8">
+        <div
+          class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10"
+        >
+          <h3 class="font-bold text-xl text-on-surface mb-2">Frontend / UI</h3>
+          <ul class="list-disc pl-4 space-y-2">
+            <li>Compose Multiplatform</li>
+            <li>Jetpack Compose (Android)</li>
+          </ul>
+        </div>
 
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mt-8">
-    <div class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10">
-      <h3 class="font-bold text-xl text-on-surface mb-2">Frontend / UI</h3>
-      <ul class="list-disc pl-4 space-y-2">
-        <li>Compose Multiplatform</li>
-        <li>Jetpack Compose (Android)</li>
-      </ul>
-    </div>
+        <div
+          class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10"
+        >
+          <h3 class="font-bold text-xl text-on-surface mb-2">Backend / Sync</h3>
+          <ul class="list-disc pl-4 space-y-2">
+            <li>Ktor Server</li>
+            <li>Kotlin Coroutines & Flow</li>
+          </ul>
+        </div>
 
-    <div class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10">
-      <h3 class="font-bold text-xl text-on-surface mb-2">Backend / Sync</h3>
-      <ul class="list-disc pl-4 space-y-2">
-        <li>Ktor Server</li>
-        <li>Kotlin Coroutines & Flow</li>
-      </ul>
-    </div>
+        <div
+          class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10"
+        >
+          <h3 class="font-bold text-xl text-on-surface mb-2">Database Layer</h3>
+          <ul class="list-disc pl-4 space-y-2">
+            <li>SQLite</li>
+            <li>Room Database (Local Persistence)</li>
+          </ul>
+        </div>
 
-    <div class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10">
-      <h3 class="font-bold text-xl text-on-surface mb-2">Database Layer</h3>
-      <ul class="list-disc pl-4 space-y-2">
-        <li>SQLite</li>
-        <li>Room Database (Local Persistence)</li>
-      </ul>
-    </div>
-
-    <div class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10">
-      <h3 class="font-bold text-xl text-on-surface mb-2">Core Logic</h3>
-      <ul class="list-disc pl-4 space-y-2">
-        <li>Kotlin Multiplatform (Shared library)</li>
-        <li>MVVM / Clean Architecture</li>
-      </ul>
-    </div>
-  </div>
-</section>
-
+        <div
+          class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10"
+        >
+          <h3 class="font-bold text-xl text-on-surface mb-2">Core Logic</h3>
+          <ul class="list-disc pl-4 space-y-2">
+            <li>Kotlin Multiplatform (Shared library)</li>
+            <li>MVVM / Clean Architecture</li>
+          </ul>
+        </div>
+      </div>
+    </section>
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -1,248 +1,439 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
 
 const title = "Changelog";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
-  
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
+
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
-    
-<!-- Sidebar: System Vitals -->
-<aside class="col-span-3 flex flex-col gap-6">
-<div class="flex flex-col gap-1">
-<h2 class="font-headline text-2xl font-bold tracking-tight text-on-surface">System Vital Statistics</h2>
-<p class="font-mono text-[10px] text-primary uppercase tracking-[0.2em]">Live Telemetry Feed</p>
-</div>
-<!-- Vital Graphs -->
-<div class="flex flex-col gap-4">
-<!-- CPU -->
-<div class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10 relative overflow-hidden group">
-<div class="absolute top-0 right-0 w-32 h-32 bg-primary/5 rounded-full -mr-16 -mt-16"></div>
-<div class="flex justify-between items-end mb-4">
-<div>
-<p class="font-mono text-[10px] text-outline uppercase">CPU Load</p>
-<p class="font-headline text-3xl font-bold">42<span class="text-sm text-primary ml-1">%</span></p>
-</div>
-<div class="flex gap-1 items-end h-8">
-<div class="w-1 bg-zinc-800 h-2"></div>
-<div class="w-1 bg-zinc-800 h-4"></div>
-<div class="w-1 bg-primary h-6 shadow-[0_0_30px_#ba9eff]"></div>
-<div class="w-1 bg-primary h-5 shadow-[0_0_30px_#ba9eff]"></div>
-<div class="w-1 bg-zinc-800 h-3"></div>
-</div>
-</div>
-<div class="w-full h-1.5 bg-surface-container-lowest rounded-full overflow-hidden">
-<div class="h-full bg-linear-to-r from-primary-dim to-primary w-[42%]"></div>
-</div>
-</div>
-<!-- Neural Load -->
-<div class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10 relative overflow-hidden group">
-<div class="flex justify-between items-end mb-4">
-<div>
-<p class="font-mono text-[10px] text-outline uppercase">Neural Synapse</p>
-<p class="font-headline text-3xl font-bold">89<span class="text-sm text-primary ml-1">Hz</span></p>
-</div>
-<span class="material-symbols-outlined text-primary" style="font-variation-settings: 'FILL' 1;">psychology</span>
-</div>
-<div class="w-full h-12 flex items-center justify-between gap-1">
-<div class="flex-1 h-1 bg-primary/20 rounded-full"></div>
-<div class="flex-1 h-3 bg-primary/40 rounded-full"></div>
-<div class="flex-1 h-6 bg-primary rounded-full shadow-[0_0_40px_#ba9eff]"></div>
-<div class="flex-1 h-8 bg-primary-dim rounded-full"></div>
-<div class="flex-1 h-4 bg-primary/40 rounded-full"></div>
-<div class="flex-1 h-2 bg-primary/20 rounded-full"></div>
-</div>
-</div>
-<!-- Memory -->
-<div class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10">
-<p class="font-mono text-[10px] text-outline uppercase mb-2">Memory Allocation</p>
-<div class="flex items-center gap-4">
-<div class="relative w-16 h-16">
-<svg class="w-full h-full -rotate-90" viewBox="0 0 36 36">
-<circle class="stroke-surface-container-highest" cx="18" cy="18" fill="none" r="16" stroke-width="3"></circle>
-<circle class="stroke-primary" cx="18" cy="18" fill="none" r="16" stroke-dasharray="75, 100" stroke-linecap="round" stroke-width="3"></circle>
-</svg>
-<div class="absolute inset-0 flex items-center justify-center text-[10px] font-mono">75%</div>
-</div>
-<div class="flex flex-col">
-<span class="text-xl font-headline font-bold">12.4<span class="text-xs text-outline font-normal">/16GB</span></span>
-<span class="text-[10px] font-mono text-zinc-500 uppercase">Buffer: 2.1GB</span>
-</div>
-</div>
-</div>
-</div>
-<!-- Status Nodes -->
-<div class="mt-4 flex flex-col gap-4">
-<p class="font-mono text-[10px] text-outline uppercase tracking-widest">Cognitive Services</p>
-<div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-<div class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2">
-<div class="flex justify-between items-start">
-<span class="material-symbols-outlined text-xs text-primary">hub</span>
-<div class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse shadow-[0_0_20px_#ba9eff]"></div>
-</div>
-<span class="font-mono text-[9px] uppercase tracking-tighter">Sync_Node</span>
-</div>
-<div class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2">
-<div class="flex justify-between items-start">
-<span class="material-symbols-outlined text-xs text-zinc-500">memory</span>
-<div class="w-1.5 h-1.5 rounded-full bg-zinc-700"></div>
-</div>
-<span class="font-mono text-[9px] uppercase tracking-tighter text-zinc-500">Core_Idle</span>
-</div>
-<div class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2">
-<div class="flex justify-between items-start">
-<span class="material-symbols-outlined text-xs text-primary">security</span>
-<div class="w-1.5 h-1.5 rounded-full bg-primary shadow-[0_0_20px_#ba9eff]"></div>
-</div>
-<span class="font-mono text-[9px] uppercase tracking-tighter">Vault_Enc</span>
-</div>
-<div class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2">
-<div class="flex justify-between items-start">
-<span class="material-symbols-outlined text-xs text-tertiary">warning</span>
-<div class="w-1.5 h-1.5 rounded-full bg-tertiary"></div>
-</div>
-<span class="font-mono text-[9px] uppercase tracking-tighter text-tertiary">Latency_H</span>
-</div>
-</div>
-</div>
-</aside>
-<!-- Main Center: Terminal Live Activity -->
-<section class="col-span-9 flex flex-col gap-4">
-<div class="bg-surface-container-lowest border border-outline-variant/10 rounded-3xl flex flex-col h-[750px] overflow-hidden terminal-glow shadow-[0_20px_50px_rgba(0,0,0,0.3)]">
-<!-- Terminal Header -->
-<div class="bg-surface-container-high px-6 py-3 flex justify-between items-center border-b border-outline-variant/5">
-<div class="flex items-center gap-4">
-<div class="flex gap-1.5">
-<div class="w-2.5 h-2.5 rounded-full bg-error/20 border border-error/40"></div>
-<div class="w-2.5 h-2.5 rounded-full bg-primary/20 border border-primary/40"></div>
-<div class="w-2.5 h-2.5 rounded-full bg-zinc-800 border border-zinc-700"></div>
-</div>
-<span class="font-mono text-[11px] text-zinc-400">system_activity_monitor --live</span>
-</div>
-<div class="flex items-center gap-4">
-<span class="font-mono text-[10px] text-zinc-600">STABLE_RELEASE_V4.02</span>
-<div class="flex bg-surface-container-lowest rounded-xl overflow-hidden border border-outline-variant/20">
-<button  class="px-3 min-h-[48px] flex items-center justify-center bg-primary text-on-primary text-[10px] font-mono">LIVE</button>
-<button  class="px-3 min-h-[48px] flex items-center justify-center text-zinc-500 text-[10px] font-mono hover:text-white">HISTORY</button>
-</div>
-</div>
-</div>
-<!-- Terminal Content -->
-<div class="flex-1 overflow-y-auto p-8 font-mono text-[13px] leading-relaxed selection:bg-primary/30">
-<div class="flex flex-col gap-2">
-<!-- Log Entry -->
-<div class="grid grid-cols-[140px_1fr] group">
-<span class="text-zinc-600">[2024.05.12 14:22:01]</span>
-<div class="flex items-start gap-4">
-<span class="text-primary font-bold">INFO</span>
-<p class="text-zinc-300">Kernel initialized. Loading neural weights for <span class="text-secondary-fixed">model_id: T-900</span>...</p>
-</div>
-</div>
-<div class="grid grid-cols-[140px_1fr] group">
-<span class="text-zinc-600">[2024.05.12 14:22:03]</span>
-<div class="flex items-start gap-4">
-<span class="text-primary font-bold">INFO</span>
-<p class="text-zinc-300">Memory allocation successful. <span class="text-primary">4096MB</span> reserved for context window.</p>
-</div>
-</div>
-<div class="grid grid-cols-[140px_1fr] group bg-zinc-800/40 -mx-8 px-8 py-1">
-<span class="text-zinc-600">[2024.05.12 14:22:05]</span>
-<div class="flex items-start gap-4">
-<span class="text-primary font-bold">PROCESS</span>
-<p class="text-white">Neural synapsing sequence <span class="text-primary">#OP-9821</span> initiated by user_auth_primary.</p>
-</div>
-</div>
-<div class="grid grid-cols-[140px_1fr] group">
-<span class="text-zinc-600">[2024.05.12 14:22:12]</span>
-<div class="flex items-start gap-4">
-<span class="text-zinc-500 font-bold">DEBUG</span>
-<p class="text-zinc-500">Latency spike detected in <span class="font-bold underline decoration-zinc-700">region_eu_west</span>. Rerouting via secondary node.</p>
-</div>
-</div>
-<div class="grid grid-cols-[140px_1fr] group">
-<span class="text-zinc-600">[2024.05.12 14:22:15]</span>
-<div class="flex items-start gap-4">
-<span class="text-primary font-bold">INFO</span>
-<p class="text-zinc-300">Reroute successful. Current latency: <span class="text-primary">12ms</span>.</p>
-</div>
-</div>
-<div class="grid grid-cols-[140px_1fr] group py-1">
-<span class="text-zinc-600">[2024.05.12 14:22:18]</span>
-<div class="flex items-start gap-4">
-<span class="text-tertiary font-bold">WARN</span>
-<p class="text-tertiary/80">Cognitive load exceeding threshold (85%). Initiating cooling protocol.</p>
-</div>
-</div>
-<div class="grid grid-cols-[140px_1fr] group">
-<span class="text-zinc-600">[2024.05.12 14:22:20]</span>
-<div class="flex items-start gap-4">
-<span class="text-primary font-bold">INFO</span>
-<p class="text-zinc-300">Thermal management engaged. CPU frequency scaled to <span class="text-primary">3.2GHz</span>.</p>
-</div>
-</div>
-<div class="grid grid-cols-[140px_1fr] group">
-<span class="text-zinc-600">[2024.05.12 14:22:25]</span>
-<div class="flex items-start gap-4">
-<span class="text-primary font-bold">SUCCESS</span>
-<p class="text-zinc-300">Neural Sync established. Ready for cognitive queries.</p>
-</div>
-</div>
-<!-- Typing Prompt -->
-<div class="mt-8 flex gap-4 items-center">
-<span class="text-primary font-bold animate-pulse">_</span>
-<div class="h-5 w-1 bg-primary animate-pulse"></div>
-</div>
-</div>
-</div>
-<!-- Footer Console Input -->
+    <!-- Sidebar: System Vitals -->
+    <aside class="col-span-3 flex flex-col gap-6">
+      <div class="flex flex-col gap-1">
+        <h2
+          class="font-headline text-2xl font-bold tracking-tight text-on-surface"
+        >
+          System Vital Statistics
+        </h2>
+        <p
+          class="font-mono text-[10px] text-primary uppercase tracking-[0.2em]"
+        >
+          Live Telemetry Feed
+        </p>
+      </div>
+      <!-- Vital Graphs -->
+      <div class="flex flex-col gap-4">
+        <!-- CPU -->
+        <div
+          class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10 relative overflow-hidden group"
+        >
+          <div
+            class="absolute top-0 right-0 w-32 h-32 bg-primary/5 rounded-full -mr-16 -mt-16"
+          >
+          </div>
+          <div class="flex justify-between items-end mb-4">
+            <div>
+              <p class="font-mono text-[10px] text-outline uppercase">
+                CPU Load
+              </p>
+              <p class="font-headline text-3xl font-bold">
+                42<span class="text-sm text-primary ml-1">%</span>
+              </p>
+            </div>
+            <div class="flex gap-1 items-end h-8">
+              <div class="w-1 bg-zinc-800 h-2"></div>
+              <div class="w-1 bg-zinc-800 h-4"></div>
+              <div class="w-1 bg-primary h-6 shadow-[0_0_30px_#ba9eff]"></div>
+              <div class="w-1 bg-primary h-5 shadow-[0_0_30px_#ba9eff]"></div>
+              <div class="w-1 bg-zinc-800 h-3"></div>
+            </div>
+          </div>
+          <div
+            class="w-full h-1.5 bg-surface-container-lowest rounded-full overflow-hidden"
+          >
+            <div
+              class="h-full bg-linear-to-r from-primary-dim to-primary w-[42%]"
+            >
+            </div>
+          </div>
+        </div>
+        <!-- Neural Load -->
+        <div
+          class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10 relative overflow-hidden group"
+        >
+          <div class="flex justify-between items-end mb-4">
+            <div>
+              <p class="font-mono text-[10px] text-outline uppercase">
+                Neural Synapse
+              </p>
+              <p class="font-headline text-3xl font-bold">
+                89<span class="text-sm text-primary ml-1">Hz</span>
+              </p>
+            </div>
+            <span
+              class="material-symbols-outlined text-primary"
+              style="font-variation-settings: 'FILL' 1;">psychology</span
+            >
+          </div>
+          <div class="w-full h-12 flex items-center justify-between gap-1">
+            <div class="flex-1 h-1 bg-primary/20 rounded-full"></div>
+            <div class="flex-1 h-3 bg-primary/40 rounded-full"></div>
+            <div
+              class="flex-1 h-6 bg-primary rounded-full shadow-[0_0_40px_#ba9eff]"
+            >
+            </div>
+            <div class="flex-1 h-8 bg-primary-dim rounded-full"></div>
+            <div class="flex-1 h-4 bg-primary/40 rounded-full"></div>
+            <div class="flex-1 h-2 bg-primary/20 rounded-full"></div>
+          </div>
+        </div>
+        <!-- Memory -->
+        <div
+          class="bg-surface-container-low p-6 rounded-3xl border border-outline-variant/10"
+        >
+          <p class="font-mono text-[10px] text-outline uppercase mb-2">
+            Memory Allocation
+          </p>
+          <div class="flex items-center gap-4">
+            <div class="relative w-16 h-16">
+              <svg class="w-full h-full -rotate-90" viewBox="0 0 36 36">
+                <circle
+                  class="stroke-surface-container-highest"
+                  cx="18"
+                  cy="18"
+                  fill="none"
+                  r="16"
+                  stroke-width="3"></circle>
+                <circle
+                  class="stroke-primary"
+                  cx="18"
+                  cy="18"
+                  fill="none"
+                  r="16"
+                  stroke-dasharray="75, 100"
+                  stroke-linecap="round"
+                  stroke-width="3"></circle>
+              </svg>
+              <div
+                class="absolute inset-0 flex items-center justify-center text-[10px] font-mono"
+              >
+                75%
+              </div>
+            </div>
+            <div class="flex flex-col">
+              <span class="text-xl font-headline font-bold"
+                >12.4<span class="text-xs text-outline font-normal">/16GB</span
+                ></span
+              >
+              <span class="text-[10px] font-mono text-zinc-500 uppercase"
+                >Buffer: 2.1GB</span
+              >
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Status Nodes -->
+      <div class="mt-4 flex flex-col gap-4">
+        <p class="font-mono text-[10px] text-outline uppercase tracking-widest">
+          Cognitive Services
+        </p>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div
+            class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2"
+          >
+            <div class="flex justify-between items-start">
+              <span class="material-symbols-outlined text-xs text-primary"
+                >hub</span
+              >
+              <div
+                class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse shadow-[0_0_20px_#ba9eff]"
+              >
+              </div>
+            </div>
+            <span class="font-mono text-[9px] uppercase tracking-tighter"
+              >Sync_Node</span
+            >
+          </div>
+          <div
+            class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2"
+          >
+            <div class="flex justify-between items-start">
+              <span class="material-symbols-outlined text-xs text-zinc-500"
+                >memory</span
+              >
+              <div class="w-1.5 h-1.5 rounded-full bg-zinc-700"></div>
+            </div>
+            <span
+              class="font-mono text-[9px] uppercase tracking-tighter text-zinc-500"
+              >Core_Idle</span
+            >
+          </div>
+          <div
+            class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2"
+          >
+            <div class="flex justify-between items-start">
+              <span class="material-symbols-outlined text-xs text-primary"
+                >security</span
+              >
+              <div
+                class="w-1.5 h-1.5 rounded-full bg-primary shadow-[0_0_20px_#ba9eff]"
+              >
+              </div>
+            </div>
+            <span class="font-mono text-[9px] uppercase tracking-tighter"
+              >Vault_Enc</span
+            >
+          </div>
+          <div
+            class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2"
+          >
+            <div class="flex justify-between items-start">
+              <span class="material-symbols-outlined text-xs text-tertiary"
+                >warning</span
+              >
+              <div class="w-1.5 h-1.5 rounded-full bg-tertiary"></div>
+            </div>
+            <span
+              class="font-mono text-[9px] uppercase tracking-tighter text-tertiary"
+              >Latency_H</span
+            >
+          </div>
+        </div>
+      </div>
+    </aside>
+    <!-- Main Center: Terminal Live Activity -->
+    <section class="col-span-9 flex flex-col gap-4">
+      <div
+        class="bg-surface-container-lowest border border-outline-variant/10 rounded-3xl flex flex-col h-[750px] overflow-hidden terminal-glow shadow-[0_20px_50px_rgba(0,0,0,0.3)]"
+      >
+        <!-- Terminal Header -->
+        <div
+          class="bg-surface-container-high px-6 py-3 flex justify-between items-center border-b border-outline-variant/5"
+        >
+          <div class="flex items-center gap-4">
+            <div class="flex gap-1.5">
+              <div
+                class="w-2.5 h-2.5 rounded-full bg-error/20 border border-error/40"
+              >
+              </div>
+              <div
+                class="w-2.5 h-2.5 rounded-full bg-primary/20 border border-primary/40"
+              >
+              </div>
+              <div
+                class="w-2.5 h-2.5 rounded-full bg-zinc-800 border border-zinc-700"
+              >
+              </div>
+            </div>
+            <span class="font-mono text-[11px] text-zinc-400"
+              >system_activity_monitor --live</span
+            >
+          </div>
+          <div class="flex items-center gap-4">
+            <span class="font-mono text-[10px] text-zinc-600"
+              >STABLE_RELEASE_V4.02</span
+            >
+            <div
+              class="flex bg-surface-container-lowest rounded-xl overflow-hidden border border-outline-variant/20"
+            >
+              <button
+                class="px-3 min-h-[48px] flex items-center justify-center bg-primary text-on-primary text-[10px] font-mono"
+                >LIVE</button
+              >
+              <button
+                class="px-3 min-h-[48px] flex items-center justify-center text-zinc-500 text-[10px] font-mono hover:text-white"
+                >HISTORY</button
+              >
+            </div>
+          </div>
+        </div>
+        <!-- Terminal Content -->
+        <div
+          class="flex-1 overflow-y-auto p-8 font-mono text-[13px] leading-relaxed selection:bg-primary/30"
+        >
+          <div class="flex flex-col gap-2">
+            <!-- Log Entry -->
+            <div class="grid grid-cols-[140px_1fr] group">
+              <span class="text-zinc-600">[2024.05.12 14:22:01]</span>
+              <div class="flex items-start gap-4">
+                <span class="text-primary font-bold">INFO</span>
+                <p class="text-zinc-300">
+                  Kernel initialized. Loading neural weights for <span
+                    class="text-secondary-fixed">model_id: T-900</span
+                  >...
+                </p>
+              </div>
+            </div>
+            <div class="grid grid-cols-[140px_1fr] group">
+              <span class="text-zinc-600">[2024.05.12 14:22:03]</span>
+              <div class="flex items-start gap-4">
+                <span class="text-primary font-bold">INFO</span>
+                <p class="text-zinc-300">
+                  Memory allocation successful. <span class="text-primary"
+                    >4096MB</span
+                  > reserved for context window.
+                </p>
+              </div>
+            </div>
+            <div
+              class="grid grid-cols-[140px_1fr] group bg-zinc-800/40 -mx-8 px-8 py-1"
+            >
+              <span class="text-zinc-600">[2024.05.12 14:22:05]</span>
+              <div class="flex items-start gap-4">
+                <span class="text-primary font-bold">PROCESS</span>
+                <p class="text-white">
+                  Neural synapsing sequence <span class="text-primary"
+                    >#OP-9821</span
+                  > initiated by user_auth_primary.
+                </p>
+              </div>
+            </div>
+            <div class="grid grid-cols-[140px_1fr] group">
+              <span class="text-zinc-600">[2024.05.12 14:22:12]</span>
+              <div class="flex items-start gap-4">
+                <span class="text-zinc-500 font-bold">DEBUG</span>
+                <p class="text-zinc-500">
+                  Latency spike detected in <span
+                    class="font-bold underline decoration-zinc-700"
+                    >region_eu_west</span
+                  >. Rerouting via secondary node.
+                </p>
+              </div>
+            </div>
+            <div class="grid grid-cols-[140px_1fr] group">
+              <span class="text-zinc-600">[2024.05.12 14:22:15]</span>
+              <div class="flex items-start gap-4">
+                <span class="text-primary font-bold">INFO</span>
+                <p class="text-zinc-300">
+                  Reroute successful. Current latency: <span
+                    class="text-primary">12ms</span
+                  >.
+                </p>
+              </div>
+            </div>
+            <div class="grid grid-cols-[140px_1fr] group py-1">
+              <span class="text-zinc-600">[2024.05.12 14:22:18]</span>
+              <div class="flex items-start gap-4">
+                <span class="text-tertiary font-bold">WARN</span>
+                <p class="text-tertiary/80">
+                  Cognitive load exceeding threshold (85%). Initiating cooling
+                  protocol.
+                </p>
+              </div>
+            </div>
+            <div class="grid grid-cols-[140px_1fr] group">
+              <span class="text-zinc-600">[2024.05.12 14:22:20]</span>
+              <div class="flex items-start gap-4">
+                <span class="text-primary font-bold">INFO</span>
+                <p class="text-zinc-300">
+                  Thermal management engaged. CPU frequency scaled to <span
+                    class="text-primary">3.2GHz</span
+                  >.
+                </p>
+              </div>
+            </div>
+            <div class="grid grid-cols-[140px_1fr] group">
+              <span class="text-zinc-600">[2024.05.12 14:22:25]</span>
+              <div class="flex items-start gap-4">
+                <span class="text-primary font-bold">SUCCESS</span>
+                <p class="text-zinc-300">
+                  Neural Sync established. Ready for cognitive queries.
+                </p>
+              </div>
+            </div>
+            <!-- Typing Prompt -->
+            <div class="mt-8 flex gap-4 items-center">
+              <span class="text-primary font-bold animate-pulse">_</span>
+              <div class="h-5 w-1 bg-primary animate-pulse"></div>
+            </div>
+          </div>
+        </div>
+        <!-- Footer Console Input -->
 
-<div class="bg-surface-container-low px-8 py-4 flex items-center gap-4 focus-within:ring-1 focus-within:ring-primary focus-within:ring-inset">
-<span class="text-primary font-mono text-sm">tajsos@root:~ $</span>
-<input class="bg-transparent border-transparent outline-none w-full text-white font-mono placeholder:text-zinc-700" placeholder="Execute command..." type="text"/>
-<div class="flex gap-3">
-<span class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors">history</span>
-<span class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors">terminal</span>
-</div>
-</div>
-</div>
-<!-- Bottom Cards Row -->
-<div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-<div class="bg-surface-container-low p-6 rounded-3xl border border-transparent flex items-center gap-4 group hover:border-primary/20 transition-all">
-<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary border border-outline-variant/10">
-<span class="material-symbols-outlined">analytics</span>
-</div>
-<div>
-<h4 class="font-headline font-bold">Deep Insights</h4>
-<p class="text-xs text-outline font-mono uppercase tracking-tighter">Analyze patterns</p>
-</div>
-</div>
-<div class="bg-surface-container-low p-6 rounded-3xl border border-transparent flex items-center gap-4 group hover:border-primary/20 transition-all">
-<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-secondary border border-outline-variant/10">
-<span class="material-symbols-outlined">dns</span>
-</div>
-<div>
-<h4 class="font-headline font-bold">Node Manager</h4>
-<p class="text-xs text-outline font-mono uppercase tracking-tighter">12 Active Clusters</p>
-</div>
-</div>
-<div class="bg-surface-container-low p-6 rounded-3xl border border-transparent flex items-center gap-4 group hover:border-primary/20 transition-all">
-<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-tertiary border border-outline-variant/10">
-<span class="material-symbols-outlined">security</span>
-</div>
-<div>
-<h4 class="font-headline font-bold">Security Hub</h4>
-<p class="text-xs text-outline font-mono uppercase tracking-tighter">Level 4 Protocol</p>
-</div>
-</div>
-</div>
-</section>
-
+        <div
+          class="bg-surface-container-low px-8 py-4 flex items-center gap-4 focus-within:ring-1 focus-within:ring-primary focus-within:ring-inset"
+        >
+          <span class="text-primary font-mono text-sm">tajsos@root:~ $</span>
+          <input
+            class="bg-transparent border-transparent outline-none w-full text-white font-mono placeholder:text-zinc-700"
+            placeholder="Execute command..."
+            type="text"
+          />
+          <div class="flex gap-3">
+            <span
+              class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors"
+              >history</span
+            >
+            <span
+              class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors"
+              >terminal</span
+            >
+          </div>
+        </div>
+      </div>
+      <!-- Bottom Cards Row -->
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div
+          class="bg-surface-container-low p-6 rounded-3xl border border-transparent flex items-center gap-4 group hover:border-primary/20 transition-all"
+        >
+          <div
+            class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary border border-outline-variant/10"
+          >
+            <span class="material-symbols-outlined">analytics</span>
+          </div>
+          <div>
+            <h4 class="font-headline font-bold">Deep Insights</h4>
+            <p
+              class="text-xs text-outline font-mono uppercase tracking-tighter"
+            >
+              Analyze patterns
+            </p>
+          </div>
+        </div>
+        <div
+          class="bg-surface-container-low p-6 rounded-3xl border border-transparent flex items-center gap-4 group hover:border-primary/20 transition-all"
+        >
+          <div
+            class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-secondary border border-outline-variant/10"
+          >
+            <span class="material-symbols-outlined">dns</span>
+          </div>
+          <div>
+            <h4 class="font-headline font-bold">Node Manager</h4>
+            <p
+              class="text-xs text-outline font-mono uppercase tracking-tighter"
+            >
+              12 Active Clusters
+            </p>
+          </div>
+        </div>
+        <div
+          class="bg-surface-container-low p-6 rounded-3xl border border-transparent flex items-center gap-4 group hover:border-primary/20 transition-all"
+        >
+          <div
+            class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-tertiary border border-outline-variant/10"
+          >
+            <span class="material-symbols-outlined">security</span>
+          </div>
+          <div>
+            <h4 class="font-headline font-bold">Security Hub</h4>
+            <p
+              class="text-xs text-outline font-mono uppercase tracking-tighter"
+            >
+              Level 4 Protocol
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -1,40 +1,54 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
-import { FEATURES } from '../data/features';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
+import { FEATURES } from "../data/features";
 
 const title = "FEATURES";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
 
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
-
     <header class="mb-16">
-      <h1 class="text-5xl md:text-7xl font-headline font-bold tracking-tighter text-on-surface mb-6">
-          Core <span class="text-primary">Features</span>
+      <h1
+        class="text-5xl md:text-7xl font-headline font-bold tracking-tighter text-on-surface mb-6"
+      >
+        Core <span class="text-primary">Features</span>
       </h1>
       <p class="text-xl text-on-surface-variant max-w-3xl">
-          TajsOS is built around a small set of shared life objects that stay connected. Instead of splitting everything into isolated tools, TajsOS makes them work as one system.
+        TajsOS is built around a small set of shared life objects that stay
+        connected. Instead of splitting everything into isolated tools, TajsOS
+        makes them work as one system.
       </p>
     </header>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-32">
-      {FEATURES.map((feature) => (
-        <div class="bg-surface-container-low p-8 rounded-3xl border border-transparent hover:border-primary/30 transition-all group">
-          <span class="material-symbols-outlined text-4xl text-primary mb-6" style="font-variation-settings: 'FILL' 1;">
-            {feature.icon}
-          </span>
-          <h3 class="font-headline font-bold text-2xl mb-4 text-on-surface">{feature.title}</h3>
-          <p class="text-on-surface-variant leading-relaxed">{feature.description}</p>
-        </div>
-      ))}
+      {
+        FEATURES.map((feature) => (
+          <div class="bg-surface-container-low p-8 rounded-3xl border border-transparent hover:border-primary/30 transition-all group">
+            <span
+              class="material-symbols-outlined text-4xl text-primary mb-6"
+              style="font-variation-settings: 'FILL' 1;"
+            >
+              {feature.icon}
+            </span>
+            <h3 class="font-headline font-bold text-2xl mb-4 text-on-surface">
+              {feature.title}
+            </h3>
+            <p class="text-on-surface-variant leading-relaxed">
+              {feature.description}
+            </p>
+          </div>
+        ))
+      }
     </div>
-
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/local-first.astro
+++ b/website/src/pages/local-first.astro
@@ -1,53 +1,79 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
 
 const title = "LOCAL-FIRST";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
 
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
-
-<!-- Top Header Section -->
-<header class="mb-16 flex justify-between items-start">
-<div class="max-w-3xl">
-<h1 class="font-headline font-bold text-7xl lg:text-8xl tracking-tighter leading-none mb-2 text-on-surface">
+    <!-- Top Header Section -->
+    <header class="mb-16 flex justify-between items-start">
+      <div class="max-w-3xl">
+        <h1
+          class="font-headline font-bold text-7xl lg:text-8xl tracking-tighter leading-none mb-2 text-on-surface"
+        >
           LOCAL <span class="text-primary">FIRST</span>
         </h1>
-<p class="font-mono text-primary tracking-widest text-sm ml-2">
+        <p class="font-mono text-primary tracking-widest text-sm ml-2">
           &gt; FAST, RELIABLE, PRIVATE
         </p>
-</div>
-<div class="flex flex-wrap gap-2 justify-end max-w-xs">
-<div class="px-3 py-1 bg-primary/10 border border-primary/30 rounded-full flex items-center gap-2">
-<div class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse"></div>
-<span class="font-mono text-[10px] text-primary">SQLITE_READY</span>
-</div>
-</div>
-</header>
+      </div>
+      <div class="flex flex-wrap gap-2 justify-end max-w-xs">
+        <div
+          class="px-3 py-1 bg-primary/10 border border-primary/30 rounded-full flex items-center gap-2"
+        >
+          <div class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse"></div>
+          <span class="font-mono text-[10px] text-primary">SQLITE_READY</span>
+        </div>
+      </div>
+    </header>
 
-<section class="max-w-4xl text-lg text-on-surface-variant leading-relaxed space-y-6">
-  <p>
-    TajsOS is built on a fundamental principle: your life's operating system shouldn't depend on an internet connection or a slow cloud service. It must be fast, private, and always available.
-  </p>
-  <p>
-    The local model keeps a compatibility `NodeEntity` spine for the current app shell, while moving deeper behavior into typed companion tables instead of growing one giant nullable row. This keeps the ontology small, typed, and local-first while leaving room for rich integrations.
-  </p>
+    <section
+      class="max-w-4xl text-lg text-on-surface-variant leading-relaxed space-y-6"
+    >
+      <p>
+        TajsOS is built on a fundamental principle: your life's operating system
+        shouldn't depend on an internet connection or a slow cloud service. It
+        must be fast, private, and always available.
+      </p>
+      <p>
+        The local model keeps a compatibility `NodeEntity` spine for the current
+        app shell, while moving deeper behavior into typed companion tables
+        instead of growing one giant nullable row. This keeps the ontology
+        small, typed, and local-first while leaving room for rich integrations.
+      </p>
 
-  <h2 class="text-3xl font-bold font-headline mt-12 mb-6 text-on-surface">Data Architecture</h2>
-  <ul class="list-disc pl-6 space-y-4">
-    <li><strong class="text-on-surface">InboxEntryEntity:</strong> Stores raw capture before triage.</li>
-    <li><strong class="text-on-surface">NodeEntity:</strong> The shared local identity row for task/note/record/project/area items.</li>
-    <li><strong class="text-on-surface">Typed Companion Tables:</strong> `TaskFacet`, `NoteFacet`, `RecordFacet`, etc., hold object-specific state.</li>
-    <li><strong class="text-on-surface">RelationEntity & Tags:</strong> Shared layers across the system, keeping everything cross-cutting and first-class.</li>
-  </ul>
-</section>
-
+      <h2 class="text-3xl font-bold font-headline mt-12 mb-6 text-on-surface">
+        Data Architecture
+      </h2>
+      <ul class="list-disc pl-6 space-y-4">
+        <li>
+          <strong class="text-on-surface">InboxEntryEntity:</strong> Stores raw capture
+          before triage.
+        </li>
+        <li>
+          <strong class="text-on-surface">NodeEntity:</strong> The shared local identity
+          row for task/note/record/project/area items.
+        </li>
+        <li>
+          <strong class="text-on-surface">Typed Companion Tables:</strong> `TaskFacet`,
+          `NoteFacet`, `RecordFacet`, etc., hold object-specific state.
+        </li>
+        <li>
+          <strong class="text-on-surface">RelationEntity & Tags:</strong> Shared layers
+          across the system, keeping everything cross-cutting and first-class.
+        </li>
+      </ul>
+    </section>
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/philosophy.astro
+++ b/website/src/pages/philosophy.astro
@@ -1,72 +1,114 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
 
 const title = "PHILOSOPHY";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
 
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
-
-<div class="grid grid-cols-1 lg:grid-cols-12 gap-16">
-<!-- Main Content Area -->
-<div class="col-span-12 lg:col-span-8 space-y-32">
-<h1 class="font-headline text-5xl font-bold tracking-tight text-on-surface">Philosophy</h1>
-<!-- Section I -->
-<section class="space-y-10" id="neurodivergent-by-design">
-<div class="flex items-baseline gap-4">
-<span class="font-mono text-primary text-xl">I.</span>
-<h2 class="font-headline text-5xl font-bold tracking-tight">Neurodivergent by Design</h2>
-</div>
-<div class="prose prose-invert max-w-none space-y-6 text-on-surface-variant leading-relaxed text-lg">
-<p>
-                            TajsOS is a local-first personal operating system for life, projects, thoughts, execution, and insight. It is not necessarily just for ADHD brains, but it is designed with neurodivergent brains in mind.
-                        </p>
-<p>
-                            Modern interfaces assume a linear mind. They are built on metaphors of filing cabinets, rigid hierarchies, and sequential tasks. But biological cognition is chaotic, associative, and concurrent. We need tools that work the way our brains do.
-                        </p>
-</div>
-</section>
-<!-- Section II -->
-<section class="space-y-10" id="unified-system">
-<div class="flex items-baseline gap-4">
-<span class="font-mono text-primary text-xl">II.</span>
-<h2 class="font-headline text-5xl font-bold tracking-tight">A Unified System</h2>
-</div>
-<div class="prose prose-invert max-w-none space-y-6 text-on-surface-variant leading-relaxed text-lg">
-<p>
-                            Instead of splitting everything into isolated tools, TajsOS tries to make them work as one system. The app is built around a small set of shared life objects that can still stay connected.
-                        </p>
-                        <p>
-                            The core model connects Inbox captures, Tasks, Notes, Records, Projects, and Areas into a single semantic mesh. The value is in the connections between these nodes, creating a true external pre-frontal cortex.
-                        </p>
-</div>
-</section>
-<!-- Section III -->
-<section class="space-y-10" id="local-persistence">
-<div class="flex items-baseline gap-4">
-<span class="font-mono text-primary text-xl">III.</span>
-<h2 class="font-headline text-5xl font-bold tracking-tight">Local Persistence</h2>
-</div>
-<div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-<div class="p-8 bg-surface-container-low rounded-3xl border border-outline-variant/10">
-<h3 class="font-headline text-xl font-bold mb-4 text-on-surface">Offline by Default</h3>
-<p class="text-on-surface-variant text-sm leading-relaxed">Your data lives on your device first. No internet connection is required to capture a thought or execute a task. Sync is an enhancement, not a requirement.</p>
-</div>
-<div class="p-8 bg-surface-container-low rounded-3xl border border-outline-variant/10">
-<h3 class="font-headline text-xl font-bold mb-4 text-on-surface">Typed Companion Tables</h3>
-<p class="text-on-surface-variant text-sm leading-relaxed">We use a NodeEntity spine with specific facet tables (TaskFacet, NoteFacet) to keep the database schema clean and typed, avoiding massive nullable rows.</p>
-</div>
-</div>
-</section>
-</div>
-</div>
-
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-16">
+      <!-- Main Content Area -->
+      <div class="col-span-12 lg:col-span-8 space-y-32">
+        <h1
+          class="font-headline text-5xl font-bold tracking-tight text-on-surface"
+        >
+          Philosophy
+        </h1>
+        <!-- Section I -->
+        <section class="space-y-10" id="neurodivergent-by-design">
+          <div class="flex items-baseline gap-4">
+            <span class="font-mono text-primary text-xl">I.</span>
+            <h2 class="font-headline text-5xl font-bold tracking-tight">
+              Neurodivergent by Design
+            </h2>
+          </div>
+          <div
+            class="prose prose-invert max-w-none space-y-6 text-on-surface-variant leading-relaxed text-lg"
+          >
+            <p>
+              TajsOS is a local-first personal operating system for life,
+              projects, thoughts, execution, and insight. It is not necessarily
+              just for ADHD brains, but it is designed with neurodivergent
+              brains in mind.
+            </p>
+            <p>
+              Modern interfaces assume a linear mind. They are built on
+              metaphors of filing cabinets, rigid hierarchies, and sequential
+              tasks. But biological cognition is chaotic, associative, and
+              concurrent. We need tools that work the way our brains do.
+            </p>
+          </div>
+        </section>
+        <!-- Section II -->
+        <section class="space-y-10" id="unified-system">
+          <div class="flex items-baseline gap-4">
+            <span class="font-mono text-primary text-xl">II.</span>
+            <h2 class="font-headline text-5xl font-bold tracking-tight">
+              A Unified System
+            </h2>
+          </div>
+          <div
+            class="prose prose-invert max-w-none space-y-6 text-on-surface-variant leading-relaxed text-lg"
+          >
+            <p>
+              Instead of splitting everything into isolated tools, TajsOS tries
+              to make them work as one system. The app is built around a small
+              set of shared life objects that can still stay connected.
+            </p>
+            <p>
+              The core model connects Inbox captures, Tasks, Notes, Records,
+              Projects, and Areas into a single semantic mesh. The value is in
+              the connections between these nodes, creating a true external
+              pre-frontal cortex.
+            </p>
+          </div>
+        </section>
+        <!-- Section III -->
+        <section class="space-y-10" id="local-persistence">
+          <div class="flex items-baseline gap-4">
+            <span class="font-mono text-primary text-xl">III.</span>
+            <h2 class="font-headline text-5xl font-bold tracking-tight">
+              Local Persistence
+            </h2>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <div
+              class="p-8 bg-surface-container-low rounded-3xl border border-outline-variant/10"
+            >
+              <h3 class="font-headline text-xl font-bold mb-4 text-on-surface">
+                Offline by Default
+              </h3>
+              <p class="text-on-surface-variant text-sm leading-relaxed">
+                Your data lives on your device first. No internet connection is
+                required to capture a thought or execute a task. Sync is an
+                enhancement, not a requirement.
+              </p>
+            </div>
+            <div
+              class="p-8 bg-surface-container-low rounded-3xl border border-outline-variant/10"
+            >
+              <h3 class="font-headline text-xl font-bold mb-4 text-on-surface">
+                Typed Companion Tables
+              </h3>
+              <p class="text-on-surface-variant text-sm leading-relaxed">
+                We use a NodeEntity spine with specific facet tables (TaskFacet,
+                NoteFacet) to keep the database schema clean and typed, avoiding
+                massive nullable rows.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -1,216 +1,372 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
 
 const title = "PRICING";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
-  
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
+
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
-    
-<!-- Hero Section -->
-<section class="mb-24 relative">
-<div class="absolute -top-24 -left-24 w-96 h-96 bg-primary/10 rounded-full"></div>
-<div class="relative z-10 flex flex-col md:flex-row md:items-end justify-between gap-8">
-<div class="max-w-3xl">
-<div class="inline-block py-1 px-3 mb-6 border border-primary/20 bg-primary/5 rounded-full">
-<span class="font-label text-xs uppercase tracking-[0.2em] text-primary font-bold">Billing Architecture v2.0</span>
-</div>
-<h1 class="text-6xl md:text-8xl font-headline font-bold tracking-tighter leading-none mb-8">
-                        PRICING // <span class="text-primary text-glow">PROTOCOL</span>
-</h1>
-</div>
-<div class="md:w-1/3 pb-4">
-<p class="text-on-surface-variant font-mono text-sm leading-relaxed border-l border-outline-variant pl-6">
-                        &gt; SYSTEM_NOTE: ACCESS TO TAJSOS NEURAL INTERFACE IS TIERED BASED ON SYNAPTIC BANDWIDTH REQUIREMENTS. SELECT YOUR PROTOCOL BELOW.
-                    </p>
-</div>
-</div>
-</section>
-<!-- Pricing Cards -->
-<div class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-32">
-<!-- Tier 1: Initiate -->
-<div class="bg-surface-container-low glow-hover p-8 rounded-3xl flex flex-col transition-all duration-500">
-<div class="flex justify-between items-start mb-12">
-<div>
-<h3 class="font-headline text-2xl font-bold uppercase tracking-tight mb-2">Initiate</h3>
-<p class="text-on-surface-variant text-sm">Base Layer Access</p>
-</div>
-<span class="material-symbols-outlined text-primary-dim text-3xl">token</span>
-</div>
-<div class="mb-12">
-<div class="flex items-baseline gap-2">
-<span class="text-5xl font-headline font-bold text-on-surface">$0</span>
-<span class="text-on-surface-variant font-mono text-xs uppercase tracking-widest">/ Perpetual</span>
-</div>
-</div>
-<ul class="space-y-4 mb-12 flex-grow">
-<li class="flex items-center gap-3 text-sm">
-<span class="material-symbols-outlined text-primary text-sm">check_circle</span>
-<span>Basic Neural Capture</span>
-</li>
-<li class="flex items-center gap-3 text-sm">
-<span class="material-symbols-outlined text-primary text-sm">check_circle</span>
-<span>Today's Payload Sync</span>
-</li>
-<li class="flex items-center gap-3 text-sm text-on-surface-variant/50">
-<span class="material-symbols-outlined text-sm">block</span>
-<span class="line-through">Pattern Tracking</span>
-</li>
-</ul>
-<button  class="w-full py-4 bg-surface-container-highest text-on-surface hover:bg-surface-container-low font-label font-bold uppercase tracking-widest text-xs rounded-lg transition-all min-h-[48px]">Select Protocol</button>
-</div>
-<!-- Tier 2: Synapse (Featured) -->
-<div class="relative bg-surface-container-highest glow-hover p-8 rounded-3xl flex flex-col transition-all duration-500">
-<div class="absolute -top-4 left-1/2 -translate-x-1/2 bg-primary text-on-primary-fixed px-4 py-1 rounded-full text-[10px] font-bold uppercase tracking-widest">Recommended</div>
-<div class="flex justify-between items-start mb-12">
-<div>
-<h3 class="font-headline text-2xl font-bold uppercase tracking-tight mb-2 text-primary text-glow">Synapse</h3>
-<p class="text-on-surface-variant text-sm">Dynamic Neural Expansion</p>
-</div>
-<span class="material-symbols-outlined text-primary text-3xl" style="font-variation-settings: 'FILL' 1;">psychology</span>
-</div>
-<div class="mb-12">
-<div class="flex items-baseline gap-2">
-<span class="text-5xl font-headline font-bold text-on-surface">$24</span>
-<span class="text-on-surface-variant font-mono text-xs uppercase tracking-widest">/ Monthly Cycle</span>
-</div>
-</div>
-<ul class="space-y-4 mb-12 flex-grow">
-<li class="flex items-center gap-3 text-sm">
-<span class="material-symbols-outlined text-primary text-sm">check_circle</span>
-<span>Advanced Focus Mode</span>
-</li>
-<li class="flex items-center gap-3 text-sm">
-<span class="material-symbols-outlined text-primary text-sm">check_circle</span>
-<span>Pattern Tracking &amp; Analysis</span>
-</li>
-<li class="flex items-center gap-3 text-sm">
-<span class="material-symbols-outlined text-primary text-sm">check_circle</span>
-<span>Multi-Kernel Synchronization</span>
-</li>
-</ul>
-<button  class="w-full py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-label font-bold uppercase tracking-widest text-xs rounded-lg shadow-[0_0_50px_rgba(186,158,255,0.3)] hover:shadow-[0_0_60px_rgba(186,158,255,0.5)] transition-all min-h-[48px]">Inject Protocol</button>
-</div>
-<!-- Tier 3: Transcend -->
-<div class="bg-surface-container-low glow-hover p-8 rounded-3xl flex flex-col transition-all duration-500">
-<div class="flex justify-between items-start mb-12">
-<div>
-<h3 class="font-headline text-2xl font-bold uppercase tracking-tight mb-2">Transcend</h3>
-<p class="text-on-surface-variant text-sm">Absolute Interface Unity</p>
-</div>
-<span class="material-symbols-outlined text-primary-dim text-3xl">all_inclusive</span>
-</div>
-<div class="mb-12">
-<div class="flex items-baseline gap-2">
-<span class="text-5xl font-headline font-bold text-on-surface">$599</span>
-<span class="text-on-surface-variant font-mono text-xs uppercase tracking-widest">/ Lifetime Link</span>
-</div>
-</div>
-<ul class="space-y-4 mb-12 flex-grow">
-<li class="flex items-center gap-3 text-sm">
-<span class="material-symbols-outlined text-primary text-sm">check_circle</span>
-<span>Priority Neural Linkage</span>
-</li>
-<li class="flex items-center gap-3 text-sm">
-<span class="material-symbols-outlined text-primary text-sm">check_circle</span>
-<span>Early Alpha Module Access</span>
-</li>
-<li class="flex items-center gap-3 text-sm">
-<span class="material-symbols-outlined text-primary text-sm">check_circle</span>
-<span>White-Glove Tech Support</span>
-</li>
-</ul>
-<button  class="w-full py-4 bg-surface-container-highest text-on-surface hover:bg-surface-container-low font-label font-bold uppercase tracking-widest text-xs rounded-lg transition-all min-h-[48px]">Secure Lifetime</button>
-</div>
-</div>
-<!-- Feature Comparison Table -->
-<section class="mb-32 overflow-hidden">
-<h2 class="font-headline text-4xl font-bold mb-12 tracking-tight">FEATURE // <span class="text-primary-dim">COMPARISON</span></h2>
-<div class="bg-surface-container-low rounded-3xl overflow-x-auto">
-<table class="w-full border-collapse text-left font-mono">
-<thead>
-<tr class="border-b border-outline-variant">
-<th class="p-8 text-on-surface-variant text-xs uppercase tracking-widest">Specification</th>
-<th class="p-8 text-on-surface text-sm font-headline">Initiate</th>
-<th class="p-8 text-primary text-sm font-headline">Synapse</th>
-<th class="p-8 text-on-surface text-sm font-headline">Transcend</th>
-</tr>
-</thead>
-<tbody class="text-sm">
-<tr class="border-b border-outline-variant/30 hover:bg-surface-container-high transition-colors">
-<td class="p-8 text-on-surface-variant">Synaptic Bandwidth</td>
-<td class="p-8">128 GB</td>
-<td class="p-8 text-primary">2.5 TB</td>
-<td class="p-8">Unlimited</td>
-</tr>
-<tr class="border-b border-outline-variant/30 hover:bg-surface-container-high transition-colors">
-<td class="p-8 text-on-surface-variant">Focus Mode Pulse</td>
-<td class="p-8">None</td>
-<td class="p-8 text-primary">15min Bursts</td>
-<td class="p-8">Continuous</td>
-</tr>
-<tr class="border-b border-outline-variant/30 hover:bg-surface-container-high transition-colors">
-<td class="p-8 text-on-surface-variant">Neural Patterning</td>
-<td class="p-8"><span class="material-symbols-outlined text-error opacity-40">close</span></td>
-<td class="p-8 text-primary"><span class="material-symbols-outlined">check_circle</span></td>
-<td class="p-8"><span class="material-symbols-outlined">check_circle</span></td>
-</tr>
-<tr class="border-b border-outline-variant/30 hover:bg-surface-container-high transition-colors">
-<td class="p-8 text-on-surface-variant">API Integration</td>
-<td class="p-8">Restricted</td>
-<td class="p-8 text-primary">Full REST</td>
-<td class="p-8">GQL + Webhooks</td>
-</tr>
-<tr class="hover:bg-surface-container-high transition-colors">
-<td class="p-8 text-on-surface-variant">System Response</td>
-<td class="p-8">Standard</td>
-<td class="p-8 text-primary">Accelerated</td>
-<td class="p-8">Instant</td>
-</tr>
-</tbody>
-</table>
-</div>
-</section>
-<!-- FAQ Section -->
-<section class="max-w-4xl">
-<h2 class="font-headline text-4xl font-bold mb-12 tracking-tight">PROTOCOL // <span class="text-primary-dim">FAQ</span></h2>
-<div class="space-y-4">
-<details class="group glass-panel rounded-3xl overflow-hidden border-transparent">
-<summary class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors">
-<span class="font-label text-sm font-medium tracking-tight">How secure is my neural data payload?</span>
-<span class="material-symbols-outlined group-open:rotate-180 transition-transform">expand_more</span>
-</summary>
-<div class="p-6 pt-0 text-on-surface-variant text-sm leading-relaxed font-mono">
-                        TajsOS employs end-to-end polymorphic encryption. Your data is fragmented across decentralized nodes; only your private neural key can reconstruct the interface.
-                    </div>
-</details>
-<details class="group glass-panel rounded-3xl overflow-hidden border-transparent">
-<summary class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors">
-<span class="font-label text-sm font-medium tracking-tight">Can I downgrade my subscription tier?</span>
-<span class="material-symbols-outlined group-open:rotate-180 transition-transform">expand_more</span>
-</summary>
-<div class="p-6 pt-0 text-on-surface-variant text-sm leading-relaxed font-mono">
-                        Downgrades take effect at the end of the current billing cycle. Data overages will be archived but inaccessible until the tier is restored.
-                    </div>
-</details>
-<details class="group glass-panel rounded-3xl overflow-hidden border-transparent">
-<summary class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors">
-<span class="font-label text-sm font-medium tracking-tight">What happens if my neural link fails?</span>
-<span class="material-symbols-outlined group-open:rotate-180 transition-transform">expand_more</span>
-</summary>
-<div class="p-6 pt-0 text-on-surface-variant text-sm leading-relaxed font-mono">
-                        Our emergency fallback protocol ensures no data loss. Local cache will synchronize immediately upon re-establishing the kernel connection.
-                    </div>
-</details>
-</div>
-</section>
-
+    <!-- Hero Section -->
+    <section class="mb-24 relative">
+      <div
+        class="absolute -top-24 -left-24 w-96 h-96 bg-primary/10 rounded-full"
+      >
+      </div>
+      <div
+        class="relative z-10 flex flex-col md:flex-row md:items-end justify-between gap-8"
+      >
+        <div class="max-w-3xl">
+          <div
+            class="inline-block py-1 px-3 mb-6 border border-primary/20 bg-primary/5 rounded-full"
+          >
+            <span
+              class="font-label text-xs uppercase tracking-[0.2em] text-primary font-bold"
+              >Billing Architecture v2.0</span
+            >
+          </div>
+          <h1
+            class="text-6xl md:text-8xl font-headline font-bold tracking-tighter leading-none mb-8"
+          >
+            PRICING // <span class="text-primary text-glow">PROTOCOL</span>
+          </h1>
+        </div>
+        <div class="md:w-1/3 pb-4">
+          <p
+            class="text-on-surface-variant font-mono text-sm leading-relaxed border-l border-outline-variant pl-6"
+          >
+            &gt; SYSTEM_NOTE: ACCESS TO TAJSOS NEURAL INTERFACE IS TIERED BASED
+            ON SYNAPTIC BANDWIDTH REQUIREMENTS. SELECT YOUR PROTOCOL BELOW.
+          </p>
+        </div>
+      </div>
+    </section>
+    <!-- Pricing Cards -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-32">
+      <!-- Tier 1: Initiate -->
+      <div
+        class="bg-surface-container-low glow-hover p-8 rounded-3xl flex flex-col transition-all duration-500"
+      >
+        <div class="flex justify-between items-start mb-12">
+          <div>
+            <h3
+              class="font-headline text-2xl font-bold uppercase tracking-tight mb-2"
+            >
+              Initiate
+            </h3>
+            <p class="text-on-surface-variant text-sm">Base Layer Access</p>
+          </div>
+          <span class="material-symbols-outlined text-primary-dim text-3xl"
+            >token</span
+          >
+        </div>
+        <div class="mb-12">
+          <div class="flex items-baseline gap-2">
+            <span class="text-5xl font-headline font-bold text-on-surface"
+              >$0</span
+            >
+            <span
+              class="text-on-surface-variant font-mono text-xs uppercase tracking-widest"
+              >/ Perpetual</span
+            >
+          </div>
+        </div>
+        <ul class="space-y-4 mb-12 flex-grow">
+          <li class="flex items-center gap-3 text-sm">
+            <span class="material-symbols-outlined text-primary text-sm"
+              >check_circle</span
+            >
+            <span>Basic Neural Capture</span>
+          </li>
+          <li class="flex items-center gap-3 text-sm">
+            <span class="material-symbols-outlined text-primary text-sm"
+              >check_circle</span
+            >
+            <span>Today's Payload Sync</span>
+          </li>
+          <li
+            class="flex items-center gap-3 text-sm text-on-surface-variant/50"
+          >
+            <span class="material-symbols-outlined text-sm">block</span>
+            <span class="line-through">Pattern Tracking</span>
+          </li>
+        </ul>
+        <button
+          class="w-full py-4 bg-surface-container-highest text-on-surface hover:bg-surface-container-low font-label font-bold uppercase tracking-widest text-xs rounded-lg transition-all min-h-[48px]"
+          >Select Protocol</button
+        >
+      </div>
+      <!-- Tier 2: Synapse (Featured) -->
+      <div
+        class="relative bg-surface-container-highest glow-hover p-8 rounded-3xl flex flex-col transition-all duration-500"
+      >
+        <div
+          class="absolute -top-4 left-1/2 -translate-x-1/2 bg-primary text-on-primary-fixed px-4 py-1 rounded-full text-[10px] font-bold uppercase tracking-widest"
+        >
+          Recommended
+        </div>
+        <div class="flex justify-between items-start mb-12">
+          <div>
+            <h3
+              class="font-headline text-2xl font-bold uppercase tracking-tight mb-2 text-primary text-glow"
+            >
+              Synapse
+            </h3>
+            <p class="text-on-surface-variant text-sm">
+              Dynamic Neural Expansion
+            </p>
+          </div>
+          <span
+            class="material-symbols-outlined text-primary text-3xl"
+            style="font-variation-settings: 'FILL' 1;">psychology</span
+          >
+        </div>
+        <div class="mb-12">
+          <div class="flex items-baseline gap-2">
+            <span class="text-5xl font-headline font-bold text-on-surface"
+              >$24</span
+            >
+            <span
+              class="text-on-surface-variant font-mono text-xs uppercase tracking-widest"
+              >/ Monthly Cycle</span
+            >
+          </div>
+        </div>
+        <ul class="space-y-4 mb-12 flex-grow">
+          <li class="flex items-center gap-3 text-sm">
+            <span class="material-symbols-outlined text-primary text-sm"
+              >check_circle</span
+            >
+            <span>Advanced Focus Mode</span>
+          </li>
+          <li class="flex items-center gap-3 text-sm">
+            <span class="material-symbols-outlined text-primary text-sm"
+              >check_circle</span
+            >
+            <span>Pattern Tracking &amp; Analysis</span>
+          </li>
+          <li class="flex items-center gap-3 text-sm">
+            <span class="material-symbols-outlined text-primary text-sm"
+              >check_circle</span
+            >
+            <span>Multi-Kernel Synchronization</span>
+          </li>
+        </ul>
+        <button
+          class="w-full py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-label font-bold uppercase tracking-widest text-xs rounded-lg shadow-[0_0_50px_rgba(186,158,255,0.3)] hover:shadow-[0_0_60px_rgba(186,158,255,0.5)] transition-all min-h-[48px]"
+          >Inject Protocol</button
+        >
+      </div>
+      <!-- Tier 3: Transcend -->
+      <div
+        class="bg-surface-container-low glow-hover p-8 rounded-3xl flex flex-col transition-all duration-500"
+      >
+        <div class="flex justify-between items-start mb-12">
+          <div>
+            <h3
+              class="font-headline text-2xl font-bold uppercase tracking-tight mb-2"
+            >
+              Transcend
+            </h3>
+            <p class="text-on-surface-variant text-sm">
+              Absolute Interface Unity
+            </p>
+          </div>
+          <span class="material-symbols-outlined text-primary-dim text-3xl"
+            >all_inclusive</span
+          >
+        </div>
+        <div class="mb-12">
+          <div class="flex items-baseline gap-2">
+            <span class="text-5xl font-headline font-bold text-on-surface"
+              >$599</span
+            >
+            <span
+              class="text-on-surface-variant font-mono text-xs uppercase tracking-widest"
+              >/ Lifetime Link</span
+            >
+          </div>
+        </div>
+        <ul class="space-y-4 mb-12 flex-grow">
+          <li class="flex items-center gap-3 text-sm">
+            <span class="material-symbols-outlined text-primary text-sm"
+              >check_circle</span
+            >
+            <span>Priority Neural Linkage</span>
+          </li>
+          <li class="flex items-center gap-3 text-sm">
+            <span class="material-symbols-outlined text-primary text-sm"
+              >check_circle</span
+            >
+            <span>Early Alpha Module Access</span>
+          </li>
+          <li class="flex items-center gap-3 text-sm">
+            <span class="material-symbols-outlined text-primary text-sm"
+              >check_circle</span
+            >
+            <span>White-Glove Tech Support</span>
+          </li>
+        </ul>
+        <button
+          class="w-full py-4 bg-surface-container-highest text-on-surface hover:bg-surface-container-low font-label font-bold uppercase tracking-widest text-xs rounded-lg transition-all min-h-[48px]"
+          >Secure Lifetime</button
+        >
+      </div>
+    </div>
+    <!-- Feature Comparison Table -->
+    <section class="mb-32 overflow-hidden">
+      <h2 class="font-headline text-4xl font-bold mb-12 tracking-tight">
+        FEATURE // <span class="text-primary-dim">COMPARISON</span>
+      </h2>
+      <div class="bg-surface-container-low rounded-3xl overflow-x-auto">
+        <table class="w-full border-collapse text-left font-mono">
+          <thead>
+            <tr class="border-b border-outline-variant">
+              <th
+                class="p-8 text-on-surface-variant text-xs uppercase tracking-widest"
+                >Specification</th
+              >
+              <th class="p-8 text-on-surface text-sm font-headline">Initiate</th
+              >
+              <th class="p-8 text-primary text-sm font-headline">Synapse</th>
+              <th class="p-8 text-on-surface text-sm font-headline"
+                >Transcend</th
+              >
+            </tr>
+          </thead>
+          <tbody class="text-sm">
+            <tr
+              class="border-b border-outline-variant/30 hover:bg-surface-container-high transition-colors"
+            >
+              <td class="p-8 text-on-surface-variant">Synaptic Bandwidth</td>
+              <td class="p-8">128 GB</td>
+              <td class="p-8 text-primary">2.5 TB</td>
+              <td class="p-8">Unlimited</td>
+            </tr>
+            <tr
+              class="border-b border-outline-variant/30 hover:bg-surface-container-high transition-colors"
+            >
+              <td class="p-8 text-on-surface-variant">Focus Mode Pulse</td>
+              <td class="p-8">None</td>
+              <td class="p-8 text-primary">15min Bursts</td>
+              <td class="p-8">Continuous</td>
+            </tr>
+            <tr
+              class="border-b border-outline-variant/30 hover:bg-surface-container-high transition-colors"
+            >
+              <td class="p-8 text-on-surface-variant">Neural Patterning</td>
+              <td class="p-8"
+                ><span class="material-symbols-outlined text-error opacity-40"
+                  >close</span
+                ></td
+              >
+              <td class="p-8 text-primary"
+                ><span class="material-symbols-outlined">check_circle</span></td
+              >
+              <td class="p-8"
+                ><span class="material-symbols-outlined">check_circle</span></td
+              >
+            </tr>
+            <tr
+              class="border-b border-outline-variant/30 hover:bg-surface-container-high transition-colors"
+            >
+              <td class="p-8 text-on-surface-variant">API Integration</td>
+              <td class="p-8">Restricted</td>
+              <td class="p-8 text-primary">Full REST</td>
+              <td class="p-8">GQL + Webhooks</td>
+            </tr>
+            <tr class="hover:bg-surface-container-high transition-colors">
+              <td class="p-8 text-on-surface-variant">System Response</td>
+              <td class="p-8">Standard</td>
+              <td class="p-8 text-primary">Accelerated</td>
+              <td class="p-8">Instant</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <!-- FAQ Section -->
+    <section class="max-w-4xl">
+      <h2 class="font-headline text-4xl font-bold mb-12 tracking-tight">
+        PROTOCOL // <span class="text-primary-dim">FAQ</span>
+      </h2>
+      <div class="space-y-4">
+        <details
+          class="group glass-panel rounded-3xl overflow-hidden border-transparent"
+        >
+          <summary
+            class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors"
+          >
+            <span class="font-label text-sm font-medium tracking-tight"
+              >How secure is my neural data payload?</span
+            >
+            <span
+              class="material-symbols-outlined group-open:rotate-180 transition-transform"
+              >expand_more</span
+            >
+          </summary>
+          <div
+            class="p-6 pt-0 text-on-surface-variant text-sm leading-relaxed font-mono"
+          >
+            TajsOS employs end-to-end polymorphic encryption. Your data is
+            fragmented across decentralized nodes; only your private neural key
+            can reconstruct the interface.
+          </div>
+        </details>
+        <details
+          class="group glass-panel rounded-3xl overflow-hidden border-transparent"
+        >
+          <summary
+            class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors"
+          >
+            <span class="font-label text-sm font-medium tracking-tight"
+              >Can I downgrade my subscription tier?</span
+            >
+            <span
+              class="material-symbols-outlined group-open:rotate-180 transition-transform"
+              >expand_more</span
+            >
+          </summary>
+          <div
+            class="p-6 pt-0 text-on-surface-variant text-sm leading-relaxed font-mono"
+          >
+            Downgrades take effect at the end of the current billing cycle. Data
+            overages will be archived but inaccessible until the tier is
+            restored.
+          </div>
+        </details>
+        <details
+          class="group glass-panel rounded-3xl overflow-hidden border-transparent"
+        >
+          <summary
+            class="flex items-center justify-between p-6 cursor-pointer hover:bg-surface-container-high transition-colors"
+          >
+            <span class="font-label text-sm font-medium tracking-tight"
+              >What happens if my neural link fails?</span
+            >
+            <span
+              class="material-symbols-outlined group-open:rotate-180 transition-transform"
+              >expand_more</span
+            >
+          </summary>
+          <div
+            class="p-6 pt-0 text-on-surface-variant text-sm leading-relaxed font-mono"
+          >
+            Our emergency fallback protocol ensures no data loss. Local cache
+            will synchronize immediately upon re-establishing the kernel
+            connection.
+          </div>
+        </details>
+      </div>
+    </section>
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -1,172 +1,293 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
 
 const title = "PRIVACY";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
-  
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
+
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
-    
-<!-- Hero Section: Neo-Editorial Asymmetry -->
-<section class="mb-32">
-<div class="flex flex-col lg:flex-row items-end justify-between gap-12">
-<div class="w-full lg:w-2/3">
-<p class="font-label text-primary uppercase tracking-[0.4em] text-sm mb-4">PROTOCOL V4.0.2 // ESTABLISHED</p>
-<h1 class="font-headline font-bold text-7xl md:text-9xl leading-[0.9] tracking-tighter neon-glow">
-                        PRIVACY // <br/> <span class="text-primary-dim">PROTOCOL</span>
-</h1>
-</div>
-<div class="w-full lg:w-1/3 border-l border-outline-variant/30 pl-8 pb-4">
-<p class="font-mono text-xs text-on-surface-variant mb-4 uppercase tracking-widest">System_Log: Decryption_Active</p>
-<p class="text-lg font-light text-on-surface-variant leading-relaxed italic">
-                        "The human mind is the final frontier of data sovereignty. We don't just protect your files; we isolate your consciousness from the noise of the centralized web."
-                    </p>
-</div>
-</div>
-</section>
-<!-- Bento Grid Policy Sections -->
-<section class="grid grid-cols-1 md:grid-cols-12 gap-6 mb-32">
-<!-- Data Encryption Large Card -->
-<div class="md:col-span-8 glass-panel rounded-3xl p-8 border border-outline-variant/10 relative overflow-hidden group">
-<div class="absolute top-0 right-0 p-4 font-mono text-[10px] text-primary/40 uppercase tracking-tighter">Cipher: 0x8F22A</div>
-<div class="mb-12">
-<span class="material-symbols-outlined text-primary text-4xl mb-6" data-icon="lock" style="font-variation-settings: 'FILL' 1;">lock</span>
-<h2 class="font-headline text-4xl font-bold tracking-tight mb-4">Data Encryption</h2>
-<p class="text-on-surface-variant max-w-xl leading-relaxed">
-                        Every bit of data passing through the TajsOS kernel is wrapped in <span class="text-on-surface font-mono">AES-256-GCM</span> hardware-level encryption. Your keys are generated in a secure enclave, never touching the persistent storage layer until authorized by your neural signature.
-                    </p>
-</div>
-<div class="flex flex-wrap gap-4 mt-auto">
-<div class="bg-surface-container-highest px-4 py-2 rounded-lg border border-outline-variant/20 flex items-center gap-3">
-<div class="w-2 h-2 rounded-full bg-primary animate-pulse"></div>
-<span class="font-mono text-xs uppercase">ENCRYPTION: ACTIVE</span>
-</div>
-<div class="bg-surface-container-highest px-4 py-2 rounded-lg border border-outline-variant/20">
-<span class="font-mono text-xs uppercase text-on-surface-variant">Standard: FIPS 140-2</span>
-</div>
-</div>
-<div class="absolute -bottom-10 -right-10 opacity-5 pointer-events-none">
-<span class="material-symbols-outlined text-[20rem]" data-icon="security">security</span>
-</div>
-</div>
-<!-- Neural Sovereignty Card -->
-<div class="md:col-span-4 bg-primary-dim rounded-xl p-8 flex flex-col justify-between text-on-primary-fixed relative overflow-hidden">
-<div class="relative z-10">
-<h2 class="font-headline text-3xl font-bold tracking-tight mb-4">Neural Sovereignty</h2>
-<p class="text-on-primary-fixed/80 text-sm leading-relaxed">
-                        Your neural mapping data remains strictly local. We utilize federated learning paradigms that ensure "Intelligence stays, Data goes nowhere."
-                    </p>
-</div>
-<div class="mt-8 relative z-10">
-<div class="font-mono text-[10px] uppercase mb-2">Sovereignty Status</div>
-<div class="text-xl font-headline font-bold uppercase tracking-tighter">Verified Local</div>
-</div>
-<!-- Background visual noise -->
-<div class="absolute inset-0 opacity-20 pointer-events-none mix-blend-overlay">
-<img class="w-full h-full object-cover" data-alt="Abstract neural network visual pattern" src="https://lh3.googleusercontent.com/aida-public/AB6AXuDyv0q6wIQmu1iQP0IOvx58GvLx31H4alSvKOhU1A_NDqJnwuohXZoUxk6Xi1DBBJBNHe2cEkYmMHsIL8Ajs7meHiwpXZGBaX0d2P0MD4u9_Za14BX1oaM7Qv_gWSJy9OeozDTP8M6UVCm_clKbfcazMZ4o-c7m1ZK0qLoC1rV-RCk25N_Q1JiPvOC1VmFJvjYWWbit4n_qnoCnV_EYY6JuvKdTcrwTGLfG1jKtH3wquZhlNo-3OHObFdmCaI4aMRc-nY7V0_lwb9w"/>
-</div>
-</div>
-<!-- Zero-Knowledge Sync -->
-<div class="md:col-span-6 bg-surface-container-low rounded-3xl p-8 border border-transparent group hover:border-primary/30 transition-colors">
-<div class="flex items-start justify-between mb-8">
-<div class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary border border-outline-variant/20">
-<span class="material-symbols-outlined" data-icon="sync_saved_locally">sync_saved_locally</span>
-</div>
-<span class="font-mono text-[10px] text-on-surface-variant">SYNC_ID: 1024-ALPHA</span>
-</div>
-<h3 class="font-headline text-2xl font-bold mb-3">Zero-Knowledge Sync</h3>
-<p class="text-on-surface-variant text-sm leading-relaxed mb-6">
-                    Multi-device synchronization is achieved through end-to-end encrypted tunnels. TajsOS nodes never see your content—only the encrypted blobs move between your authorized devices.
-                </p>
-<button  class="font-label text-xs uppercase tracking-widest text-primary flex items-center gap-2 group-hover:gap-4 transition-all min-h-[48px]">
-                    Review Protocol <span class="material-symbols-outlined text-sm" data-icon="arrow_forward">arrow_forward</span>
-</button>
-</div>
-<!-- Retention Policy -->
-<div class="md:col-span-6 glass-panel rounded-3xl p-8 border border-outline-variant/10 overflow-hidden relative">
-<div class="flex items-start gap-6">
-<div class="flex-1">
-<h3 class="font-headline text-2xl font-bold mb-3">Retention Policy</h3>
-<p class="text-on-surface-variant text-sm leading-relaxed mb-4">
-                            Ephemeral by default. Metadata is purged every 24 cycles unless pinned to your long-term neural memory. We don't build profiles; we facilitate experiences.
-                        </p>
-<div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-<div class="bg-surface-container-high rounded-3xl p-4">
-<div class="text-xs font-mono text-on-surface-variant uppercase">Default State</div>
-<div class="font-headline font-bold uppercase">Ephemeral</div>
-</div>
-<div class="bg-surface-container-high rounded-3xl p-4">
-<div class="text-xs font-mono text-on-surface-variant uppercase">Purge Cycle</div>
-<div class="font-headline font-bold uppercase">24 Hours</div>
-</div>
-</div>
-</div>
-<div class="hidden sm:block">
-<span class="material-symbols-outlined text-6xl text-outline-variant/20" data-icon="delete_sweep">delete_sweep</span>
-</div>
-</div>
-</div>
-</section>
-<!-- Technical Metadata Overlay Section -->
-<section class="mb-32">
-<div class="bg-surface-container-lowest border border-outline-variant/20 rounded-3xl overflow-hidden">
-<div class="bg-surface-container-high px-6 py-3 flex items-center justify-between border-b border-outline-variant/20">
-<div class="flex gap-2">
-<div class="w-2.5 h-2.5 rounded-full bg-error/40"></div>
-<div class="w-2.5 h-2.5 rounded-full bg-primary/40"></div>
-<div class="w-2.5 h-2.5 rounded-full bg-surface-variant"></div>
-</div>
-<div class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest">Protocol_Inspector_V1.0</div>
-</div>
-<div class="p-8 font-mono text-sm overflow-x-auto">
-<div class="flex gap-8 mb-4 opacity-60">
-<span>[0.0034s] Initializing_Interface...</span>
-<span class="text-primary">OK</span>
-</div>
-<div class="flex gap-8 mb-4 opacity-60">
-<span>[0.0081s] Loading_Security_Manifest...</span>
-<span class="text-primary">OK</span>
-</div>
-<div class="mb-6">
-<span class="text-primary-dim">ROOT@TajsOS:</span><span class="text-on-surface"> ~ # cat /etc/privacy-manifest.json</span>
-</div>
-<div class="text-on-surface-variant leading-relaxed">
-                        &#123;<br/>
-                          "identity": "pseudonymous",<br/>
-                          "tracking": false,<br/>
-                          "telemetry": "opt-out-permanent",<br/>
-                          "encryption_layer": "XChaCha20-Poly1305",<br/>
-                          "node_integrity": "verified",<br/>
-                          "neural_lock": "enabled"<br/>
-                        &#125;
-                    </div>
-<div class="mt-6 flex items-center gap-2">
-<span class="text-primary-dim animate-pulse">_</span>
-<span class="text-on-surface-variant italic">// System standing by for user override</span>
-</div>
-</div>
-</div>
-</section>
-<!-- CTA / Footer Transition Section -->
-<div class="w-full h-[1px] bg-outline-variant/10"></div>
-<section class="text-center py-20">
-<h2 class="font-headline text-5xl font-bold mb-8">Ready to reclaim your <span class="text-primary">digital ghost?</span></h2>
-<div class="flex flex-col sm:flex-row justify-center gap-6">
-<button  class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold py-4 px-10 rounded-xl hover:scale-105 transition-transform duration-300 flex items-center gap-3 mx-auto sm:mx-0 min-h-[48px]">
-                    INITIALIZE INTERFACE <span class="material-symbols-outlined" data-icon="bolt">bolt</span>
-</button>
-<button  class="bg-surface-container-highest text-on-surface font-headline font-bold py-4 px-10 rounded-lg border border-outline-variant/30 hover:bg-surface-container-high transition-colors mx-auto sm:mx-0 min-h-[48px]">
-                    READ THE WHITE PAPER
-                </button>
-</div>
-</section>
-
+    <!-- Hero Section: Neo-Editorial Asymmetry -->
+    <section class="mb-32">
+      <div class="flex flex-col lg:flex-row items-end justify-between gap-12">
+        <div class="w-full lg:w-2/3">
+          <p
+            class="font-label text-primary uppercase tracking-[0.4em] text-sm mb-4"
+          >
+            PROTOCOL V4.0.2 // ESTABLISHED
+          </p>
+          <h1
+            class="font-headline font-bold text-7xl md:text-9xl leading-[0.9] tracking-tighter neon-glow"
+          >
+            PRIVACY // <br />
+            <span class="text-primary-dim">PROTOCOL</span>
+          </h1>
+        </div>
+        <div
+          class="w-full lg:w-1/3 border-l border-outline-variant/30 pl-8 pb-4"
+        >
+          <p
+            class="font-mono text-xs text-on-surface-variant mb-4 uppercase tracking-widest"
+          >
+            System_Log: Decryption_Active
+          </p>
+          <p
+            class="text-lg font-light text-on-surface-variant leading-relaxed italic"
+          >
+            "The human mind is the final frontier of data sovereignty. We don't
+            just protect your files; we isolate your consciousness from the
+            noise of the centralized web."
+          </p>
+        </div>
+      </div>
+    </section>
+    <!-- Bento Grid Policy Sections -->
+    <section class="grid grid-cols-1 md:grid-cols-12 gap-6 mb-32">
+      <!-- Data Encryption Large Card -->
+      <div
+        class="md:col-span-8 glass-panel rounded-3xl p-8 border border-outline-variant/10 relative overflow-hidden group"
+      >
+        <div
+          class="absolute top-0 right-0 p-4 font-mono text-[10px] text-primary/40 uppercase tracking-tighter"
+        >
+          Cipher: 0x8F22A
+        </div>
+        <div class="mb-12">
+          <span
+            class="material-symbols-outlined text-primary text-4xl mb-6"
+            data-icon="lock"
+            style="font-variation-settings: 'FILL' 1;">lock</span
+          >
+          <h2 class="font-headline text-4xl font-bold tracking-tight mb-4">
+            Data Encryption
+          </h2>
+          <p class="text-on-surface-variant max-w-xl leading-relaxed">
+            Every bit of data passing through the TajsOS kernel is wrapped in <span
+              class="text-on-surface font-mono">AES-256-GCM</span
+            > hardware-level encryption. Your keys are generated in a secure enclave,
+            never touching the persistent storage layer until authorized by your neural
+            signature.
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-4 mt-auto">
+          <div
+            class="bg-surface-container-highest px-4 py-2 rounded-lg border border-outline-variant/20 flex items-center gap-3"
+          >
+            <div class="w-2 h-2 rounded-full bg-primary animate-pulse"></div>
+            <span class="font-mono text-xs uppercase">ENCRYPTION: ACTIVE</span>
+          </div>
+          <div
+            class="bg-surface-container-highest px-4 py-2 rounded-lg border border-outline-variant/20"
+          >
+            <span class="font-mono text-xs uppercase text-on-surface-variant"
+              >Standard: FIPS 140-2</span
+            >
+          </div>
+        </div>
+        <div
+          class="absolute -bottom-10 -right-10 opacity-5 pointer-events-none"
+        >
+          <span
+            class="material-symbols-outlined text-[20rem]"
+            data-icon="security">security</span
+          >
+        </div>
+      </div>
+      <!-- Neural Sovereignty Card -->
+      <div
+        class="md:col-span-4 bg-primary-dim rounded-xl p-8 flex flex-col justify-between text-on-primary-fixed relative overflow-hidden"
+      >
+        <div class="relative z-10">
+          <h2 class="font-headline text-3xl font-bold tracking-tight mb-4">
+            Neural Sovereignty
+          </h2>
+          <p class="text-on-primary-fixed/80 text-sm leading-relaxed">
+            Your neural mapping data remains strictly local. We utilize
+            federated learning paradigms that ensure "Intelligence stays, Data
+            goes nowhere."
+          </p>
+        </div>
+        <div class="mt-8 relative z-10">
+          <div class="font-mono text-[10px] uppercase mb-2">
+            Sovereignty Status
+          </div>
+          <div
+            class="text-xl font-headline font-bold uppercase tracking-tighter"
+          >
+            Verified Local
+          </div>
+        </div>
+        <!-- Background visual noise -->
+        <div
+          class="absolute inset-0 opacity-20 pointer-events-none mix-blend-overlay"
+        >
+          <img
+            class="w-full h-full object-cover"
+            data-alt="Abstract neural network visual pattern"
+            src="https://lh3.googleusercontent.com/aida-public/AB6AXuDyv0q6wIQmu1iQP0IOvx58GvLx31H4alSvKOhU1A_NDqJnwuohXZoUxk6Xi1DBBJBNHe2cEkYmMHsIL8Ajs7meHiwpXZGBaX0d2P0MD4u9_Za14BX1oaM7Qv_gWSJy9OeozDTP8M6UVCm_clKbfcazMZ4o-c7m1ZK0qLoC1rV-RCk25N_Q1JiPvOC1VmFJvjYWWbit4n_qnoCnV_EYY6JuvKdTcrwTGLfG1jKtH3wquZhlNo-3OHObFdmCaI4aMRc-nY7V0_lwb9w"
+          />
+        </div>
+      </div>
+      <!-- Zero-Knowledge Sync -->
+      <div
+        class="md:col-span-6 bg-surface-container-low rounded-3xl p-8 border border-transparent group hover:border-primary/30 transition-colors"
+      >
+        <div class="flex items-start justify-between mb-8">
+          <div
+            class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary border border-outline-variant/20"
+          >
+            <span
+              class="material-symbols-outlined"
+              data-icon="sync_saved_locally">sync_saved_locally</span
+            >
+          </div>
+          <span class="font-mono text-[10px] text-on-surface-variant"
+            >SYNC_ID: 1024-ALPHA</span
+          >
+        </div>
+        <h3 class="font-headline text-2xl font-bold mb-3">
+          Zero-Knowledge Sync
+        </h3>
+        <p class="text-on-surface-variant text-sm leading-relaxed mb-6">
+          Multi-device synchronization is achieved through end-to-end encrypted
+          tunnels. TajsOS nodes never see your content—only the encrypted blobs
+          move between your authorized devices.
+        </p>
+        <button
+          class="font-label text-xs uppercase tracking-widest text-primary flex items-center gap-2 group-hover:gap-4 transition-all min-h-[48px]"
+        >
+          Review Protocol <span
+            class="material-symbols-outlined text-sm"
+            data-icon="arrow_forward">arrow_forward</span
+          >
+        </button>
+      </div>
+      <!-- Retention Policy -->
+      <div
+        class="md:col-span-6 glass-panel rounded-3xl p-8 border border-outline-variant/10 overflow-hidden relative"
+      >
+        <div class="flex items-start gap-6">
+          <div class="flex-1">
+            <h3 class="font-headline text-2xl font-bold mb-3">
+              Retention Policy
+            </h3>
+            <p class="text-on-surface-variant text-sm leading-relaxed mb-4">
+              Ephemeral by default. Metadata is purged every 24 cycles unless
+              pinned to your long-term neural memory. We don't build profiles;
+              we facilitate experiences.
+            </p>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+              <div class="bg-surface-container-high rounded-3xl p-4">
+                <div
+                  class="text-xs font-mono text-on-surface-variant uppercase"
+                >
+                  Default State
+                </div>
+                <div class="font-headline font-bold uppercase">Ephemeral</div>
+              </div>
+              <div class="bg-surface-container-high rounded-3xl p-4">
+                <div
+                  class="text-xs font-mono text-on-surface-variant uppercase"
+                >
+                  Purge Cycle
+                </div>
+                <div class="font-headline font-bold uppercase">24 Hours</div>
+              </div>
+            </div>
+          </div>
+          <div class="hidden sm:block">
+            <span
+              class="material-symbols-outlined text-6xl text-outline-variant/20"
+              data-icon="delete_sweep">delete_sweep</span
+            >
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Technical Metadata Overlay Section -->
+    <section class="mb-32">
+      <div
+        class="bg-surface-container-lowest border border-outline-variant/20 rounded-3xl overflow-hidden"
+      >
+        <div
+          class="bg-surface-container-high px-6 py-3 flex items-center justify-between border-b border-outline-variant/20"
+        >
+          <div class="flex gap-2">
+            <div class="w-2.5 h-2.5 rounded-full bg-error/40"></div>
+            <div class="w-2.5 h-2.5 rounded-full bg-primary/40"></div>
+            <div class="w-2.5 h-2.5 rounded-full bg-surface-variant"></div>
+          </div>
+          <div
+            class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest"
+          >
+            Protocol_Inspector_V1.0
+          </div>
+        </div>
+        <div class="p-8 font-mono text-sm overflow-x-auto">
+          <div class="flex gap-8 mb-4 opacity-60">
+            <span>[0.0034s] Initializing_Interface...</span>
+            <span class="text-primary">OK</span>
+          </div>
+          <div class="flex gap-8 mb-4 opacity-60">
+            <span>[0.0081s] Loading_Security_Manifest...</span>
+            <span class="text-primary">OK</span>
+          </div>
+          <div class="mb-6">
+            <span class="text-primary-dim">ROOT@TajsOS:</span><span
+              class="text-on-surface"
+            >
+              ~ # cat /etc/privacy-manifest.json</span
+            >
+          </div>
+          <div class="text-on-surface-variant leading-relaxed">
+            &#123;<br />
+              "identity": "pseudonymous",<br />
+              "tracking": false,<br />
+              "telemetry": "opt-out-permanent",<br />
+              "encryption_layer": "XChaCha20-Poly1305",<br />
+              "node_integrity": "verified",<br />
+              "neural_lock": "enabled"<br />
+            &#125;
+          </div>
+          <div class="mt-6 flex items-center gap-2">
+            <span class="text-primary-dim animate-pulse">_</span>
+            <span class="text-on-surface-variant italic"
+              >// System standing by for user override</span
+            >
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- CTA / Footer Transition Section -->
+    <div class="w-full h-[1px] bg-outline-variant/10"></div>
+    <section class="text-center py-20">
+      <h2 class="font-headline text-5xl font-bold mb-8">
+        Ready to reclaim your <span class="text-primary">digital ghost?</span>
+      </h2>
+      <div class="flex flex-col sm:flex-row justify-center gap-6">
+        <button
+          class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold py-4 px-10 rounded-xl hover:scale-105 transition-transform duration-300 flex items-center gap-3 mx-auto sm:mx-0 min-h-[48px]"
+        >
+          INITIALIZE INTERFACE <span
+            class="material-symbols-outlined"
+            data-icon="bolt">bolt</span
+          >
+        </button>
+        <button
+          class="bg-surface-container-highest text-on-surface font-headline font-bold py-4 px-10 rounded-lg border border-outline-variant/30 hover:bg-surface-container-high transition-colors mx-auto sm:mx-0 min-h-[48px]"
+        >
+          READ THE WHITE PAPER
+        </button>
+      </div>
+    </section>
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/security.astro
+++ b/website/src/pages/security.astro
@@ -1,238 +1,436 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
 
 const title = "SECURITY";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
-  
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
+
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
-    
-<!-- Hero Section -->
-<section class="relative grid grid-cols-1 lg:grid-cols-12 gap-12 items-start">
-<div class="lg:col-span-8">
-<div class="flex items-center gap-3 mb-6">
-<div class="w-2 h-2 rounded-full bg-primary animate-pulse"></div>
-<span class="font-label text-primary text-sm tracking-widest uppercase font-bold">KERNEL: ENCRYPTED</span>
-</div>
-<h1 class="font-headline text-7xl md:text-9xl font-bold tracking-tighter leading-tight mb-8">
-                    SECURITY<br/>
-<span class="gradient-text">ARCHITECTURE</span>
-</h1>
-<p class="font-body text-on-surface-variant text-xl max-w-xl leading-relaxed">
-                    TajsOS implements a zero-trust neural substrate. Every process is isolated within a cryptographic vault, monitored by real-time heuristic analysis.
-                </p>
-</div>
-<div class="lg:col-span-4 self-center">
-<div class="glass-panel p-8 rounded-3xl relative overflow-hidden">
-<div class="absolute top-0 right-0 w-32 h-32 bg-primary/5 rounded-full -mr-16 -mt-16"></div>
-<div class="space-y-6 relative z-10">
-<div class="flex justify-between items-end">
-<span class="font-label text-[10px] text-primary uppercase font-bold">System Integrity</span>
-<span class="font-mono text-xs text-primary">99.98%</span>
-</div>
-<div class="h-1 bg-surface-container-highest rounded-full overflow-hidden">
-<div class="h-full bg-primary w-[99.98%]"></div>
-</div>
-<div class="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4">
-<div class="bg-surface-container-lowest/50 p-4 rounded-lg">
-<span class="block font-label text-[10px] text-on-surface-variant uppercase mb-1">Active Shields</span>
-<span class="font-mono text-lg font-bold">14,209</span>
-</div>
-<div class="bg-surface-container-lowest/50 p-4 rounded-lg">
-<span class="block font-label text-[10px] text-on-surface-variant uppercase mb-1">Threat Level</span>
-<span class="font-mono text-lg font-bold text-primary">ZERO</span>
-</div>
-</div>
-</div>
-</div>
-</div>
-</section>
-<!-- Section 1: Neural Vault -->
-<section class="space-y-12">
-<div class="flex flex-col md:flex-row md:items-end justify-between gap-6 bg-surface-container-low rounded-3xl p-8">
-<div>
-<h2 class="font-headline text-4xl font-bold uppercase tracking-tight mb-2">Neural Vault</h2>
-<p class="font-body text-on-surface-variant max-w-md">Multi-layer volumetric encryption that adapts to usage patterns.</p>
-</div>
-<div class="font-mono text-xs text-primary/40 uppercase tracking-widest">SUBSTRATE-LAYER-01</div>
-</div>
-<div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-<!-- Card 1 -->
-<div class="glass-panel p-1 rounded-2xl group hover:border-primary/40 transition-all duration-500">
-<div class="bg-surface-container-low h-full p-8 rounded-[14px]">
-<div class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-8 text-primary">
-<span class="material-symbols-outlined text-3xl" data-icon="biometric_setup" style="font-variation-settings: 'FILL' 1;">android_fingerprint</span>
-</div>
-<h3 class="font-headline text-xl font-bold mb-4 uppercase">Biometric Mesh</h3>
-<p class="font-body text-on-surface-variant text-sm leading-relaxed mb-8">Continuous behavioral verification using low-latency neural processing to ensure user persistence.</p>
-<div class="flex items-center gap-2 font-mono text-[10px] text-primary">
-<span class="material-symbols-outlined text-sm" data-icon="check_circle">check_circle</span>
-                            ACTIVE
-                        </div>
-</div>
-</div>
-<!-- Card 2 -->
-<div class="glass-panel p-1 rounded-2xl group hover:border-primary/40 transition-all duration-500">
-<div class="bg-surface-container-low h-full p-8 rounded-[14px]">
-<div class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-8 text-primary">
-<span class="material-symbols-outlined text-3xl" data-icon="v_loss" style="font-variation-settings: 'FILL' 1;">water_loss</span>
-</div>
-<h3 class="font-headline text-xl font-bold mb-4 uppercase">Quantum Latency</h3>
-<p class="font-body text-on-surface-variant text-sm leading-relaxed mb-8">Post-quantum cryptographic wrappers protecting long-term data storage against future decryption vectors.</p>
-<div class="flex items-center gap-2 font-mono text-[10px] text-primary">
-<span class="material-symbols-outlined text-sm" data-icon="check_circle">check_circle</span>
-                            ACTIVE
-                        </div>
-</div>
-</div>
-<!-- Card 3 -->
-<div class="glass-panel p-1 rounded-2xl group hover:border-primary/40 transition-all duration-500">
-<div class="bg-surface-container-low h-full p-8 rounded-[14px]">
-<div class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-8 text-primary">
-<span class="material-symbols-outlined text-3xl" data-icon="shield_lock" style="font-variation-settings: 'FILL' 1;">shield_lock</span>
-</div>
-<h3 class="font-headline text-xl font-bold mb-4 uppercase">Kernel Sandboxing</h3>
-<p class="font-body text-on-surface-variant text-sm leading-relaxed mb-8">Immutable process isolation ensures that zero-day exploits cannot propagate beyond the execution thread.</p>
-<div class="flex items-center gap-2 font-mono text-[10px] text-primary">
-<span class="material-symbols-outlined text-sm" data-icon="check_circle">check_circle</span>
-                            ACTIVE
-                        </div>
-</div>
-</div>
-</div>
-</section>
-<!-- Section 2: Real-time Threat Monitoring -->
-<section class="grid grid-cols-1 lg:grid-cols-12 gap-8">
-<div class="lg:col-span-4 flex flex-col justify-center">
-<h2 class="font-headline text-4xl font-bold uppercase tracking-tight mb-4">Threat<br/>Monitoring</h2>
-<p class="font-body text-on-surface-variant mb-8">Active heuristic scanning of all system interrupts. Real-time visualization of packet flows and process entropy.</p>
-<div class="space-y-4">
-<div class="flex items-center justify-between p-4 bg-surface-container-highest rounded-3xl">
-<span class="font-label text-xs uppercase font-bold tracking-widest">Network Flow</span>
-<span class="font-mono text-xs text-primary">NOMINAL</span>
-</div>
-<div class="flex items-center justify-between p-4 bg-surface-container-low rounded-3xl">
-<span class="font-label text-xs uppercase font-bold tracking-widest text-on-surface-variant">Mem-Entropy</span>
-<span class="font-mono text-xs text-on-surface-variant">4.2% STD</span>
-</div>
-</div>
-</div>
-<div class="lg:col-span-8">
-<div class="glass-panel rounded-2xl overflow-hidden">
-<div class="bg-surface-container-highest/50 px-6 py-4 flex justify-between items-center">
-<div class="flex gap-2">
-<div class="w-2 h-2 rounded-full bg-error"></div>
-<div class="w-2 h-2 rounded-full bg-primary/40"></div>
-<div class="w-2 h-2 rounded-full bg-primary/40"></div>
-</div>
-<span class="font-mono text-[10px] tracking-widest text-on-surface-variant">LOGS: SYSTEM_RUNTIME_v4.2</span>
-</div>
-<div class="w-full h-[1px] bg-outline-variant/10"></div>
-<div class="p-8 bg-surface-container-lowest h-[400px] font-mono text-sm relative">
-<div class="space-y-2 opacity-80">
-<div class="flex gap-4">
-<span class="text-primary/40">[09:44:21]</span>
-<span class="text-on-surface">SYS_INT: Interrupt received at 0x44F2A</span>
-</div>
-<div class="flex gap-4">
-<span class="text-primary/40">[09:44:22]</span>
-<span class="text-primary">KERN_SEC: Validating thread signature...</span>
-</div>
-<div class="flex gap-4">
-<span class="text-primary/40">[09:44:22]</span>
-<span class="text-[#4ade80]">KERN_SEC: Signature verified (RSA-4096)</span>
-</div>
-<div class="flex gap-4">
-<span class="text-primary/40">[09:44:23]</span>
-<span class="text-on-surface">PROC_MGR: Spawning sub-process 9128...</span>
-</div>
-<div class="flex gap-4">
-<span class="text-primary/40">[09:44:25]</span>
-<span class="text-primary/40">HEX: 46 6C 6F 77 20 63 6F 6E 74 72 6F 6C 20</span>
-</div>
-<div class="flex gap-4">
-<span class="text-primary/40">[09:44:28]</span>
-<span class="text-on-surface-variant">SCAN: Analyzing entropy patterns... No anomalies.</span>
-</div>
-<div class="flex gap-4">
-<span class="text-primary/40">[09:44:30]</span>
-<span class="text-primary">NET_SHIELD: 124 packets filtered from unknown origin</span>
-</div>
-<div class="flex gap-4">
-<span class="text-primary/40">[09:44:31]</span>
-<span class="text-on-surface">SYS_INT: Thread 9128 finalized successfully.</span>
-</div>
-<div class="flex gap-4">
-<span class="text-primary/40">[09:44:33]</span>
-<span class="text-on-surface">AUTH_SERV: User session refreshed.</span>
-</div>
-</div>
-<!-- Visual Graph Overlay Simulation -->
-<div class="absolute bottom-8 right-8 w-64 h-32 flex items-end gap-1 px-4">
-<div class="w-full bg-primary/20 h-1/2"></div>
-<div class="w-full bg-primary/30 h-3/4"></div>
-<div class="w-full bg-primary/20 h-2/3"></div>
-<div class="w-full bg-primary/50 h-full"></div>
-<div class="w-full bg-primary/20 h-1/2"></div>
-<div class="w-full bg-primary/30 h-1/3"></div>
-<div class="w-full bg-primary/10 h-1/4"></div>
-</div>
-</div>
-</div>
-</div>
-</section>
-<!-- Section 3: Protocol Shield -->
-<section class="grid grid-cols-1 md:grid-cols-2 gap-16 items-center">
-<div class="relative">
-<div class="absolute -top-12 -left-12 w-64 h-64 bg-primary/10 rounded-full"></div>
-<img alt="Abstract technical representation of cryptographic layers and data streams" class="w-full aspect-square object-cover rounded-3xl mix-blend-luminosity opacity-40 grayscale" data-alt="Technical visualization of digital encryption layers" src="https://lh3.googleusercontent.com/aida-public/AB6AXuAj8yb6ml9lXksULfmKi8lbt5WsCrxNmfnQ32Vaj_il6eOXEDRCpqrhtB_D9LuEBVztydHUiM9Bt_A0igMJ8EVKhgKet8t2AqsnNEzSEH-DoAifuTw60Tkq-U6w7-7dkVvEhbAeHccIn5lbs_L5DGhE-GaKH3Td7DsCrj7FI2IH57mpXDFcBRbSIdULjs1SgKSH_u8SKpKdt8L7pWZgW0CW7R3IfFT2SGR3Ved6nPLDX_j2c0l-JksjP_UXzDAYvJDaA8B-IQINqSo"/>
-<div class="absolute inset-0 bg-linear-to-t from-background via-transparent to-transparent"></div>
-<div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex gap-4">
-<div class="glass-panel w-20 h-20 rounded-2xl flex items-center justify-center border-primary/40 neon-glow-primary">
-<span class="font-headline font-bold text-2xl">AES</span>
-</div>
-<div class="glass-panel w-20 h-20 rounded-2xl flex items-center justify-center border-primary/20">
-<span class="font-headline font-bold text-2xl">RSA</span>
-</div>
-</div>
-</div>
-<div class="space-y-8">
-<div>
-<h2 class="font-headline text-5xl font-bold uppercase mb-6 leading-tight">Protocol Shield</h2>
-<p class="font-body text-on-surface-variant text-lg">Every data packet within TajsOS is encapsulated in a triple-layered security wrapper. AES-256 GCM provides high-speed encryption for local storage, while RSA-4096 handles secure handshakes.</p>
-</div>
-<ul class="space-y-6">
-<li class="flex gap-4">
-<div class="flex-shrink-0 w-8 h-8 rounded-full border border-primary/30 flex items-center justify-center text-primary font-mono text-xs">01</div>
-<div>
-<h4 class="font-headline font-bold text-lg uppercase">Zero-Knowledge Storage</h4>
-<p class="font-body text-on-surface-variant text-sm">We never store your keys. Decryption occurs only in the isolated secure enclave of the hardware.</p>
-</div>
-</li>
-<li class="flex gap-4">
-<div class="flex-shrink-0 w-8 h-8 rounded-full border border-primary/30 flex items-center justify-center text-primary font-mono text-xs">02</div>
-<div>
-<h4 class="font-headline font-bold text-lg uppercase">Ephemeral Keys</h4>
-<p class="font-body text-on-surface-variant text-sm">Session keys are regenerated every 15 minutes to prevent replay attacks and ensure forward secrecy.</p>
-</div>
-</li>
-<li class="flex gap-4">
-<div class="flex-shrink-0 w-8 h-8 rounded-full border border-primary/30 flex items-center justify-center text-primary font-mono text-xs">03</div>
-<div>
-<h4 class="font-headline font-bold text-lg uppercase">Hardware Root of Trust</h4>
-<p class="font-body text-on-surface-variant text-sm">Direct integration with TPM 2.0 and Apple Secure Enclave for hardware-level integrity checks.</p>
-</div>
-</li>
-</ul>
-</div>
-</section>
-
+    <!-- Hero Section -->
+    <section
+      class="relative grid grid-cols-1 lg:grid-cols-12 gap-12 items-start"
+    >
+      <div class="lg:col-span-8">
+        <div class="flex items-center gap-3 mb-6">
+          <div class="w-2 h-2 rounded-full bg-primary animate-pulse"></div>
+          <span
+            class="font-label text-primary text-sm tracking-widest uppercase font-bold"
+            >KERNEL: ENCRYPTED</span
+          >
+        </div>
+        <h1
+          class="font-headline text-7xl md:text-9xl font-bold tracking-tighter leading-tight mb-8"
+        >
+          SECURITY<br />
+          <span class="gradient-text">ARCHITECTURE</span>
+        </h1>
+        <p
+          class="font-body text-on-surface-variant text-xl max-w-xl leading-relaxed"
+        >
+          TajsOS implements a zero-trust neural substrate. Every process is
+          isolated within a cryptographic vault, monitored by real-time
+          heuristic analysis.
+        </p>
+      </div>
+      <div class="lg:col-span-4 self-center">
+        <div class="glass-panel p-8 rounded-3xl relative overflow-hidden">
+          <div
+            class="absolute top-0 right-0 w-32 h-32 bg-primary/5 rounded-full -mr-16 -mt-16"
+          >
+          </div>
+          <div class="space-y-6 relative z-10">
+            <div class="flex justify-between items-end">
+              <span
+                class="font-label text-[10px] text-primary uppercase font-bold"
+                >System Integrity</span
+              >
+              <span class="font-mono text-xs text-primary">99.98%</span>
+            </div>
+            <div
+              class="h-1 bg-surface-container-highest rounded-full overflow-hidden"
+            >
+              <div class="h-full bg-primary w-[99.98%]"></div>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4">
+              <div class="bg-surface-container-lowest/50 p-4 rounded-lg">
+                <span
+                  class="block font-label text-[10px] text-on-surface-variant uppercase mb-1"
+                  >Active Shields</span
+                >
+                <span class="font-mono text-lg font-bold">14,209</span>
+              </div>
+              <div class="bg-surface-container-lowest/50 p-4 rounded-lg">
+                <span
+                  class="block font-label text-[10px] text-on-surface-variant uppercase mb-1"
+                  >Threat Level</span
+                >
+                <span class="font-mono text-lg font-bold text-primary"
+                  >ZERO</span
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Section 1: Neural Vault -->
+    <section class="space-y-12">
+      <div
+        class="flex flex-col md:flex-row md:items-end justify-between gap-6 bg-surface-container-low rounded-3xl p-8"
+      >
+        <div>
+          <h2
+            class="font-headline text-4xl font-bold uppercase tracking-tight mb-2"
+          >
+            Neural Vault
+          </h2>
+          <p class="font-body text-on-surface-variant max-w-md">
+            Multi-layer volumetric encryption that adapts to usage patterns.
+          </p>
+        </div>
+        <div
+          class="font-mono text-xs text-primary/40 uppercase tracking-widest"
+        >
+          SUBSTRATE-LAYER-01
+        </div>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <!-- Card 1 -->
+        <div
+          class="glass-panel p-1 rounded-2xl group hover:border-primary/40 transition-all duration-500"
+        >
+          <div class="bg-surface-container-low h-full p-8 rounded-[14px]">
+            <div
+              class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-8 text-primary"
+            >
+              <span
+                class="material-symbols-outlined text-3xl"
+                data-icon="biometric_setup"
+                style="font-variation-settings: 'FILL' 1;"
+                >android_fingerprint</span
+              >
+            </div>
+            <h3 class="font-headline text-xl font-bold mb-4 uppercase">
+              Biometric Mesh
+            </h3>
+            <p
+              class="font-body text-on-surface-variant text-sm leading-relaxed mb-8"
+            >
+              Continuous behavioral verification using low-latency neural
+              processing to ensure user persistence.
+            </p>
+            <div
+              class="flex items-center gap-2 font-mono text-[10px] text-primary"
+            >
+              <span
+                class="material-symbols-outlined text-sm"
+                data-icon="check_circle">check_circle</span
+              >
+              ACTIVE
+            </div>
+          </div>
+        </div>
+        <!-- Card 2 -->
+        <div
+          class="glass-panel p-1 rounded-2xl group hover:border-primary/40 transition-all duration-500"
+        >
+          <div class="bg-surface-container-low h-full p-8 rounded-[14px]">
+            <div
+              class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-8 text-primary"
+            >
+              <span
+                class="material-symbols-outlined text-3xl"
+                data-icon="v_loss"
+                style="font-variation-settings: 'FILL' 1;">water_loss</span
+              >
+            </div>
+            <h3 class="font-headline text-xl font-bold mb-4 uppercase">
+              Quantum Latency
+            </h3>
+            <p
+              class="font-body text-on-surface-variant text-sm leading-relaxed mb-8"
+            >
+              Post-quantum cryptographic wrappers protecting long-term data
+              storage against future decryption vectors.
+            </p>
+            <div
+              class="flex items-center gap-2 font-mono text-[10px] text-primary"
+            >
+              <span
+                class="material-symbols-outlined text-sm"
+                data-icon="check_circle">check_circle</span
+              >
+              ACTIVE
+            </div>
+          </div>
+        </div>
+        <!-- Card 3 -->
+        <div
+          class="glass-panel p-1 rounded-2xl group hover:border-primary/40 transition-all duration-500"
+        >
+          <div class="bg-surface-container-low h-full p-8 rounded-[14px]">
+            <div
+              class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-8 text-primary"
+            >
+              <span
+                class="material-symbols-outlined text-3xl"
+                data-icon="shield_lock"
+                style="font-variation-settings: 'FILL' 1;">shield_lock</span
+              >
+            </div>
+            <h3 class="font-headline text-xl font-bold mb-4 uppercase">
+              Kernel Sandboxing
+            </h3>
+            <p
+              class="font-body text-on-surface-variant text-sm leading-relaxed mb-8"
+            >
+              Immutable process isolation ensures that zero-day exploits cannot
+              propagate beyond the execution thread.
+            </p>
+            <div
+              class="flex items-center gap-2 font-mono text-[10px] text-primary"
+            >
+              <span
+                class="material-symbols-outlined text-sm"
+                data-icon="check_circle">check_circle</span
+              >
+              ACTIVE
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Section 2: Real-time Threat Monitoring -->
+    <section class="grid grid-cols-1 lg:grid-cols-12 gap-8">
+      <div class="lg:col-span-4 flex flex-col justify-center">
+        <h2
+          class="font-headline text-4xl font-bold uppercase tracking-tight mb-4"
+        >
+          Threat<br />Monitoring
+        </h2>
+        <p class="font-body text-on-surface-variant mb-8">
+          Active heuristic scanning of all system interrupts. Real-time
+          visualization of packet flows and process entropy.
+        </p>
+        <div class="space-y-4">
+          <div
+            class="flex items-center justify-between p-4 bg-surface-container-highest rounded-3xl"
+          >
+            <span class="font-label text-xs uppercase font-bold tracking-widest"
+              >Network Flow</span
+            >
+            <span class="font-mono text-xs text-primary">NOMINAL</span>
+          </div>
+          <div
+            class="flex items-center justify-between p-4 bg-surface-container-low rounded-3xl"
+          >
+            <span
+              class="font-label text-xs uppercase font-bold tracking-widest text-on-surface-variant"
+              >Mem-Entropy</span
+            >
+            <span class="font-mono text-xs text-on-surface-variant"
+              >4.2% STD</span
+            >
+          </div>
+        </div>
+      </div>
+      <div class="lg:col-span-8">
+        <div class="glass-panel rounded-2xl overflow-hidden">
+          <div
+            class="bg-surface-container-highest/50 px-6 py-4 flex justify-between items-center"
+          >
+            <div class="flex gap-2">
+              <div class="w-2 h-2 rounded-full bg-error"></div>
+              <div class="w-2 h-2 rounded-full bg-primary/40"></div>
+              <div class="w-2 h-2 rounded-full bg-primary/40"></div>
+            </div>
+            <span
+              class="font-mono text-[10px] tracking-widest text-on-surface-variant"
+              >LOGS: SYSTEM_RUNTIME_v4.2</span
+            >
+          </div>
+          <div class="w-full h-[1px] bg-outline-variant/10"></div>
+          <div
+            class="p-8 bg-surface-container-lowest h-[400px] font-mono text-sm relative"
+          >
+            <div class="space-y-2 opacity-80">
+              <div class="flex gap-4">
+                <span class="text-primary/40">[09:44:21]</span>
+                <span class="text-on-surface"
+                  >SYS_INT: Interrupt received at 0x44F2A</span
+                >
+              </div>
+              <div class="flex gap-4">
+                <span class="text-primary/40">[09:44:22]</span>
+                <span class="text-primary"
+                  >KERN_SEC: Validating thread signature...</span
+                >
+              </div>
+              <div class="flex gap-4">
+                <span class="text-primary/40">[09:44:22]</span>
+                <span class="text-[#4ade80]"
+                  >KERN_SEC: Signature verified (RSA-4096)</span
+                >
+              </div>
+              <div class="flex gap-4">
+                <span class="text-primary/40">[09:44:23]</span>
+                <span class="text-on-surface"
+                  >PROC_MGR: Spawning sub-process 9128...</span
+                >
+              </div>
+              <div class="flex gap-4">
+                <span class="text-primary/40">[09:44:25]</span>
+                <span class="text-primary/40"
+                  >HEX: 46 6C 6F 77 20 63 6F 6E 74 72 6F 6C 20</span
+                >
+              </div>
+              <div class="flex gap-4">
+                <span class="text-primary/40">[09:44:28]</span>
+                <span class="text-on-surface-variant"
+                  >SCAN: Analyzing entropy patterns... No anomalies.</span
+                >
+              </div>
+              <div class="flex gap-4">
+                <span class="text-primary/40">[09:44:30]</span>
+                <span class="text-primary"
+                  >NET_SHIELD: 124 packets filtered from unknown origin</span
+                >
+              </div>
+              <div class="flex gap-4">
+                <span class="text-primary/40">[09:44:31]</span>
+                <span class="text-on-surface"
+                  >SYS_INT: Thread 9128 finalized successfully.</span
+                >
+              </div>
+              <div class="flex gap-4">
+                <span class="text-primary/40">[09:44:33]</span>
+                <span class="text-on-surface"
+                  >AUTH_SERV: User session refreshed.</span
+                >
+              </div>
+            </div>
+            <!-- Visual Graph Overlay Simulation -->
+            <div
+              class="absolute bottom-8 right-8 w-64 h-32 flex items-end gap-1 px-4"
+            >
+              <div class="w-full bg-primary/20 h-1/2"></div>
+              <div class="w-full bg-primary/30 h-3/4"></div>
+              <div class="w-full bg-primary/20 h-2/3"></div>
+              <div class="w-full bg-primary/50 h-full"></div>
+              <div class="w-full bg-primary/20 h-1/2"></div>
+              <div class="w-full bg-primary/30 h-1/3"></div>
+              <div class="w-full bg-primary/10 h-1/4"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Section 3: Protocol Shield -->
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-16 items-center">
+      <div class="relative">
+        <div
+          class="absolute -top-12 -left-12 w-64 h-64 bg-primary/10 rounded-full"
+        >
+        </div>
+        <img
+          alt="Abstract technical representation of cryptographic layers and data streams"
+          class="w-full aspect-square object-cover rounded-3xl mix-blend-luminosity opacity-40 grayscale"
+          data-alt="Technical visualization of digital encryption layers"
+          src="https://lh3.googleusercontent.com/aida-public/AB6AXuAj8yb6ml9lXksULfmKi8lbt5WsCrxNmfnQ32Vaj_il6eOXEDRCpqrhtB_D9LuEBVztydHUiM9Bt_A0igMJ8EVKhgKet8t2AqsnNEzSEH-DoAifuTw60Tkq-U6w7-7dkVvEhbAeHccIn5lbs_L5DGhE-GaKH3Td7DsCrj7FI2IH57mpXDFcBRbSIdULjs1SgKSH_u8SKpKdt8L7pWZgW0CW7R3IfFT2SGR3Ved6nPLDX_j2c0l-JksjP_UXzDAYvJDaA8B-IQINqSo"
+        />
+        <div
+          class="absolute inset-0 bg-linear-to-t from-background via-transparent to-transparent"
+        >
+        </div>
+        <div
+          class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex gap-4"
+        >
+          <div
+            class="glass-panel w-20 h-20 rounded-2xl flex items-center justify-center border-primary/40 neon-glow-primary"
+          >
+            <span class="font-headline font-bold text-2xl">AES</span>
+          </div>
+          <div
+            class="glass-panel w-20 h-20 rounded-2xl flex items-center justify-center border-primary/20"
+          >
+            <span class="font-headline font-bold text-2xl">RSA</span>
+          </div>
+        </div>
+      </div>
+      <div class="space-y-8">
+        <div>
+          <h2
+            class="font-headline text-5xl font-bold uppercase mb-6 leading-tight"
+          >
+            Protocol Shield
+          </h2>
+          <p class="font-body text-on-surface-variant text-lg">
+            Every data packet within TajsOS is encapsulated in a triple-layered
+            security wrapper. AES-256 GCM provides high-speed encryption for
+            local storage, while RSA-4096 handles secure handshakes.
+          </p>
+        </div>
+        <ul class="space-y-6">
+          <li class="flex gap-4">
+            <div
+              class="flex-shrink-0 w-8 h-8 rounded-full border border-primary/30 flex items-center justify-center text-primary font-mono text-xs"
+            >
+              01
+            </div>
+            <div>
+              <h4 class="font-headline font-bold text-lg uppercase">
+                Zero-Knowledge Storage
+              </h4>
+              <p class="font-body text-on-surface-variant text-sm">
+                We never store your keys. Decryption occurs only in the isolated
+                secure enclave of the hardware.
+              </p>
+            </div>
+          </li>
+          <li class="flex gap-4">
+            <div
+              class="flex-shrink-0 w-8 h-8 rounded-full border border-primary/30 flex items-center justify-center text-primary font-mono text-xs"
+            >
+              02
+            </div>
+            <div>
+              <h4 class="font-headline font-bold text-lg uppercase">
+                Ephemeral Keys
+              </h4>
+              <p class="font-body text-on-surface-variant text-sm">
+                Session keys are regenerated every 15 minutes to prevent replay
+                attacks and ensure forward secrecy.
+              </p>
+            </div>
+          </li>
+          <li class="flex gap-4">
+            <div
+              class="flex-shrink-0 w-8 h-8 rounded-full border border-primary/30 flex items-center justify-center text-primary font-mono text-xs"
+            >
+              03
+            </div>
+            <div>
+              <h4 class="font-headline font-bold text-lg uppercase">
+                Hardware Root of Trust
+              </h4>
+              <p class="font-body text-on-surface-variant text-sm">
+                Direct integration with TPM 2.0 and Apple Secure Enclave for
+                hardware-level integrity checks.
+              </p>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/status.astro
+++ b/website/src/pages/status.astro
@@ -1,268 +1,475 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
 
 const title = "SYSTEM STATUS";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
-  
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
+
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
-    
-<!-- Header Status Indicator -->
-<header class="flex flex-col md:flex-row justify-between items-start md:items-end gap-6">
-<div class="space-y-2">
-<div class="flex items-center gap-3 px-4 py-1.5 bg-surface-container-low rounded-full border border-outline-variant/10 w-fit">
-<span class="relative flex h-3 w-3">
-<span class="status-pulse absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
-<span class="relative inline-flex rounded-full h-3 w-3 bg-emerald-500"></span>
-</span>
-<span class="font-mono text-[10px] tracking-[0.2em] text-emerald-400 uppercase font-bold">System // Operational</span>
-</div>
-<h1 class="text-5xl md:text-7xl font-headline font-bold tracking-tighter text-on-surface">
-                    System <br/><span class="text-primary">Status</span>
-</h1>
-</div>
-<div class="text-right hidden md:block">
-<p class="font-mono text-xs text-on-surface-variant uppercase tracking-widest">Last Checked</p>
-<p class="font-mono text-sm text-primary">2024-05-24 14:02:11 UTC</p>
-</div>
-</header>
-<!-- Hero: Uptime Stats -->
-<section class="grid grid-cols-1 md:grid-cols-3 gap-6">
-<div class="md:col-span-2 glass-panel p-10 rounded-3xl border border-outline-variant/10 relative overflow-hidden group">
-<div class="absolute -right-20 -top-20 w-64 h-64 bg-primary/5 rounded-full group-hover:bg-primary/10 transition-colors"></div>
-<p class="font-mono text-xs text-on-surface-variant uppercase tracking-[0.3em] mb-4">Cumulative System Uptime</p>
-<div class="flex items-baseline gap-4">
-<span class="text-8xl md:text-9xl font-headline font-bold tracking-tighter">99.98<span class="text-primary text-5xl md:text-7xl">%</span></span>
-</div>
-<div class="mt-8 flex gap-2 overflow-hidden h-1">
-<div class="flex-1 bg-emerald-500/80 rounded-full"></div>
-<div class="flex-1 bg-emerald-500/80 rounded-full"></div>
-<div class="flex-1 bg-emerald-500/80 rounded-full"></div>
-<div class="flex-1 bg-emerald-500/80 rounded-full"></div>
-<div class="flex-1 bg-error/80 rounded-full"></div>
-<div class="flex-1 bg-emerald-500/80 rounded-full"></div>
-<div class="flex-1 bg-emerald-500/80 rounded-full"></div>
-</div>
-<p class="mt-4 font-mono text-[10px] text-on-surface-variant/60">Service reliability measured over the last 90 days.</p>
-</div>
-<div class="bg-surface-container-highest p-10 rounded-3xl border border-outline-variant/10 flex flex-col justify-between">
-<div>
-<span class="material-symbols-outlined text-primary mb-4" style="font-variation-settings: 'FILL' 1;">analytics</span>
-<p class="font-mono text-xs text-on-surface-variant uppercase tracking-widest">Active Requests</p>
-<p class="text-4xl font-headline font-bold mt-2">1.2M <span class="text-sm font-normal text-on-surface-variant/60">/sec</span></p>
-</div>
-<div class="w-full h-[1px] bg-outline-variant/10 mb-8"></div>
-<div class="pt-8">
-<p class="font-mono text-xs text-on-surface-variant uppercase tracking-widest">Global Latency</p>
-<p class="text-4xl font-headline font-bold mt-2 text-secondary">24<span class="text-sm font-normal text-on-surface-variant/60">ms</span></p>
-</div>
-</div>
-</section>
-<!-- Status Grid -->
-<section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-<!-- Auth Service -->
-<div class="bg-surface-container-highest p-6 rounded-3xl transition-all cursor-default">
-<div class="flex justify-between items-start mb-6">
-<h3 class="font-headline font-bold text-lg">Auth Service</h3>
-<span class="text-[10px] font-mono text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded uppercase">Operational</span>
-</div>
-<div class="flex items-center gap-4 mb-4">
-<div class="flex-1 h-8 flex items-end gap-1">
-<div class="w-1 bg-primary/20 h-3 rounded-full"></div>
-<div class="w-1 bg-primary/40 h-5 rounded-full"></div>
-<div class="w-1 bg-primary/20 h-4 rounded-full"></div>
-<div class="w-1 bg-primary/60 h-6 rounded-full"></div>
-<div class="w-1 bg-primary h-8 rounded-full"></div>
-<div class="w-1 bg-primary/40 h-5 rounded-full"></div>
-<div class="w-1 bg-primary/20 h-3 rounded-full"></div>
-</div>
-<div class="text-right">
-<p class="font-mono text-xs text-on-surface-variant">Latency</p>
-<p class="font-mono text-sm font-bold">12ms</p>
-</div>
-</div>
-</div>
-<!-- Database Cluster -->
-<div class="bg-surface-container-highest p-6 rounded-3xl transition-all cursor-default">
-<div class="flex justify-between items-start mb-6">
-<h3 class="font-headline font-bold text-lg">Database Cluster</h3>
-<span class="text-[10px] font-mono text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded uppercase">Operational</span>
-</div>
-<div class="flex items-center gap-4 mb-4">
-<div class="flex-1 h-8 flex items-end gap-1">
-<div class="w-1 bg-primary/20 h-4 rounded-full"></div>
-<div class="w-1 bg-primary/40 h-4 rounded-full"></div>
-<div class="w-1 bg-primary/60 h-7 rounded-full"></div>
-<div class="w-1 bg-primary h-5 rounded-full"></div>
-<div class="w-1 bg-primary/60 h-6 rounded-full"></div>
-<div class="w-1 bg-primary/40 h-4 rounded-full"></div>
-<div class="w-1 bg-primary/20 h-5 rounded-full"></div>
-</div>
-<div class="text-right">
-<p class="font-mono text-xs text-on-surface-variant">Latency</p>
-<p class="font-mono text-sm font-bold">48ms</p>
-</div>
-</div>
-</div>
-<!-- Backend Sync API -->
-<div class="bg-surface-container-highest p-6 rounded-3xl transition-all cursor-default">
-<div class="flex justify-between items-start mb-6">
-<h3 class="font-headline font-bold text-lg">Backend Sync API</h3>
-<span class="text-[10px] font-mono text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded uppercase">Operational</span>
-</div>
-<div class="flex items-center gap-4 mb-4">
-<div class="flex-1 h-8 flex items-end gap-1">
-<div class="w-1 bg-primary/40 h-2 rounded-full"></div>
-<div class="w-1 bg-primary/60 h-4 rounded-full"></div>
-<div class="w-1 bg-primary/20 h-3 rounded-full"></div>
-<div class="w-1 bg-primary h-5 rounded-full"></div>
-<div class="w-1 bg-primary/60 h-8 rounded-full"></div>
-<div class="w-1 bg-primary/40 h-6 rounded-full"></div>
-<div class="w-1 bg-primary/20 h-4 rounded-full"></div>
-</div>
-<div class="text-right">
-<p class="font-mono text-xs text-on-surface-variant">Latency</p>
-<p class="font-mono text-sm font-bold">142ms</p>
-</div>
-</div>
-</div>
-<!-- CDN -->
-<div class="bg-surface-container-highest p-6 rounded-3xl transition-all cursor-default">
-<div class="flex justify-between items-start mb-6">
-<h3 class="font-headline font-bold text-lg">CDN</h3>
-<span class="text-[10px] font-mono text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded uppercase">Operational</span>
-</div>
-<div class="flex items-center gap-4 mb-4">
-<div class="flex-1 h-8 flex items-end gap-1">
-<div class="w-1 bg-primary/20 h-3 rounded-full"></div>
-<div class="w-1 bg-primary/40 h-5 rounded-full"></div>
-<div class="w-1 bg-primary/60 h-4 rounded-full"></div>
-<div class="w-1 bg-primary h-6 rounded-full"></div>
-<div class="w-1 bg-primary/60 h-7 rounded-full"></div>
-<div class="w-1 bg-primary/40 h-5 rounded-full"></div>
-<div class="w-1 bg-primary/20 h-4 rounded-full"></div>
-</div>
-<div class="text-right">
-<p class="font-mono text-xs text-on-surface-variant">Latency</p>
-<p class="font-mono text-sm font-bold">8ms</p>
-</div>
-</div>
-</div>
-</section>
-<!-- Latency Graph Section -->
-<section class="space-y-6">
-<div class="flex items-center justify-between">
-<h2 class="font-headline font-bold text-2xl tracking-tight">Latency Response (24H)</h2>
-<div class="flex gap-4">
-<div class="flex items-center gap-2">
-<div class="w-3 h-3 rounded-full bg-primary"></div>
-<span class="font-mono text-[10px] text-on-surface-variant uppercase">P99 Metric</span>
-</div>
-<div class="flex items-center gap-2">
-<div class="w-3 h-3 rounded-full bg-surface-container-highest"></div>
-<span class="font-mono text-[10px] text-on-surface-variant uppercase">Average</span>
-</div>
-</div>
-</div>
-<div class="bg-surface-container-low p-8 rounded-3xl h-64 relative overflow-hidden flex items-end gap-1">
-<!-- Abstract Graph bars -->
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[20%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[25%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[15%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[30%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[45%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[20%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[10%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[35%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[60%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[80%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[40%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[30%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[20%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary h-[15%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[18%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[22%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[28%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[32%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[25%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[20%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[15%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[12%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[10%] rounded-t-sm"></div>
-<div class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[8%] rounded-t-sm"></div>
-<div class="absolute inset-x-0 bottom-0 h-[1px] bg-primary/40"></div>
-<!-- Grid Lines -->
-<div class="absolute inset-0 flex flex-col justify-between py-8 opacity-10 pointer-events-none">
-<div class="bg-on-surface-variant h-[1px] w-full"></div>
-<div class="bg-on-surface-variant h-[1px] w-full"></div>
-<div class="bg-on-surface-variant h-[1px] w-full"></div>
-</div>
-</div>
-<div class="flex justify-between px-2">
-<span class="font-mono text-[9px] text-on-surface-variant">24H AGO</span>
-<span class="font-mono text-[9px] text-on-surface-variant">12H AGO</span>
-<span class="font-mono text-[9px] text-on-surface-variant">PRESENT</span>
-</div>
-</section>
-<!-- Incident History -->
-<section class="space-y-6">
-<h2 class="font-headline font-bold text-2xl tracking-tight">Incident History</h2>
-<div class="bg-surface-container-lowest rounded-3xl overflow-hidden">
-<div class="bg-surface-container-high px-6 py-3 flex items-center justify-between">
-<span class="font-mono text-xs uppercase tracking-widest text-on-surface-variant">Changelog // May 2024</span>
-<span class="font-mono text-xs text-emerald-400">STATUS: NOMINAL</span>
-</div>
-<div class="w-full h-[1px] bg-outline-variant/10"></div>
-<div class="p-0 divide-y divide-outline-variant/5">
-<!-- Log Item -->
-<div class="p-6 flex gap-8 items-start hover:bg-surface-container-low transition-colors group">
-<div class="font-mono text-sm text-on-surface-variant shrink-0 mt-1">MAY 22</div>
-<div class="space-y-2">
-<h4 class="font-bold text-on-surface flex items-center gap-2 group-hover:text-primary transition-colors">
-<span class="material-symbols-outlined text-sm">check_circle</span>
-                                No Incidents Reported
-                            </h4>
-<p class="text-sm text-on-surface-variant leading-relaxed">All services remained within performance thresholds. Auto-scaling protocols handled traffic peaks in the US-EAST-1 cluster.</p>
-</div>
-</div>
-<!-- Log Item -->
-<div class="p-6 flex gap-8 items-start hover:bg-surface-container-low transition-colors group">
-<div class="font-mono text-sm text-on-surface-variant shrink-0 mt-1">MAY 21</div>
-<div class="space-y-2">
-<h4 class="font-bold text-on-surface flex items-center gap-2 group-hover:text-primary transition-colors">
-<span class="material-symbols-outlined text-sm">check_circle</span>
-                                System Maintenance
-                            </h4>
-<p class="text-sm text-on-surface-variant leading-relaxed">Completed scheduled database maintenance in the EU-CENTRAL-1 region. Zero downtime recorded.</p>
-</div>
-</div>
-<!-- Log Item -->
-<div class="p-6 flex gap-8 items-start hover:bg-surface-container-low transition-colors group opacity-60">
-<div class="font-mono text-sm text-on-surface-variant shrink-0 mt-1">MAY 20</div>
-<div class="space-y-2">
-<h4 class="font-bold text-on-surface flex items-center gap-2">
-<span class="material-symbols-outlined text-sm">warning</span>
-                                Minor Latency Spike
-                            </h4>
-<p class="text-sm text-on-surface-variant leading-relaxed font-mono">CODE: 0x4492. Resolved: CDN cache invalidation delay. Impact: &lt;5 minutes.</p>
-</div>
-</div>
-</div>
-</div>
-<div class="flex justify-center pt-4">
-<button  class="font-label text-xs uppercase tracking-widest text-primary hover:text-on-surface transition-colors flex items-center gap-2 group min-h-[48px]">
-                    View Archive 
-                    <span class="material-symbols-outlined text-sm group-hover:translate-x-1 transition-transform">arrow_right_alt</span>
-</button>
-</div>
-</section>
-
+    <!-- Header Status Indicator -->
+    <header
+      class="flex flex-col md:flex-row justify-between items-start md:items-end gap-6"
+    >
+      <div class="space-y-2">
+        <div
+          class="flex items-center gap-3 px-4 py-1.5 bg-surface-container-low rounded-full border border-outline-variant/10 w-fit"
+        >
+          <span class="relative flex h-3 w-3">
+            <span
+              class="status-pulse absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"
+            ></span>
+            <span
+              class="relative inline-flex rounded-full h-3 w-3 bg-emerald-500"
+            ></span>
+          </span>
+          <span
+            class="font-mono text-[10px] tracking-[0.2em] text-emerald-400 uppercase font-bold"
+            >System // Operational</span
+          >
+        </div>
+        <h1
+          class="text-5xl md:text-7xl font-headline font-bold tracking-tighter text-on-surface"
+        >
+          System <br /><span class="text-primary">Status</span>
+        </h1>
+      </div>
+      <div class="text-right hidden md:block">
+        <p
+          class="font-mono text-xs text-on-surface-variant uppercase tracking-widest"
+        >
+          Last Checked
+        </p>
+        <p class="font-mono text-sm text-primary">2024-05-24 14:02:11 UTC</p>
+      </div>
+    </header>
+    <!-- Hero: Uptime Stats -->
+    <section class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div
+        class="md:col-span-2 glass-panel p-10 rounded-3xl border border-outline-variant/10 relative overflow-hidden group"
+      >
+        <div
+          class="absolute -right-20 -top-20 w-64 h-64 bg-primary/5 rounded-full group-hover:bg-primary/10 transition-colors"
+        >
+        </div>
+        <p
+          class="font-mono text-xs text-on-surface-variant uppercase tracking-[0.3em] mb-4"
+        >
+          Cumulative System Uptime
+        </p>
+        <div class="flex items-baseline gap-4">
+          <span
+            class="text-8xl md:text-9xl font-headline font-bold tracking-tighter"
+            >99.98<span class="text-primary text-5xl md:text-7xl">%</span></span
+          >
+        </div>
+        <div class="mt-8 flex gap-2 overflow-hidden h-1">
+          <div class="flex-1 bg-emerald-500/80 rounded-full"></div>
+          <div class="flex-1 bg-emerald-500/80 rounded-full"></div>
+          <div class="flex-1 bg-emerald-500/80 rounded-full"></div>
+          <div class="flex-1 bg-emerald-500/80 rounded-full"></div>
+          <div class="flex-1 bg-error/80 rounded-full"></div>
+          <div class="flex-1 bg-emerald-500/80 rounded-full"></div>
+          <div class="flex-1 bg-emerald-500/80 rounded-full"></div>
+        </div>
+        <p class="mt-4 font-mono text-[10px] text-on-surface-variant/60">
+          Service reliability measured over the last 90 days.
+        </p>
+      </div>
+      <div
+        class="bg-surface-container-highest p-10 rounded-3xl border border-outline-variant/10 flex flex-col justify-between"
+      >
+        <div>
+          <span
+            class="material-symbols-outlined text-primary mb-4"
+            style="font-variation-settings: 'FILL' 1;">analytics</span
+          >
+          <p
+            class="font-mono text-xs text-on-surface-variant uppercase tracking-widest"
+          >
+            Active Requests
+          </p>
+          <p class="text-4xl font-headline font-bold mt-2">
+            1.2M <span class="text-sm font-normal text-on-surface-variant/60"
+              >/sec</span>
+          </p>
+        </div>
+        <div class="w-full h-[1px] bg-outline-variant/10 mb-8"></div>
+        <div class="pt-8">
+          <p
+            class="font-mono text-xs text-on-surface-variant uppercase tracking-widest"
+          >
+            Global Latency
+          </p>
+          <p class="text-4xl font-headline font-bold mt-2 text-secondary">
+            24<span class="text-sm font-normal text-on-surface-variant/60"
+              >ms</span>
+          </p>
+        </div>
+      </div>
+    </section>
+    <!-- Status Grid -->
+    <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <!-- Auth Service -->
+      <div
+        class="bg-surface-container-highest p-6 rounded-3xl transition-all cursor-default"
+      >
+        <div class="flex justify-between items-start mb-6">
+          <h3 class="font-headline font-bold text-lg">Auth Service</h3>
+          <span
+            class="text-[10px] font-mono text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded uppercase"
+            >Operational</span
+          >
+        </div>
+        <div class="flex items-center gap-4 mb-4">
+          <div class="flex-1 h-8 flex items-end gap-1">
+            <div class="w-1 bg-primary/20 h-3 rounded-full"></div>
+            <div class="w-1 bg-primary/40 h-5 rounded-full"></div>
+            <div class="w-1 bg-primary/20 h-4 rounded-full"></div>
+            <div class="w-1 bg-primary/60 h-6 rounded-full"></div>
+            <div class="w-1 bg-primary h-8 rounded-full"></div>
+            <div class="w-1 bg-primary/40 h-5 rounded-full"></div>
+            <div class="w-1 bg-primary/20 h-3 rounded-full"></div>
+          </div>
+          <div class="text-right">
+            <p class="font-mono text-xs text-on-surface-variant">Latency</p>
+            <p class="font-mono text-sm font-bold">12ms</p>
+          </div>
+        </div>
+      </div>
+      <!-- Database Cluster -->
+      <div
+        class="bg-surface-container-highest p-6 rounded-3xl transition-all cursor-default"
+      >
+        <div class="flex justify-between items-start mb-6">
+          <h3 class="font-headline font-bold text-lg">Database Cluster</h3>
+          <span
+            class="text-[10px] font-mono text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded uppercase"
+            >Operational</span
+          >
+        </div>
+        <div class="flex items-center gap-4 mb-4">
+          <div class="flex-1 h-8 flex items-end gap-1">
+            <div class="w-1 bg-primary/20 h-4 rounded-full"></div>
+            <div class="w-1 bg-primary/40 h-4 rounded-full"></div>
+            <div class="w-1 bg-primary/60 h-7 rounded-full"></div>
+            <div class="w-1 bg-primary h-5 rounded-full"></div>
+            <div class="w-1 bg-primary/60 h-6 rounded-full"></div>
+            <div class="w-1 bg-primary/40 h-4 rounded-full"></div>
+            <div class="w-1 bg-primary/20 h-5 rounded-full"></div>
+          </div>
+          <div class="text-right">
+            <p class="font-mono text-xs text-on-surface-variant">Latency</p>
+            <p class="font-mono text-sm font-bold">48ms</p>
+          </div>
+        </div>
+      </div>
+      <!-- Backend Sync API -->
+      <div
+        class="bg-surface-container-highest p-6 rounded-3xl transition-all cursor-default"
+      >
+        <div class="flex justify-between items-start mb-6">
+          <h3 class="font-headline font-bold text-lg">Backend Sync API</h3>
+          <span
+            class="text-[10px] font-mono text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded uppercase"
+            >Operational</span
+          >
+        </div>
+        <div class="flex items-center gap-4 mb-4">
+          <div class="flex-1 h-8 flex items-end gap-1">
+            <div class="w-1 bg-primary/40 h-2 rounded-full"></div>
+            <div class="w-1 bg-primary/60 h-4 rounded-full"></div>
+            <div class="w-1 bg-primary/20 h-3 rounded-full"></div>
+            <div class="w-1 bg-primary h-5 rounded-full"></div>
+            <div class="w-1 bg-primary/60 h-8 rounded-full"></div>
+            <div class="w-1 bg-primary/40 h-6 rounded-full"></div>
+            <div class="w-1 bg-primary/20 h-4 rounded-full"></div>
+          </div>
+          <div class="text-right">
+            <p class="font-mono text-xs text-on-surface-variant">Latency</p>
+            <p class="font-mono text-sm font-bold">142ms</p>
+          </div>
+        </div>
+      </div>
+      <!-- CDN -->
+      <div
+        class="bg-surface-container-highest p-6 rounded-3xl transition-all cursor-default"
+      >
+        <div class="flex justify-between items-start mb-6">
+          <h3 class="font-headline font-bold text-lg">CDN</h3>
+          <span
+            class="text-[10px] font-mono text-emerald-400 bg-emerald-400/10 px-2 py-0.5 rounded uppercase"
+            >Operational</span
+          >
+        </div>
+        <div class="flex items-center gap-4 mb-4">
+          <div class="flex-1 h-8 flex items-end gap-1">
+            <div class="w-1 bg-primary/20 h-3 rounded-full"></div>
+            <div class="w-1 bg-primary/40 h-5 rounded-full"></div>
+            <div class="w-1 bg-primary/60 h-4 rounded-full"></div>
+            <div class="w-1 bg-primary h-6 rounded-full"></div>
+            <div class="w-1 bg-primary/60 h-7 rounded-full"></div>
+            <div class="w-1 bg-primary/40 h-5 rounded-full"></div>
+            <div class="w-1 bg-primary/20 h-4 rounded-full"></div>
+          </div>
+          <div class="text-right">
+            <p class="font-mono text-xs text-on-surface-variant">Latency</p>
+            <p class="font-mono text-sm font-bold">8ms</p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Latency Graph Section -->
+    <section class="space-y-6">
+      <div class="flex items-center justify-between">
+        <h2 class="font-headline font-bold text-2xl tracking-tight">
+          Latency Response (24H)
+        </h2>
+        <div class="flex gap-4">
+          <div class="flex items-center gap-2">
+            <div class="w-3 h-3 rounded-full bg-primary"></div>
+            <span
+              class="font-mono text-[10px] text-on-surface-variant uppercase"
+              >P99 Metric</span
+            >
+          </div>
+          <div class="flex items-center gap-2">
+            <div class="w-3 h-3 rounded-full bg-surface-container-highest">
+            </div>
+            <span
+              class="font-mono text-[10px] text-on-surface-variant uppercase"
+              >Average</span
+            >
+          </div>
+        </div>
+      </div>
+      <div
+        class="bg-surface-container-low p-8 rounded-3xl h-64 relative overflow-hidden flex items-end gap-1"
+      >
+        <!-- Abstract Graph bars -->
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[20%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[25%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[15%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[30%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[45%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[20%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[10%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[35%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[60%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[80%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[40%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[30%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[20%] rounded-t-sm"
+        >
+        </div>
+        <div class="flex-1 bg-primary h-[15%] rounded-t-sm"></div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[18%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[22%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[28%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[32%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[25%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[20%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[15%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[12%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[10%] rounded-t-sm"
+        >
+        </div>
+        <div
+          class="flex-1 bg-primary/20 hover:bg-primary transition-colors h-[8%] rounded-t-sm"
+        >
+        </div>
+        <div class="absolute inset-x-0 bottom-0 h-[1px] bg-primary/40"></div>
+        <!-- Grid Lines -->
+        <div
+          class="absolute inset-0 flex flex-col justify-between py-8 opacity-10 pointer-events-none"
+        >
+          <div class="bg-on-surface-variant h-[1px] w-full"></div>
+          <div class="bg-on-surface-variant h-[1px] w-full"></div>
+          <div class="bg-on-surface-variant h-[1px] w-full"></div>
+        </div>
+      </div>
+      <div class="flex justify-between px-2">
+        <span class="font-mono text-[9px] text-on-surface-variant">24H AGO</span
+        >
+        <span class="font-mono text-[9px] text-on-surface-variant">12H AGO</span
+        >
+        <span class="font-mono text-[9px] text-on-surface-variant">PRESENT</span
+        >
+      </div>
+    </section>
+    <!-- Incident History -->
+    <section class="space-y-6">
+      <h2 class="font-headline font-bold text-2xl tracking-tight">
+        Incident History
+      </h2>
+      <div class="bg-surface-container-lowest rounded-3xl overflow-hidden">
+        <div
+          class="bg-surface-container-high px-6 py-3 flex items-center justify-between"
+        >
+          <span
+            class="font-mono text-xs uppercase tracking-widest text-on-surface-variant"
+            >Changelog // May 2024</span
+          >
+          <span class="font-mono text-xs text-emerald-400">STATUS: NOMINAL</span
+          >
+        </div>
+        <div class="w-full h-[1px] bg-outline-variant/10"></div>
+        <div class="p-0 divide-y divide-outline-variant/5">
+          <!-- Log Item -->
+          <div
+            class="p-6 flex gap-8 items-start hover:bg-surface-container-low transition-colors group"
+          >
+            <div
+              class="font-mono text-sm text-on-surface-variant shrink-0 mt-1"
+            >
+              MAY 22
+            </div>
+            <div class="space-y-2">
+              <h4
+                class="font-bold text-on-surface flex items-center gap-2 group-hover:text-primary transition-colors"
+              >
+                <span class="material-symbols-outlined text-sm"
+                  >check_circle</span
+                >
+                No Incidents Reported
+              </h4>
+              <p class="text-sm text-on-surface-variant leading-relaxed">
+                All services remained within performance thresholds.
+                Auto-scaling protocols handled traffic peaks in the US-EAST-1
+                cluster.
+              </p>
+            </div>
+          </div>
+          <!-- Log Item -->
+          <div
+            class="p-6 flex gap-8 items-start hover:bg-surface-container-low transition-colors group"
+          >
+            <div
+              class="font-mono text-sm text-on-surface-variant shrink-0 mt-1"
+            >
+              MAY 21
+            </div>
+            <div class="space-y-2">
+              <h4
+                class="font-bold text-on-surface flex items-center gap-2 group-hover:text-primary transition-colors"
+              >
+                <span class="material-symbols-outlined text-sm"
+                  >check_circle</span
+                >
+                System Maintenance
+              </h4>
+              <p class="text-sm text-on-surface-variant leading-relaxed">
+                Completed scheduled database maintenance in the EU-CENTRAL-1
+                region. Zero downtime recorded.
+              </p>
+            </div>
+          </div>
+          <!-- Log Item -->
+          <div
+            class="p-6 flex gap-8 items-start hover:bg-surface-container-low transition-colors group opacity-60"
+          >
+            <div
+              class="font-mono text-sm text-on-surface-variant shrink-0 mt-1"
+            >
+              MAY 20
+            </div>
+            <div class="space-y-2">
+              <h4 class="font-bold text-on-surface flex items-center gap-2">
+                <span class="material-symbols-outlined text-sm">warning</span>
+                Minor Latency Spike
+              </h4>
+              <p
+                class="text-sm text-on-surface-variant leading-relaxed font-mono"
+              >
+                CODE: 0x4492. Resolved: CDN cache invalidation delay. Impact:
+                &lt;5 minutes.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="flex justify-center pt-4">
+        <button
+          class="font-label text-xs uppercase tracking-widest text-primary hover:text-on-surface transition-colors flex items-center gap-2 group min-h-[48px]"
+        >
+          View Archive
+          <span
+            class="material-symbols-outlined text-sm group-hover:translate-x-1 transition-transform"
+            >arrow_right_alt</span
+          >
+        </button>
+      </div>
+    </section>
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/terms.astro
+++ b/website/src/pages/terms.astro
@@ -1,180 +1,309 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
 
 const title = "TERMS";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
-  
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
+
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
-    
-<!-- Hero Section -->
-<section class="grid grid-cols-1 lg:grid-cols-12 gap-8 mb-32">
-<div class="col-span-12 lg:col-span-8">
-<div class="flex items-center gap-4 mb-6">
-<span class="font-mono text-primary text-sm tracking-tighter">REF_ID: 0x9928-NET-OS</span>
-<div class="h-[1px] flex-grow bg-outline-variant/30"></div>
-</div>
-<h1 class="font-headline font-bold text-7xl md:text-9xl tracking-tighter leading-[0.85] text-glow mb-8">
-                    TERMS //<br/>
-<span class="text-primary-dim">OF NETWORK</span>
-</h1>
-<p class="font-body text-xl text-on-surface-variant max-w-2xl leading-relaxed">
-                    This document governs the operational parameters of the TajsOS Neural Interface. By accessing the decentralized architecture, you acknowledge full synchronization with our Protocol Standards.
+    <!-- Hero Section -->
+    <section class="grid grid-cols-1 lg:grid-cols-12 gap-8 mb-32">
+      <div class="col-span-12 lg:col-span-8">
+        <div class="flex items-center gap-4 mb-6">
+          <span class="font-mono text-primary text-sm tracking-tighter"
+            >REF_ID: 0x9928-NET-OS</span
+          >
+          <div class="h-[1px] flex-grow bg-outline-variant/30"></div>
+        </div>
+        <h1
+          class="font-headline font-bold text-7xl md:text-9xl tracking-tighter leading-[0.85] text-glow mb-8"
+        >
+          TERMS //<br />
+          <span class="text-primary-dim">OF NETWORK</span>
+        </h1>
+        <p
+          class="font-body text-xl text-on-surface-variant max-w-2xl leading-relaxed"
+        >
+          This document governs the operational parameters of the TajsOS Neural
+          Interface. By accessing the decentralized architecture, you
+          acknowledge full synchronization with our Protocol Standards.
+        </p>
+      </div>
+      <div
+        class="col-span-12 lg:col-span-4 flex flex-col justify-end items-start lg:items-end"
+      >
+        <div class="p-6 glass-panel rounded-3xl w-full lg:w-auto">
+          <p
+            class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest mb-2"
+          >
+            Last Updated
+          </p>
+          <p class="font-mono text-xl text-primary font-bold">
+            2024.11.14 // 08:42:01
+          </p>
+          <div class="mt-6 space-y-2">
+            <div class="flex justify-between items-center gap-4">
+              <span
+                class="text-[10px] font-label text-on-surface-variant uppercase tracking-[0.1em]"
+                >Encryption</span
+              >
+              <span class="text-[10px] font-label text-primary uppercase"
+                >Active_AES_256</span
+              >
+            </div>
+            <div class="flex justify-between items-center gap-4">
+              <span
+                class="text-[10px] font-label text-on-surface-variant uppercase tracking-[0.1em]"
+                >Auth_Level</span
+              >
+              <span class="text-[10px] font-label text-primary uppercase"
+                >Zero_Knowledge</span
+              >
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Content Layout -->
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-16">
+      <!-- Sidebar Nav -->
+      <aside class="hidden lg:block col-span-3 sticky top-32 h-fit">
+        <div
+          class="mt-24 p-6 bg-surface-container-low rounded-3xl border border-outline-variant/30"
+        >
+          <span
+            class="material-symbols-outlined text-primary mb-4"
+            style="font-variation-settings: 'FILL' 1;">info</span
+          >
+          <h4
+            class="font-headline text-xs font-bold uppercase tracking-widest mb-2"
+          >
+            Network Advisory
+          </h4>
+          <p class="text-xs text-on-surface-variant leading-relaxed">
+            Nodes operating outside of version 2.4.0 may experience
+            synchronization latency. Ensure your interface is current.
+          </p>
+        </div>
+      </aside>
+      <!-- Main Legal Text -->
+      <div class="col-span-12 lg:col-span-9 space-y-24">
+        <!-- Section 01 -->
+        <section class="scroll-mt-32" id="protocol">
+          <div class="flex items-baseline gap-4 mb-10">
+            <span class="font-mono text-4xl text-primary-dim opacity-50"
+              >01.</span
+            >
+            <h2 class="font-headline text-5xl font-bold tracking-tight">
+              Protocol Standards
+            </h2>
+          </div>
+          <div class="glass-panel p-10 rounded-2xl space-y-8">
+            <div class="space-y-4">
+              <h3
+                class="font-headline text-xl font-bold text-primary flex items-center gap-3"
+              >
+                1.1 Synchronization Requirements
+              </h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                The TajsOS Network requires all nodes to maintain a minimum of
+                99.9% uptime for primary protocol synchronization. Failure to
+                maintain these parameters may result in temporary node isolation
+                within the cluster. Users must ensure that their neural
+                interfaces are calibrated to the current protocol version.
+              </p>
+            </div>
+            <div class="space-y-4">
+              <h3
+                class="font-headline text-xl font-bold text-primary flex items-center gap-3"
+              >
+                1.2 Data Transmission Latency
+              </h3>
+              <p class="text-on-surface-variant leading-relaxed">
+                Transmission through the Neural Interface is subject to
+                spatial-temporal latency constraints. While the protocol
+                optimizes for near-instantaneous relay, TajsOS does not
+                guarantee zero-latency performance in sub-optimal network
+                environments.
+              </p>
+            </div>
+          </div>
+        </section>
+        <!-- Section 02 -->
+        <section class="scroll-mt-32" id="security">
+          <div class="flex items-baseline gap-4 mb-10">
+            <span class="font-mono text-4xl text-primary-dim opacity-50"
+              >02.</span
+            >
+            <h2 class="font-headline text-5xl font-bold tracking-tight">
+              Security &amp; Encryption
+            </h2>
+          </div>
+          <div
+            class="bg-surface-container-low p-10 rounded-2xl space-y-8 border border-outline-variant/30"
+          >
+            <div class="grid md:grid-cols-2 gap-12">
+              <div class="space-y-4">
+                <h3
+                  class="font-headline text-xl font-bold text-on-surface uppercase tracking-tight"
+                >
+                  2.1 Zero-Knowledge Proofs
+                </h3>
+                <p class="text-sm text-on-surface-variant leading-relaxed">
+                  Our security architecture utilizes recursive SNARKs to ensure
+                  privacy. At no point does the central network store
+                  unencrypted neural signatures or personal cognitive data. You
+                  remain the sole custodian of your decryption keys.
                 </p>
-</div>
-<div class="col-span-12 lg:col-span-4 flex flex-col justify-end items-start lg:items-end">
-<div class="p-6 glass-panel rounded-3xl w-full lg:w-auto">
-<p class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest mb-2">Last Updated</p>
-<p class="font-mono text-xl text-primary font-bold">2024.11.14 // 08:42:01</p>
-<div class="mt-6 space-y-2">
-<div class="flex justify-between items-center gap-4">
-<span class="text-[10px] font-label text-on-surface-variant uppercase tracking-[0.1em]">Encryption</span>
-<span class="text-[10px] font-label text-primary uppercase">Active_AES_256</span>
-</div>
-<div class="flex justify-between items-center gap-4">
-<span class="text-[10px] font-label text-on-surface-variant uppercase tracking-[0.1em]">Auth_Level</span>
-<span class="text-[10px] font-label text-primary uppercase">Zero_Knowledge</span>
-</div>
-</div>
-</div>
-</div>
-</section>
-<!-- Content Layout -->
-<div class="grid grid-cols-1 lg:grid-cols-12 gap-16">
-<!-- Sidebar Nav -->
-<aside class="hidden lg:block col-span-3 sticky top-32 h-fit">
-
-<div class="mt-24 p-6 bg-surface-container-low rounded-3xl border border-outline-variant/30">
-<span class="material-symbols-outlined text-primary mb-4" style="font-variation-settings: 'FILL' 1;">info</span>
-<h4 class="font-headline text-xs font-bold uppercase tracking-widest mb-2">Network Advisory</h4>
-<p class="text-xs text-on-surface-variant leading-relaxed">
-                        Nodes operating outside of version 2.4.0 may experience synchronization latency. Ensure your interface is current.
-                    </p>
-</div>
-</aside>
-<!-- Main Legal Text -->
-<div class="col-span-12 lg:col-span-9 space-y-24">
-<!-- Section 01 -->
-<section class="scroll-mt-32" id="protocol">
-<div class="flex items-baseline gap-4 mb-10">
-<span class="font-mono text-4xl text-primary-dim opacity-50">01.</span>
-<h2 class="font-headline text-5xl font-bold tracking-tight">Protocol Standards</h2>
-</div>
-<div class="glass-panel p-10 rounded-2xl space-y-8">
-<div class="space-y-4">
-<h3 class="font-headline text-xl font-bold text-primary flex items-center gap-3">
-                                1.1 Synchronization Requirements
-                            </h3>
-<p class="text-on-surface-variant leading-relaxed">
-                                The TajsOS Network requires all nodes to maintain a minimum of 99.9% uptime for primary protocol synchronization. Failure to maintain these parameters may result in temporary node isolation within the cluster. Users must ensure that their neural interfaces are calibrated to the current protocol version.
-                            </p>
-</div>
-<div class="space-y-4">
-<h3 class="font-headline text-xl font-bold text-primary flex items-center gap-3">
-                                1.2 Data Transmission Latency
-                            </h3>
-<p class="text-on-surface-variant leading-relaxed">
-                                Transmission through the Neural Interface is subject to spatial-temporal latency constraints. While the protocol optimizes for near-instantaneous relay, TajsOS does not guarantee zero-latency performance in sub-optimal network environments.
-                            </p>
-</div>
-</div>
-</section>
-<!-- Section 02 -->
-<section class="scroll-mt-32" id="security">
-<div class="flex items-baseline gap-4 mb-10">
-<span class="font-mono text-4xl text-primary-dim opacity-50">02.</span>
-<h2 class="font-headline text-5xl font-bold tracking-tight">Security &amp; Encryption</h2>
-</div>
-<div class="bg-surface-container-low p-10 rounded-2xl space-y-8 border border-outline-variant/30">
-<div class="grid md:grid-cols-2 gap-12">
-<div class="space-y-4">
-<h3 class="font-headline text-xl font-bold text-on-surface uppercase tracking-tight">2.1 Zero-Knowledge Proofs</h3>
-<p class="text-sm text-on-surface-variant leading-relaxed">
-                                    Our security architecture utilizes recursive SNARKs to ensure privacy. At no point does the central network store unencrypted neural signatures or personal cognitive data. You remain the sole custodian of your decryption keys.
-                                </p>
-</div>
-<div class="space-y-4">
-<h3 class="font-headline text-xl font-bold text-on-surface uppercase tracking-tight">2.2 Node Validation</h3>
-<p class="text-sm text-on-surface-variant leading-relaxed">
-                                    Every interaction is validated against the global ledger. Nodes found propagating anomalous or malicious payloads will be automatically purged by the network's immune system protocol (ISP-01).
-                                </p>
-</div>
-</div>
-<div class="mt-8 w-full h-[1px] bg-outline-variant/20 mb-8"></div>
-<div class="flex items-center justify-between">
-<div class="flex items-center gap-3">
-<span class="material-symbols-outlined text-primary">verified_user</span>
-<span class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest">Quantum_Resistance_Applied</span>
-</div>
-<div class="flex items-center gap-3">
-<span class="material-symbols-outlined text-primary">lock_open</span>
-<span class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest">End_To_End_Enforced</span>
-</div>
-</div>
-</div>
-</section>
-<!-- Section 03 -->
-<section class="scroll-mt-32" id="liability">
-<div class="flex items-baseline gap-4 mb-10">
-<span class="font-mono text-4xl text-primary-dim opacity-50">03.</span>
-<h2 class="font-headline text-5xl font-bold tracking-tight">Liability Limitation</h2>
-</div>
-<div class="glass-panel p-10 rounded-2xl relative overflow-hidden">
-<div class="absolute top-0 right-0 w-64 h-64 bg-primary/5 -z-10"></div>
-<p class="text-lg text-on-surface-variant leading-relaxed mb-6 italic">
-                            "The network is a neutral fabric; it is the user's intent that shapes its outcome."
-                        </p>
-<p class="text-on-surface-variant leading-relaxed">
-                            TajsOS provides the infrastructure "AS IS" and "AS AVAILABLE." We disclaim all liability for cognitive fatigue, data loss, or unauthorized node access resulting from user-end security breaches. Under no circumstances shall TajsOS be liable for indirect, incidental, special, or consequential damages resulting from protocol interaction.
-                        </p>
-</div>
-</section>
-<!-- Section 04 -->
-<section class="scroll-mt-32" id="nodes">
-<div class="flex items-baseline gap-4 mb-10">
-<span class="font-mono text-4xl text-primary-dim opacity-50">04.</span>
-<h2 class="font-headline text-5xl font-bold tracking-tight">Node Operator Conduct</h2>
-</div>
-<div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-<div class="p-8 bg-surface-container-highest rounded-3xl">
-<h4 class="font-headline text-xs font-bold text-primary uppercase tracking-[0.2em] mb-4">Integrity</h4>
-<p class="text-sm text-on-surface-variant">Maintain the purity of the ledger and refrain from any computational deception.</p>
-</div>
-<div class="p-8 bg-surface-container-highest rounded-3xl">
-<h4 class="font-headline text-xs font-bold text-primary uppercase tracking-[0.2em] mb-4">Cooperation</h4>
-<p class="text-sm text-on-surface-variant">Assist neighboring nodes in data propagation and network healing routines.</p>
-</div>
-<div class="p-8 bg-surface-container-highest rounded-3xl">
-<h4 class="font-headline text-xs font-bold text-primary uppercase tracking-[0.2em] mb-4">Anonymity</h4>
-<p class="text-sm text-on-surface-variant">Respect the privacy headers of all encapsulated data packets.</p>
-</div>
-</div>
-</section>
-<!-- CTA Actions -->
-<div class="w-full h-[1px] bg-outline-variant/30 mb-8"></div>
-<div class="pt-12 flex flex-col md:flex-row items-center justify-between gap-8">
-<div class="flex flex-col gap-2">
-<p class="font-headline font-bold text-2xl">Confirm Synchronization</p>
-<p class="text-sm text-on-surface-variant">By proceeding, you bind your node to these protocols.</p>
-</div>
-<div class="flex items-center gap-4 w-full md:w-auto">
-<button  class="flex-1 md:flex-none px-8 py-4 bg-surface-container-highest text-on-surface font-label text-sm font-bold rounded-xl border border-outline-variant/30 hover:bg-surface-variant transition-all min-h-[48px]">
-                            Download Whitepaper
-                        </button>
-<button  class="flex-1 md:flex-none px-12 py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary font-label text-sm font-bold rounded-xl shadow-[0_0_50px_rgba(186,158,255,0.4)] active:scale-95 transition-all min-h-[48px]">
-                            Accept Protocol
-                        </button>
-</div>
-</div>
-</div>
-</div>
-
+              </div>
+              <div class="space-y-4">
+                <h3
+                  class="font-headline text-xl font-bold text-on-surface uppercase tracking-tight"
+                >
+                  2.2 Node Validation
+                </h3>
+                <p class="text-sm text-on-surface-variant leading-relaxed">
+                  Every interaction is validated against the global ledger.
+                  Nodes found propagating anomalous or malicious payloads will
+                  be automatically purged by the network's immune system
+                  protocol (ISP-01).
+                </p>
+              </div>
+            </div>
+            <div class="mt-8 w-full h-[1px] bg-outline-variant/20 mb-8"></div>
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-3">
+                <span class="material-symbols-outlined text-primary"
+                  >verified_user</span
+                >
+                <span
+                  class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest"
+                  >Quantum_Resistance_Applied</span
+                >
+              </div>
+              <div class="flex items-center gap-3">
+                <span class="material-symbols-outlined text-primary"
+                  >lock_open</span
+                >
+                <span
+                  class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest"
+                  >End_To_End_Enforced</span
+                >
+              </div>
+            </div>
+          </div>
+        </section>
+        <!-- Section 03 -->
+        <section class="scroll-mt-32" id="liability">
+          <div class="flex items-baseline gap-4 mb-10">
+            <span class="font-mono text-4xl text-primary-dim opacity-50"
+              >03.</span
+            >
+            <h2 class="font-headline text-5xl font-bold tracking-tight">
+              Liability Limitation
+            </h2>
+          </div>
+          <div class="glass-panel p-10 rounded-2xl relative overflow-hidden">
+            <div class="absolute top-0 right-0 w-64 h-64 bg-primary/5 -z-10">
+            </div>
+            <p
+              class="text-lg text-on-surface-variant leading-relaxed mb-6 italic"
+            >
+              "The network is a neutral fabric; it is the user's intent that
+              shapes its outcome."
+            </p>
+            <p class="text-on-surface-variant leading-relaxed">
+              TajsOS provides the infrastructure "AS IS" and "AS AVAILABLE." We
+              disclaim all liability for cognitive fatigue, data loss, or
+              unauthorized node access resulting from user-end security
+              breaches. Under no circumstances shall TajsOS be liable for
+              indirect, incidental, special, or consequential damages resulting
+              from protocol interaction.
+            </p>
+          </div>
+        </section>
+        <!-- Section 04 -->
+        <section class="scroll-mt-32" id="nodes">
+          <div class="flex items-baseline gap-4 mb-10">
+            <span class="font-mono text-4xl text-primary-dim opacity-50"
+              >04.</span
+            >
+            <h2 class="font-headline text-5xl font-bold tracking-tight">
+              Node Operator Conduct
+            </h2>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div class="p-8 bg-surface-container-highest rounded-3xl">
+              <h4
+                class="font-headline text-xs font-bold text-primary uppercase tracking-[0.2em] mb-4"
+              >
+                Integrity
+              </h4>
+              <p class="text-sm text-on-surface-variant">
+                Maintain the purity of the ledger and refrain from any
+                computational deception.
+              </p>
+            </div>
+            <div class="p-8 bg-surface-container-highest rounded-3xl">
+              <h4
+                class="font-headline text-xs font-bold text-primary uppercase tracking-[0.2em] mb-4"
+              >
+                Cooperation
+              </h4>
+              <p class="text-sm text-on-surface-variant">
+                Assist neighboring nodes in data propagation and network healing
+                routines.
+              </p>
+            </div>
+            <div class="p-8 bg-surface-container-highest rounded-3xl">
+              <h4
+                class="font-headline text-xs font-bold text-primary uppercase tracking-[0.2em] mb-4"
+              >
+                Anonymity
+              </h4>
+              <p class="text-sm text-on-surface-variant">
+                Respect the privacy headers of all encapsulated data packets.
+              </p>
+            </div>
+          </div>
+        </section>
+        <!-- CTA Actions -->
+        <div class="w-full h-[1px] bg-outline-variant/30 mb-8"></div>
+        <div
+          class="pt-12 flex flex-col md:flex-row items-center justify-between gap-8"
+        >
+          <div class="flex flex-col gap-2">
+            <p class="font-headline font-bold text-2xl">
+              Confirm Synchronization
+            </p>
+            <p class="text-sm text-on-surface-variant">
+              By proceeding, you bind your node to these protocols.
+            </p>
+          </div>
+          <div class="flex items-center gap-4 w-full md:w-auto">
+            <button
+              class="flex-1 md:flex-none px-8 py-4 bg-surface-container-highest text-on-surface font-label text-sm font-bold rounded-xl border border-outline-variant/30 hover:bg-surface-variant transition-all min-h-[48px]"
+            >
+              Download Whitepaper
+            </button>
+            <button
+              class="flex-1 md:flex-none px-12 py-4 bg-linear-to-br from-primary to-primary-dim text-on-primary font-label text-sm font-bold rounded-xl shadow-[0_0_50px_rgba(186,158,255,0.4)] active:scale-95 transition-all min-h-[48px]"
+            >
+              Accept Protocol
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -1,90 +1,177 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/landing/Navbar.astro';
-import Footer from '../components/landing/Footer.astro';
-import { SITE } from '../data/site';
+import Layout from "../layouts/Layout.astro";
+import Navbar from "../components/landing/Navbar.astro";
+import Footer from "../components/landing/Footer.astro";
+import { SITE } from "../data/site";
 
 const title = "WAITLIST";
 ---
 
 <Layout title={title}>
   <div class="fixed inset-0 noise-bg pointer-events-none z-50"></div>
-  <div class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"></div>
-  
+  <div
+    class="fixed top-[-10%] right-[-5%] w-[600px] h-[600px] gradient-sphere pointer-events-none -z-10"
+  >
+  </div>
+
   <Navbar />
   <main class="relative pt-32 max-w-[1600px] mx-auto px-8 min-h-dvh">
-    
-<!-- Background Spatial Layering Decor -->
-<div class="absolute inset-0 overflow-hidden pointer-events-none">
-<div class="absolute top-[20%] left-[10%] w-[40rem] h-[40rem] bg-primary/5 rounded-full"></div>
-<div class="absolute bottom-[10%] right-[5%] w-[30rem] h-[30rem] bg-secondary/5 rounded-full"></div>
-</div>
-<!-- Hero Content -->
-<div class="relative z-10 w-full max-w-5xl flex flex-col items-center text-center">
-<!-- Technical Indicator -->
-<div class="mb-8 flex items-center gap-3 bg-surface-container-low/50 px-4 py-1.5 rounded-full border border-outline-variant/20">
-<span class="flex h-2 w-2 relative">
-<span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75"></span>
-<span class="relative inline-flex rounded-full h-2 w-2 bg-primary"></span>
-</span>
-<span class="font-mono text-[10px] tracking-[0.3em] text-primary uppercase">{SITE.statusText}</span>
-</div>
-<!-- Main Headline -->
-<h1 class="font-headline font-bold text-6xl md:text-8xl lg:text-9xl tracking-tighter text-on-surface glow-text mb-4 leading-none">
-                JOIN WAITLIST
-            </h1>
-<p class="font-body text-on-surface-variant max-w-xl text-lg mb-16 leading-relaxed">
-                Join the waitlist for TajsOS. Secure early access to the local-first personal operating system.
-            </p>
-<!-- Waitlist Module -->
-<div class="w-full max-w-lg group relative">
-<div class="absolute -inset-0.5 bg-linear-to-r from-primary to-primary-dim rounded-xl blur opacity-20 transition duration-1000"></div>
-<form id="waitlist-form" class="relative flex items-center bg-surface-container-lowest border border-transparent rounded-xl overflow-hidden focus-within:ring-1 focus-within:ring-primary focus-within:ring-inset transition-all duration-500">
-<label for="waitlist-email" class="sr-only">Email address</label>
-<input id="waitlist-email" class="bg-transparent border-transparent text-on-surface placeholder:text-outline font-mono py-5 px-6 w-full text-lg outline-none" placeholder="email@example.com" type="email" required autocomplete="email"/>
-<button  id="waitlist-submit" type="submit" class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold px-12 py-6 text-xl transition-all flex items-center gap-2 group/btn relative overflow-hidden min-h-[48px]">
-                        <span id="waitlist-button-text">JOIN NOW</span>
-                        <div id="waitlist-loading" class="hidden absolute inset-0 bg-primary flex items-center justify-center">
-                            <span class="material-symbols-outlined text-on-primary animate-spin">progress_activity</span>
-                        </div>
-                        <span class="material-symbols-outlined text-xl transition-transform group-hover/btn:translate-x-1" data-icon="arrow_forward">arrow_forward</span>
-</button>
-</form>
-<p id="waitlist-status" class="hidden" role="status" aria-live="polite"></p>
-</div>
-<!-- Countdown Timer -->
-<div class="mt-16 flex flex-col items-center">
-<span class="font-label text-[10px] tracking-[0.4em] text-outline uppercase mb-4">Time to Early Access</span>
-<div class="font-mono text-4xl md:text-5xl tracking-widest text-on-surface-variant tabular-nums">
-                    <span id="countdown-days">04</span><span class="text-primary animate-pulse">:</span><span id="countdown-hours">12</span><span class="text-primary animate-pulse">:</span><span id="countdown-minutes">09</span><span class="text-primary animate-pulse">:</span><span id="countdown-seconds">55</span>
-                </div>
-</div>
-<!-- Status Panels - Bento Style -->
-<div class="mt-24 grid grid-cols-1 md:grid-cols-3 gap-4 w-full max-w-4xl">
-<div class="bg-surface-container-low/40 p-6 rounded-3xl border border-outline-variant/10 flex flex-col items-start gap-4">
-<span class="material-symbols-outlined text-primary-dim" data-icon="waves">waves</span>
-<div class="text-left">
-<div class="font-label text-[10px] tracking-widest text-outline uppercase mb-1">Sync_Status</div>
-<div class="font-mono text-xl text-on-surface">Local First</div>
-</div>
-</div>
-<div class="bg-surface-container-low/40 p-6 rounded-3xl border border-outline-variant/10 flex flex-col items-start gap-4">
-<span class="material-symbols-outlined text-primary-dim" data-icon="cloud_done">cloud_done</span>
-<div class="text-left">
-<div class="font-label text-[10px] tracking-widest text-outline uppercase mb-1">App_Size</div>
-<div class="font-mono text-xl text-primary">Lightweight</div>
-</div>
-</div>
-<div class="bg-surface-container-low/40 p-6 rounded-3xl border border-outline-variant/10 flex flex-col items-start gap-4">
-<span class="material-symbols-outlined text-primary-dim" data-icon="encrypted">encrypted</span>
-<div class="text-left">
-<div class="font-label text-[10px] tracking-widest text-outline uppercase mb-1">Database</div>
-<div class="font-mono text-xl text-on-surface">SQLite</div>
-</div>
-</div>
-</div>
-</div>
-
+    <!-- Background Spatial Layering Decor -->
+    <div class="absolute inset-0 overflow-hidden pointer-events-none">
+      <div
+        class="absolute top-[20%] left-[10%] w-[40rem] h-[40rem] bg-primary/5 rounded-full"
+      >
+      </div>
+      <div
+        class="absolute bottom-[10%] right-[5%] w-[30rem] h-[30rem] bg-secondary/5 rounded-full"
+      >
+      </div>
+    </div>
+    <!-- Hero Content -->
+    <div
+      class="relative z-10 w-full max-w-5xl flex flex-col items-center text-center"
+    >
+      <!-- Technical Indicator -->
+      <div
+        class="mb-8 flex items-center gap-3 bg-surface-container-low/50 px-4 py-1.5 rounded-full border border-outline-variant/20"
+      >
+        <span class="flex h-2 w-2 relative">
+          <span
+            class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75"
+          ></span>
+          <span class="relative inline-flex rounded-full h-2 w-2 bg-primary"
+          ></span>
+        </span>
+        <span
+          class="font-mono text-[10px] tracking-[0.3em] text-primary uppercase"
+          >{SITE.statusText}</span
+        >
+      </div>
+      <!-- Main Headline -->
+      <h1
+        class="font-headline font-bold text-6xl md:text-8xl lg:text-9xl tracking-tighter text-on-surface glow-text mb-4 leading-none"
+      >
+        JOIN WAITLIST
+      </h1>
+      <p
+        class="font-body text-on-surface-variant max-w-xl text-lg mb-16 leading-relaxed"
+      >
+        Join the waitlist for TajsOS. Secure early access to the local-first
+        personal operating system.
+      </p>
+      <!-- Waitlist Module -->
+      <div class="w-full max-w-lg group relative">
+        <div
+          class="absolute -inset-0.5 bg-linear-to-r from-primary to-primary-dim rounded-xl blur opacity-20 transition duration-1000"
+        >
+        </div>
+        <form
+          id="waitlist-form"
+          class="relative flex items-center bg-surface-container-lowest border border-transparent rounded-xl overflow-hidden focus-within:ring-1 focus-within:ring-primary focus-within:ring-inset transition-all duration-500"
+        >
+          <label for="waitlist-email" class="sr-only">Email address</label>
+          <input
+            id="waitlist-email"
+            class="bg-transparent border-transparent text-on-surface placeholder:text-outline font-mono py-5 px-6 w-full text-lg outline-none"
+            placeholder="email@example.com"
+            type="email"
+            required
+            autocomplete="email"
+          />
+          <button
+            id="waitlist-submit"
+            type="submit"
+            class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold px-12 py-6 text-xl transition-all flex items-center gap-2 group/btn relative overflow-hidden min-h-[48px]"
+          >
+            <span id="waitlist-button-text">JOIN NOW</span>
+            <div
+              id="waitlist-loading"
+              class="hidden absolute inset-0 bg-primary flex items-center justify-center"
+            >
+              <span
+                class="material-symbols-outlined text-on-primary animate-spin"
+                >progress_activity</span
+              >
+            </div>
+            <span
+              class="material-symbols-outlined text-xl transition-transform group-hover/btn:translate-x-1"
+              data-icon="arrow_forward">arrow_forward</span
+            >
+          </button>
+        </form>
+        <p id="waitlist-status" class="hidden" role="status" aria-live="polite">
+        </p>
+      </div>
+      <!-- Countdown Timer -->
+      <div class="mt-16 flex flex-col items-center">
+        <span
+          class="font-label text-[10px] tracking-[0.4em] text-outline uppercase mb-4"
+          >Time to Early Access</span
+        >
+        <div
+          class="font-mono text-4xl md:text-5xl tracking-widest text-on-surface-variant tabular-nums"
+        >
+          <span id="countdown-days">04</span><span
+            class="text-primary animate-pulse">:</span
+          ><span id="countdown-hours">12</span><span
+            class="text-primary animate-pulse">:</span
+          ><span id="countdown-minutes">09</span><span
+            class="text-primary animate-pulse">:</span
+          ><span id="countdown-seconds">55</span>
+        </div>
+      </div>
+      <!-- Status Panels - Bento Style -->
+      <div class="mt-24 grid grid-cols-1 md:grid-cols-3 gap-4 w-full max-w-4xl">
+        <div
+          class="bg-surface-container-low/40 p-6 rounded-3xl border border-outline-variant/10 flex flex-col items-start gap-4"
+        >
+          <span
+            class="material-symbols-outlined text-primary-dim"
+            data-icon="waves">waves</span
+          >
+          <div class="text-left">
+            <div
+              class="font-label text-[10px] tracking-widest text-outline uppercase mb-1"
+            >
+              Sync_Status
+            </div>
+            <div class="font-mono text-xl text-on-surface">Local First</div>
+          </div>
+        </div>
+        <div
+          class="bg-surface-container-low/40 p-6 rounded-3xl border border-outline-variant/10 flex flex-col items-start gap-4"
+        >
+          <span
+            class="material-symbols-outlined text-primary-dim"
+            data-icon="cloud_done">cloud_done</span
+          >
+          <div class="text-left">
+            <div
+              class="font-label text-[10px] tracking-widest text-outline uppercase mb-1"
+            >
+              App_Size
+            </div>
+            <div class="font-mono text-xl text-primary">Lightweight</div>
+          </div>
+        </div>
+        <div
+          class="bg-surface-container-low/40 p-6 rounded-3xl border border-outline-variant/10 flex flex-col items-start gap-4"
+        >
+          <span
+            class="material-symbols-outlined text-primary-dim"
+            data-icon="encrypted">encrypted</span
+          >
+          <div class="text-left">
+            <div
+              class="font-label text-[10px] tracking-widest text-outline uppercase mb-1"
+            >
+              Database
+            </div>
+            <div class="font-mono text-xl text-on-surface">SQLite</div>
+          </div>
+        </div>
+      </div>
+    </div>
   </main>
   <Footer />
 </Layout>
@@ -100,7 +187,10 @@ const title = "WAITLIST";
   waitlistForm?.addEventListener("submit", async (event) => {
     event.preventDefault();
 
-    if (!(waitlistEmailInput instanceof HTMLInputElement) || !(waitlistStatus instanceof HTMLElement)) {
+    if (
+      !(waitlistEmailInput instanceof HTMLInputElement) ||
+      !(waitlistStatus instanceof HTMLElement)
+    ) {
       return;
     }
 
@@ -110,14 +200,16 @@ const title = "WAITLIST";
     if (!emailPattern.test(email)) {
       waitlistStatus.textContent = "Please enter a valid email address.";
       waitlistStatus.classList.remove("hidden");
-      waitlistStatus.className = "mt-4 text-sm text-error font-mono bg-error/10 px-4 py-2 rounded-lg border border-error/20";
+      waitlistStatus.className =
+        "mt-4 text-sm text-error font-mono bg-error/10 px-4 py-2 rounded-lg border border-error/20";
       waitlistEmailInput.focus();
       return;
     }
 
     waitlistStatus.textContent = "Submitting...";
     waitlistStatus.classList.remove("hidden");
-      waitlistStatus.className = "mt-4 text-sm text-primary font-mono bg-primary/10 px-4 py-2 rounded-lg border border-primary/20";
+    waitlistStatus.className =
+      "mt-4 text-sm text-primary font-mono bg-primary/10 px-4 py-2 rounded-lg border border-primary/20";
     if (waitlistSubmit) waitlistSubmit.setAttribute("disabled", "true");
     if (waitlistLoading) waitlistLoading.classList.remove("hidden");
     if (waitlistButtonText) waitlistButtonText.classList.add("invisible");
@@ -134,23 +226,26 @@ const title = "WAITLIST";
       }
 
       if (waitlistForm instanceof HTMLFormElement) waitlistForm.reset();
-      waitlistStatus.textContent = "You are on the waitlist. We will contact you soon.";
+      waitlistStatus.textContent =
+        "You are on the waitlist. We will contact you soon.";
       waitlistStatus.classList.remove("hidden");
-      waitlistStatus.className = "mt-4 text-sm text-primary font-mono bg-primary/10 px-4 py-2 rounded-lg border border-primary/20";
+      waitlistStatus.className =
+        "mt-4 text-sm text-primary font-mono bg-primary/10 px-4 py-2 rounded-lg border border-primary/20";
       if (waitlistSubmit) waitlistSubmit.removeAttribute("disabled");
       if (waitlistLoading) waitlistLoading.classList.add("hidden");
       if (waitlistButtonText) waitlistButtonText.classList.remove("invisible");
     } catch {
-      waitlistStatus.textContent = "Could not join the waitlist right now. Try again in a moment.";
+      waitlistStatus.textContent =
+        "Could not join the waitlist right now. Try again in a moment.";
       waitlistStatus.classList.remove("hidden");
-      waitlistStatus.className = "mt-4 text-sm text-error font-mono bg-error/10 px-4 py-2 rounded-lg border border-error/20";
+      waitlistStatus.className =
+        "mt-4 text-sm text-error font-mono bg-error/10 px-4 py-2 rounded-lg border border-error/20";
       if (waitlistSubmit) waitlistSubmit.removeAttribute("disabled");
       if (waitlistLoading) waitlistLoading.classList.add("hidden");
       if (waitlistButtonText) waitlistButtonText.classList.remove("invisible");
     }
   });
 </script>
-
 
 <script>
   // Countdown Timer
@@ -166,7 +261,9 @@ const title = "WAITLIST";
     }
 
     const days = Math.floor(distance / (1000 * 60 * 60 * 24));
-    const hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+    const hours = Math.floor(
+      (distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
+    );
     const minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
     const seconds = Math.floor((distance % (1000 * 60)) / 1000);
 


### PR DESCRIPTION
This PR introduces standard code formatting to the `website` project. 

It installs `prettier-plugin-astro` to properly format `.astro` files and configures `biome.json` to handle JS/TS/JSON files. Because Biome currently lacks support for Tailwind v4's `@theme` syntax and Astro components, they are excluded from Biome's target paths.

The entire `website/src/` tree has been formatted to improve readability and consistency.

---
*PR created automatically by Jules for task [1255071731479190199](https://jules.google.com/task/1255071731479190199) started by @tajemniktv*