### PR TITLE
feat(ui): add hand cursor to mouse clickable areas on desktop

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/MouseInteractions.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/MouseInteractions.kt
@@ -213,7 +213,7 @@ fun Modifier.mouseClickable(
                     indication = indication ?: LocalIndication.current,
                     onClick = { onClick?.invoke() },
                     onLongClick = onLongClick,
-                ).let { if (enabled) it.pointerHoverIcon(PointerIcon.Hand) else it }
+                ).pointerHoverIcon(PointerIcon.Hand)
             } else {
                 this
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/MouseInteractions.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/MouseInteractions.kt
@@ -4,6 +4,8 @@
 
 package com.tajemniktv.tajsos.ui.components.common
 
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.LocalIndication
@@ -211,7 +213,7 @@ fun Modifier.mouseClickable(
                     indication = indication ?: LocalIndication.current,
                     onClick = { onClick?.invoke() },
                     onLongClick = onLongClick,
-                )
+                ).pointerHoverIcon(PointerIcon.Hand)
             } else {
                 this
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/MouseInteractions.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/MouseInteractions.kt
@@ -213,7 +213,7 @@ fun Modifier.mouseClickable(
                     indication = indication ?: LocalIndication.current,
                     onClick = { onClick?.invoke() },
                     onLongClick = onLongClick,
-                ).pointerHoverIcon(PointerIcon.Hand)
+                ).let { if (enabled) it.pointerHoverIcon(PointerIcon.Hand) else it }
             } else {
                 this
             }


### PR DESCRIPTION
Creates a safe UX enhancement by showing a hand cursor when hovering over interactive elements using the `mouseClickable` modifier, improving usability on desktop/web platforms without altering product direction.

---
*PR created automatically by Jules for task [2534016283875917829](https://jules.google.com/task/2534016283875917829) started by @tajemniktv*