### PR TITLE
perf: Replace redundant .lowercase() calls with ignoreCase=true flag for string operations

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -256,6 +256,9 @@ object DomainLensQueries {
     /**
      * Configuration class to group matching heuristics. This avoids having functions with many string/collection
      * arguments, which can trigger code health violations.
+     *
+     * Memory allocations during matching (such as repeated `.lowercase()` calls) are avoided
+     * by using Kotlin's built-in `ignoreCase = true` string evaluation operations where possible.
      */
     private class DomainMatcher(
         val maintenanceTypes: Set<String>,
@@ -271,11 +274,11 @@ object DomainLensQueries {
 
             if (node.tags.any { it.normalizedName in tagMarkers }) return true
 
-            val title = node.node.title.lowercase()
-            if (titleKeywords.any { keyword -> title.contains(keyword) }) return true
+            val title = node.node.title
+            if (titleKeywords.any { keyword -> title.contains(keyword, ignoreCase = true) }) return true
 
-            val content = node.node.content.lowercase()
-            if (titleKeywords.any { keyword -> content.contains(keyword) }) return true
+            val content = node.node.content
+            if (titleKeywords.any { keyword -> content.contains(keyword, ignoreCase = true) }) return true
 
             return false
         }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -953,6 +953,13 @@ fun maintenanceUrgency(
  * @param projects A curated list of nodes strictly identified as "project" entities.
  * @return A [TimeArchitectureSnapshot] organizing nodes into layers (e.g., today, week, semester).
  */
+/**
+ * Calculates the hierarchical time and project phases structure to populate the Time shell.
+ *
+ * To preserve UI performance and minimize garbage collection pauses on slower devices,
+ * string sorting uses `compareTo(..., ignoreCase = true)` rather than `.lowercase()`
+ * allocations.
+ */
 fun calculateTimeArchitectureSnapshot(
     nodes: List<NodeWithPin>,
     todayLayerNodes: List<NodeEntity>,
@@ -1041,7 +1048,7 @@ fun calculateTimeArchitectureSnapshot(
                     isActivePhase = isActive,
                     phaseLabel = if (isActive) "active_phase" else "inactive_phase",
                 )
-            }.sortedBy { it.project.title.lowercase() }
+            }.sortedWith { a, b -> a.project.title.compareTo(b.project.title, ignoreCase = true) }
 
     return com.tajemniktv.tajsos.ui.TimeArchitectureSnapshot(
         todayLayer = todayLayer,
@@ -1079,6 +1086,10 @@ fun nextMonthlyResetDate(): String {
  * Evaluates all person-anchored nodes and their explicitly assigned relational events
  * to generate a [RelationshipSnapshot]. Assesses when someone was last contacted and calculates follow-up pressure.
  *
+ * To preserve UI performance and minimize garbage collection pauses on slower devices,
+ * string sorting uses `compareTo(..., ignoreCase = true)` rather than `.lowercase()`
+ * allocations.
+ *
  * @param nodes The complete list of active nodes in the system.
  * @param relations The complete list of relational edges tying nodes together.
  * @return A structured [RelationshipSnapshot] describing the health of active tracked relationships.
@@ -1094,7 +1105,7 @@ fun calculateRelationshipSnapshot(
     val people =
         nodes
             .filter { it.node.isRelationshipAnchor() && it.node.status == "active" }
-            .sortedBy { it.node.title.lowercase() }
+            .sortedWith { a, b -> a.node.title.compareTo(b.node.title, ignoreCase = true) }
 
     /**
      * Filters the global node list to extract all tasks or notes explicitly mentioning or linked to a specific person.
@@ -1216,26 +1227,17 @@ fun calculateRelationshipSnapshot(
     val importantRelationships =
         peopleItems
             .filter { it.isImportant }
-            .sortedBy {
-                it.person.node.title
-                    .lowercase()
-            }
+            .sortedWith { a, b -> a.person.node.title.compareTo(b.person.node.title, ignoreCase = true) }
 
     val professors =
         peopleItems
             .filter { it.relationshipType == "professor" }
-            .sortedBy {
-                it.person.node.title
-                    .lowercase()
-            }
+            .sortedWith { a, b -> a.person.node.title.compareTo(b.person.node.title, ignoreCase = true) }
 
     val friendsAndFamily =
         peopleItems
             .filter { it.relationshipType == "friend" || it.relationshipType == "family" }
-            .sortedBy {
-                it.person.node.title
-                    .lowercase()
-            }
+            .sortedWith { a, b -> a.person.node.title.compareTo(b.person.node.title, ignoreCase = true) }
 
     val gentlePrompt =
         when
@@ -2733,7 +2735,7 @@ fun calculateStudentBoardState(
                             null
                         },
                 )
-            }.sortedBy { it.courseName.lowercase() }
+            }.sortedWith { a, b -> a.courseName.compareTo(b.courseName, ignoreCase = true) }
 
     val bySemester =
         activeNodes
@@ -2774,7 +2776,7 @@ fun calculateStudentBoardState(
                     upcomingExams = upcomingExams,
                     dueSoon = dueSoon,
                 )
-            }.sortedBy { it.semester.lowercase() }
+            }.sortedWith { a, b -> a.semester.compareTo(b.semester, ignoreCase = true) }
 
     val topicToNoteLinks =
         relations.count {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import app.cash.turbine.test
 import com.tajemniktv.tajsos.ui.SidebarMode
 import kotlinx.coroutines.flow.Flow

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
@@ -94,6 +94,7 @@ class RelationshipCommandsTest {
         val relations = repo.getRelationsForNode(1L).first()
         val relatedPersonIds = relations.filter { it.relationType == "RELATED_PERSON" }.map { it.fromNodeId }.toSet()
         assertEquals(setOf(personId), relatedPersonIds)
+        val relation = relations.find { it.relationType == "RELATED_PERSON" }
         assertTrue(relation != null)
         assertEquals(replyNodes.first().node.id, relation.toNodeId)
     }


### PR DESCRIPTION
Replaces memory-intensive `.lowercase()` calls during string sorting and matching with Kotlin's built-in `ignoreCase = true` operations, reducing GC pressure during filtering and sorting calculations in `MainSnapshotCalculators` and `DomainLensQueries`. Includes added KDoc documentation to explain the performance consideration.

---
*PR created automatically by Jules for task [9381215996988535113](https://jules.google.com/task/9381215996988535113) started by @tajemniktv*