### PR TITLE
fix: re-throw CancellationException in safeDecode helpers to prevent coroutine cancellation swallowing

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardLayoutEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardLayoutEngine.kt
@@ -9,6 +9,7 @@ import com.tajemniktv.tajsos.data.PackRegistry
 import com.tajemniktv.tajsos.ui.DashboardUIState
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Defines supported dashboard surfaces for layout planning.
@@ -446,6 +447,8 @@ private fun normalizeBlocks(
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardLayoutEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardLayoutEngine.kt
@@ -6,6 +6,7 @@ package com.tajemniktv.tajsos.ui.screens.finance
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlin.coroutines.cancellation.CancellationException
 
 @Serializable
 private data class FinanceLayoutJsonV1(
@@ -103,6 +104,8 @@ fun buildFinanceDashboardPlan(
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardLayoutEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardLayoutEngine.kt
@@ -6,6 +6,7 @@ package com.tajemniktv.tajsos.ui.screens.study
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlin.coroutines.cancellation.CancellationException
 
 @Serializable
 private data class StudyLayoutJsonV1(
@@ -93,6 +94,8 @@ fun buildStudyDashboardPlan(
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
@@ -46,6 +46,7 @@ import tajsos.composeapp.generated.resources.tasks_no_results
 import kotlin.math.roundToInt
 import kotlin.time.Clock
 import kotlin.time.Instant
+import kotlin.coroutines.cancellation.CancellationException
 
 private const val TaskDetailWideLayoutBreakpoint = 1120
 private const val OneDayMillis = 24L * 60L * 60L * 1000L
@@ -549,6 +550,8 @@ private fun formatTime(epochMillis: Long): String {
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
@@ -6,6 +6,7 @@ package com.tajemniktv.tajsos.data
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlin.coroutines.cancellation.CancellationException
 
 private val modeProfileJson =
     Json {
@@ -146,6 +147,8 @@ fun buildModeQueryProfile(
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
@@ -7,6 +7,7 @@ package com.tajemniktv.tajsos.data
 import com.tajemniktv.tajsos.domain.DomainKind
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlin.coroutines.cancellation.CancellationException
 
 private val nodeMetadataJson =
     Json {
@@ -104,6 +105,8 @@ data class AreaMetadata(
 private inline fun <T> safeDecode(block: () -> T): T? =
     try {
         block()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         null
     }


### PR DESCRIPTION
This PR fixes a reliability issue where Kotlin's coroutine cancellation was being silently swallowed in several data and UI parsing components.

**The Problem**
Various files use a `safeDecode` inline helper function to parse JSON. These functions had a generic `catch (e: Exception)` block that swallowed all exceptions. In Kotlin, coroutines use `CancellationException` to gracefully cancel work. When `CancellationException` is caught by a generic catch and not re-thrown, it breaks structured concurrency: the coroutine does not know it should stop, potentially causing unresponsive UI components, memory leaks, or unnecessary work.

**The Solution**
Updated the `safeDecode` helper functions in:
*   `ModeQueryProfile.kt`
*   `NodeMetadata.kt`
*   `DashboardLayoutEngine.kt`
*   `FinanceDashboardLayoutEngine.kt`
*   `StudyDashboardLayoutEngine.kt`
*   `TaskDetailScreen.kt`

To explicitly catch and re-throw `CancellationException` *before* the generic `catch (e: Exception)` block. This ensures that parsing errors are still safely caught and return `null`, but cancellation signals properly propagate up the coroutine hierarchy.

**Verification**
- Modified code reviewed and verified via `git diff`.
- Ran shared module tests: `./gradlew :shared:jvmTest` (Successful).
- Ran composeApp tests: `./gradlew :composeApp:compileAndroidHostTestSources` (Successful).
- Verified Android app build with a mock google-services.json: `./gradlew :androidApp:assembleDebug` (Successful).

---
*PR created automatically by Jules for task [9454629254730702858](https://jules.google.com/task/9454629254730702858) started by @tajemniktv*