### PR TITLE
fix(ui): add pointer hover icon to clickable elements

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/TrackCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/TrackCards.kt
@@ -33,6 +33,8 @@ import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.track_dosage_confirmed
 import tajsos.composeapp.generated.resources.track_medication_synk
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun MedicationSyncCard(
@@ -86,7 +88,7 @@ fun MedicationSyncCard(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { onToggleMed(med.id) }
+                                .clickable { onToggleMed(med.id) }.pointerHoverIcon(PointerIcon.Hand)
                                 .padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
@@ -35,6 +35,8 @@ import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.common_system_online
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders the dashboard header with a left menu badge and status block and a right-side system indicator with a settings button.
@@ -58,7 +60,7 @@ fun DashHeader(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.clickable { onMenuClick() },
+            modifier = Modifier.clickable { onMenuClick() }.pointerHoverIcon(PointerIcon.Hand),
         ) {
             Box(
                 modifier =

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -96,6 +96,8 @@ import tajsos.composeapp.generated.resources.decision_tap_to_add
 import tajsos.composeapp.generated.resources.detail_none
 import tajsos.composeapp.generated.resources.identity_clear
 import kotlin.time.Clock
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a detailed UI for viewing and editing a single decision node.
@@ -424,7 +426,7 @@ fun DecisionDetailContent(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { selectedOptionId = option.id },
+                                    .clickable { selectedOptionId = option.id }.pointerHoverIcon(PointerIcon.Hand),
                         ) {
                             RadioButton(
                                 selected = selectedOptionId == option.id,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a clickable task row with a circular completion indicator and title.
@@ -71,7 +73,7 @@ fun TaskBrief(
                             1.dp,
                             if (isDone) TajsOSTheme.Primary else TajsOSTheme.GhostBorder,
                             CircleShape,
-                        ).clickable { onToggle() },
+                        ).clickable { onToggle() }.pointerHoverIcon(PointerIcon.Hand),
                 contentAlignment = Alignment.Center,
             ) {
                 if (isDone) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
@@ -46,6 +46,8 @@ import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.no_active_system_alerts
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Premium "system-monitor" notification card with futuristic aesthetics.
@@ -69,7 +71,7 @@ fun TajsNotificationCard(
             modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(TajsOSTheme.RadiusMd))
-                .clickable { notification.onClick() },
+                .clickable { notification.onClick() }.pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.SurfaceLow,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
@@ -81,6 +81,8 @@ import tajsos.composeapp.generated.resources.project_detail_linked_notes
 import tajsos.composeapp.generated.resources.project_detail_status
 import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_record
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object AreaDetailBlocks {
     private val renderers: Map<String, AreaDetailBlockRenderer> =
@@ -411,7 +413,7 @@ private fun renderAreaSidebar(context: AreaDetailContext) {
                 Text(
                     "• ${node.title}",
                     color = TajsOSTheme.Text,
-                    modifier = Modifier.fillMaxWidth().clickable { },
+                    modifier = Modifier.fillMaxWidth().clickable { }.pointerHoverIcon(PointerIcon.Hand),
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -62,6 +62,8 @@ import tajsos.composeapp.generated.resources.cal_sync
 import tajsos.composeapp.generated.resources.cal_today
 import kotlin.time.Clock
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Central calendar entry point that collects system state and coordinates layout.
@@ -259,7 +261,7 @@ fun MonthView(
                                         } else {
                                             TajsOSTheme.CalendarIdleDay
                                         },
-                                    ).clickable { onDateSelected(date) },
+                                    ).clickable { onDateSelected(date) }.pointerHoverIcon(PointerIcon.Hand),
                             contentAlignment = Alignment.Center,
                         ) {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
@@ -78,6 +78,8 @@ import tajsos.composeapp.generated.resources.screen_inbox
 import tajsos.composeapp.generated.resources.screen_project
 import tajsos.composeapp.generated.resources.screen_today
 import kotlin.time.Clock
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Central dashboard entry point that collects system state and coordinates layout.
@@ -442,7 +444,7 @@ private fun RenderDashboardBlock(
                     Row(
                         modifier =
                             Modifier
-                                .clickable { context.onNewEntry() }
+                                .clickable { context.onNewEntry() }.pointerHoverIcon(PointerIcon.Hand)
                                 .background(TajsOSTheme.Primary, RoundedCornerShape(TajsOSTheme.RadiusXs))
                                 .padding(horizontal = 12.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -604,7 +606,7 @@ private fun DashboardOperationsOverview(
                                 1.dp,
                                 TajsOSTheme.Border,
                                 RoundedCornerShape(TajsOSTheme.RadiusMd),
-                            ).clickable { onNavigate(module.screen.route) }
+                            ).clickable { onNavigate(module.screen.route) }.pointerHoverIcon(PointerIcon.Hand)
                             .padding(TajsOSTheme.SpacingMd),
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
@@ -60,6 +60,8 @@ import tajsos.composeapp.generated.resources.finance_metrics_reference_count
 import tajsos.composeapp.generated.resources.finance_queue_label
 import kotlin.math.abs
 import kotlin.math.roundToInt
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders the finance dashboard header shell with high-level status chips and dataset volume context.
@@ -214,7 +216,7 @@ internal fun renderFinanceActivityBlock(context: FinanceDashboardContext) {
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clickable { context.onEditNode(item.node.id) }
+                            .clickable { context.onEditNode(item.node.id) }.pointerHoverIcon(PointerIcon.Hand)
                             .padding(vertical = 4.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -45,6 +45,8 @@ import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.note_select_inspect_context
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Collapsible right rail with note metadata, graph context, and history sections.
@@ -136,7 +138,7 @@ fun NotesContextPanel(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onOpenNode(task.id) }
+                                        .clickable { onOpenNode(task.id) }.pointerHoverIcon(PointerIcon.Hand)
                                         .padding(vertical = 2.dp),
                             )
                         }
@@ -160,7 +162,7 @@ fun NotesContextPanel(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onOpenNode(note.id) }
+                                        .clickable { onOpenNode(note.id) }.pointerHoverIcon(PointerIcon.Hand)
                                         .padding(vertical = 2.dp),
                             )
                         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -89,6 +89,8 @@ import tajsos.composeapp.generated.resources.screen_history
 import tajsos.composeapp.generated.resources.tasks_context_title
 import tajsos.composeapp.generated.resources.view_all
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Notes-first desktop workspace with separated reading/editing modes and contextual side panels.
@@ -247,7 +249,7 @@ fun NotesWorkspaceDetail(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { onNavigateToNode(item.id) },
+                                    .clickable { onNavigateToNode(item.id) }.pointerHoverIcon(PointerIcon.Hand),
                             shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                             color =
                                 if (item.id ==
@@ -419,7 +421,7 @@ fun NotesWorkspaceDetail(
                         val linkedNode = nodesById[id]?.node ?: return@forEach
                         Text(
                             "• ${linkedNode.title}",
-                            modifier = Modifier.clickable { onNavigateToNode(linkedNode.id) },
+                            modifier = Modifier.clickable { onNavigateToNode(linkedNode.id) }.pointerHoverIcon(PointerIcon.Hand),
                             color = TajsOSTheme.Text,
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
@@ -96,6 +96,8 @@ import tajsos.composeapp.generated.resources.detail_start_writing
 import tajsos.composeapp.generated.resources.note_detail_connect_node
 import tajsos.composeapp.generated.resources.note_detail_linked_context
 import tajsos.composeapp.generated.resources.note_detail_new_node
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object NoteDetailBlocks {
     private val renderers: Map<String, NoteDetailBlockRenderer> =
@@ -296,7 +298,7 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier.weight(1f).clickable {
                                 context.onShowEnergyDialog()
-                            },
+                            }.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
                             "ENERGY",
@@ -326,7 +328,7 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier.weight(1f).clickable {
                                 context.onShowFrictionDialog()
-                            },
+                            }.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
                             "FRICTION",
@@ -354,7 +356,7 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowEstimateDialog() },
+                                .clickable { context.onShowEstimateDialog() }.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
                             "ESTIMATE",
@@ -457,7 +459,7 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowMediaTypeDialog() },
+                                .clickable { context.onShowMediaTypeDialog() }.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
                             "MEDIA TYPE",
@@ -475,7 +477,7 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowRatingDialog() },
+                                .clickable { context.onShowRatingDialog() }.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
                             "RATING",
@@ -599,7 +601,7 @@ private fun renderNoteContextGraph(context: NoteDetailContext) {
                                             noteId,
                                             tag.id,
                                         )
-                                    },
+                                    }.pointerHoverIcon(PointerIcon.Hand),
                             )
                         },
                         colors =
@@ -816,7 +818,7 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .clickable { context.onShowAreaDialog() },
+                            .clickable { context.onShowAreaDialog() }.pointerHoverIcon(PointerIcon.Hand),
                 ) {
                     Text(
                         "AREA",
@@ -834,7 +836,7 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .clickable { context.onShowProjectDialog() },
+                            .clickable { context.onShowProjectDialog() }.pointerHoverIcon(PointerIcon.Hand),
                 ) {
                     Text(
                         "PROJECT",
@@ -904,7 +906,7 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowNoteTypeDialog() },
+                                .clickable { context.onShowNoteTypeDialog() }.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
                             "NOTE TYPE",
@@ -922,7 +924,7 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowNoteStateDialog() },
+                                .clickable { context.onShowNoteStateDialog() }.pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
                             "STATE",

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
@@ -97,6 +97,8 @@ import tajsos.composeapp.generated.resources.type_area
 import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_record
 import kotlin.math.roundToInt
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object ProjectDetailBlockRegistry {
     private val renderers: Map<String, ProjectDetailBlockRenderer> =
@@ -493,7 +495,7 @@ private fun renderProjectSidebar(context: ProjectDetailContext) {
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { context.onEditNode(node.id) },
+                                .clickable { context.onEditNode(node.id) }.pointerHoverIcon(PointerIcon.Hand),
                     )
                 }
             }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/PreferencesRepositoryTest.kt
@@ -4,6 +4,7 @@
 
 package com.tajemniktv.tajsos.data
 
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
@@ -91,11 +91,11 @@ class RelationshipCommandsTest {
         assertEquals(1, replyNodes.size, "Should create exactly 1 reply needed node")
         assertEquals("reply_needed", replyNodes.first().node.openLoopType)
 
-        val relations = repo.getRelationsForNode(1L).first()
+        val relations = repo.getRelationsForNode(replyNodes.first().node.id).first()
         val relatedPersonIds = relations.filter { it.relationType == "RELATED_PERSON" }.map { it.fromNodeId }.toSet()
         assertEquals(setOf(personId), relatedPersonIds)
-        assertTrue(relation != null)
-        assertEquals(replyNodes.first().node.id, relation.toNodeId)
+        assertTrue(relatedPersonIds.isNotEmpty())
+        assertEquals(personId, relatedPersonIds.first())
     }
 
     @Test


### PR DESCRIPTION
Identified multiple composable elements missing hover state tactile feedback. As part of a UX-focused run, this PR automatically appends `pointerHoverIcon(PointerIcon.Hand)` to `.clickable` interactions, matching the intended design language across common Desktop and Web environments. Includes minor JVM test compilation fixes.

---
*PR created automatically by Jules for task [8623835363595801285](https://jules.google.com/task/8623835363595801285) started by @tajemniktv*