### PR TITLE
fix(reliability): Rethrow CancellationException in generic try-catch blocks

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos
 
+import kotlin.coroutines.cancellation.CancellationException
 import android.content.Intent
 import android.net.Uri
 import android.os.BadParcelableException
@@ -420,6 +421,8 @@ class MainActivity : FragmentActivity() {
                         try {
                             authCipher.doFinal("auth".toByteArray())
                             viewModel.setAuthenticated(true)
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             Log.e(TAG, "Biometric crypto operation failed: ${e.javaClass.simpleName}")
                         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardLayoutEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardLayoutEngine.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.dashboard
 
+import kotlin.coroutines.cancellation.CancellationException
 import com.tajemniktv.tajsos.data.AppPack
 import com.tajemniktv.tajsos.data.PackRegistry
 import com.tajemniktv.tajsos.ui.DashboardUIState
@@ -446,6 +447,8 @@ private fun normalizeBlocks(
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardLayoutEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardLayoutEngine.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.finance
 
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -103,6 +104,8 @@ fun buildFinanceDashboardPlan(
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardLayoutEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardLayoutEngine.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.study
 
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -93,6 +94,8 @@ fun buildStudyDashboardPlan(
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.tasks.detail
 
+import kotlin.coroutines.cancellation.CancellationException
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -549,6 +550,8 @@ private fun formatTime(epochMillis: Long): String {
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
@@ -4,6 +4,8 @@
 
 package com.tajemniktv.tajsos.data
 
+import kotlin.coroutines.cancellation.CancellationException
+
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -146,6 +148,8 @@ fun buildModeQueryProfile(
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
@@ -4,6 +4,8 @@
 
 package com.tajemniktv.tajsos.data
 
+import kotlin.coroutines.cancellation.CancellationException
+
 import com.tajemniktv.tajsos.domain.DomainKind
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -104,6 +106,8 @@ data class AreaMetadata(
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import app.cash.turbine.test
 import com.tajemniktv.tajsos.ui.SidebarMode
 import kotlinx.coroutines.flow.Flow

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
@@ -94,8 +94,8 @@ class RelationshipCommandsTest {
         val relations = repo.getRelationsForNode(1L).first()
         val relatedPersonIds = relations.filter { it.relationType == "RELATED_PERSON" }.map { it.fromNodeId }.toSet()
         assertEquals(setOf(personId), relatedPersonIds)
-        assertTrue(relation != null)
-        assertEquals(replyNodes.first().node.id, relation.toNodeId)
+        assertTrue(relations.isNotEmpty())
+        assertEquals(replyNodes.first().node.id, relations.first().toNodeId)
     }
 
     @Test


### PR DESCRIPTION
Catching generic `Exception` often swallows Kotlin's `CancellationException`, which prevents coroutines from cancelling gracefully and can lead to wasted resources, hanging processes, and unpredictable state.
This patch explicitly catches and re-throws `CancellationException` before the generic `Exception` catch block in various layers of the application (`safeDecode` and other blocks) to restore standard coroutine behavior.
Also fixes a broken test in `RelationshipCommandsTest` where an undefined variable was being asserted.

---
*PR created automatically by Jules for task [6959083682359695338](https://jules.google.com/task/6959083682359695338) started by @tajemniktv*