### PR TITLE
docs: Add missing KDocs for public domains, entities, and modes

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
@@ -34,6 +34,72 @@ import kotlinx.serialization.Serializable
 )
 @Serializable
 @Immutable
+/**
+ * @property id The unique identifier for the node.
+ * @property type The legacy string-based type of the node.
+ * @property title The main display title of the node.
+ * @property content The main textual body of the node.
+ * @property status The execution lifecycle state (e.g. active, done).
+ * @property isPinned Indicates if the node is currently pinned.
+ * @property parentNodeId Optional ID of the parent node for hierarchy.
+ * @property projectId Optional ID linking this node to a project.
+ * @property areaId Optional ID linking this node to an area.
+ * @property color Optional UI color integer associated with this node.
+ * @property icon Optional string identifier for an icon representing this node.
+ * @property source The origin source of the node (e.g., manual, system).
+ * @property inboxState Indicates if the node is currently held in the inbox.
+ * @property sortOrder An optional integer to manually rank or order nodes.
+ * @property contextScreen An optional string representing the UI screen context.
+ * @property isSticky Indicates if the node should stick to the top of lists.
+ * @property dueAt Optional explicit deadline for the node (epoch ms).
+ * @property startAt Optional explicit start time for the node (epoch ms).
+ * @property completedAt Optional timestamp for when the node was marked done (epoch ms).
+ * @property archivedAt Optional timestamp for when the node was archived (epoch ms).
+ * @property deletedAt Optional timestamp for when the node was soft-deleted (epoch ms).
+ * @property createdAt The timestamp when the node was originally created (epoch ms).
+ * @property updatedAt The timestamp when the node was most recently modified (epoch ms).
+ * @property energyLevel Optional rating of energy required (e.g., 1=low, 3=high).
+ * @property friction Optional descriptor of the cognitive or emotional friction involved.
+ * @property nextSmallestStep An optional description of the immediate next action to take.
+ * @property estimatedMinutes Optional estimated duration in minutes to complete.
+ * @property postponeCount Tracks how many times the item's deadline has been delayed.
+ * @property completionNote Optional reflection or note added when marking as complete.
+ * @property isHardDeadline Indicates if the due date is inflexible.
+ * @property projectWhy Optional project-level statement of purpose.
+ * @property isFrozen Indicates if the project or node is currently suspended/frozen.
+ * @property projectStatus Optional specific project lifecycle string (e.g., active, on_hold).
+ * @property reminderAt Optional timestamp for a scheduled alert or reminder (epoch ms).
+ * @property isRecurring Indicates if the node represents a repeating pattern or task.
+ * @property recurringInterval Optional interval string (e.g. daily, weekly) if recurring.
+ * @property noteType Optional categorical string for knowledge items (e.g., reflection, journal).
+ * @property noteState Optional state of the knowledge item (e.g., raw, distilled).
+ * @property mediaType Optional identifier for the type of media (e.g., book, video).
+ * @property rating Optional subjective score rating (e.g., 1-5).
+ * @property author Optional creator or author of a media/reference node.
+ * @property publisher Optional publisher or source entity for a reference node.
+ * @property openLoopType Optional identifier indicating the type of unresolved loop.
+ * @property openLoopStalenessAt Optional timestamp indicating when an open loop became stale.
+ * @property decisionStatus Optional state of a decision node (e.g., pending, decided).
+ * @property decisionCategory Optional size or scope string for a decision.
+ * @property decisionRevisitAt Optional timestamp to review a past decision.
+ * @property decisionOutcome Optional recorded result or conclusion of a decision.
+ * @property decisionInfoMissing Optional notes on what data is preventing a decision.
+ * @property decisionDifficultBecause Optional notes explaining the friction of the decision.
+ * @property decisionEasierIf Optional thoughts on what would simplify the decision.
+ * @property maintenanceType Optional category string for a maintenance or routine responsibility.
+ * @property maintenanceInterval Optional text or JSON describing the maintenance frequency.
+ * @property maintenanceOverdueAt Optional timestamp when a maintenance task became past due.
+ * @property lastContactAt Optional timestamp of the last interaction for a relationship node.
+ * @property socialEnergyNotes Optional notes regarding the social dynamic or energy.
+ * @property relationshipContext Optional string describing the context of the relationship.
+ * @property locationContext Optional environmental requirement string (e.g., at_home).
+ * @property energyContext Optional cognitive requirement string (e.g., low_energy).
+ * @property deviceContext Optional hardware requirement string (e.g., laptop_required).
+ * @property socialContext Optional social requirement string (e.g., needs_privacy).
+ * @property timeWindowContext Optional duration requirement string (e.g., 10_minute).
+ * @property areaHealthStatus Optional health descriptor for an area (e.g., stable, overloaded).
+ * @property metadataJson Optional serialized envelope for extended typed facets and domain mappings.
+ */
 data class NodeEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     /**

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/ModeQueryProfile.kt
@@ -7,6 +7,11 @@ package com.tajemniktv.tajsos.data
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
+/**
+ * A shared JSON configuration instance used for safely decoding and encoding
+ * string lists associated with mode preferences (e.g., quick actions, dashboard blocks).
+ * It is configured to ignore unknown keys for forward compatibility.
+ */
 private val modeProfileJson =
     Json {
         ignoreUnknownKeys = true

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -12,22 +12,21 @@ import com.tajemniktv.tajsos.ui.MaintenanceStatusItem
 
 /**
  * Explicit maintenance item types that classify as financial responsibilities.
- *
- * This set is used in heuristic matching to implicitly map items with these maintenance
- * types into the finance domain without requiring an explicit [com.tajemniktv.tajsos.domain.DomainKind] assignment.
+ * Used in heuristic matching to implicitly map items with these maintenance
+ * types into the finance domain without requiring an explicit domain assignment.
  */
 private val financeMaintenanceTypes = setOf("bill", "subscription", "renewal")
 
 /**
  * Explicit maintenance item types that classify as health and medical responsibilities.
- *
- * This set is used in heuristic matching to implicitly map items with these maintenance
- * types into the health domain without requiring an explicit [com.tajemniktv.tajsos.domain.DomainKind] assignment.
+ * Used in heuristic matching to implicitly map items with these maintenance
+ * types into the health domain without requiring an explicit domain assignment.
  */
 private val healthMaintenanceTypes = setOf("appointment", "prescription", "med_refill")
 
 /**
- * Set of normalized tag names used to heuristically detect finance-related items.
+ * A set of specific tag strings used to detect if an item relates to finance.
+ * Matching tags implicitly associate nodes with the finance domain.
  */
 private val financeTagMarkers =
     setOf(
@@ -48,7 +47,7 @@ private val financeTagMarkers =
     )
 
 /**
- * List of substring keywords used to search titles and content for financial context.
+ * Keywords that trigger financial categorization when found in node titles or contents.
  */
 private val financeTitleKeywords =
     listOf(
@@ -70,7 +69,8 @@ private val financeTitleKeywords =
     )
 
 /**
- * Set of normalized tag names used to heuristically detect health-related items.
+ * A set of specific tag strings used to detect if an item relates to health.
+ * Matching tags implicitly associate nodes with the health domain.
  */
 private val healthTagMarkers =
     setOf(
@@ -85,7 +85,7 @@ private val healthTagMarkers =
     )
 
 /**
- * List of substring keywords used to search titles and content for health and medical context.
+ * Keywords that trigger health categorization when found in node titles or contents.
  */
 private val healthTitleKeywords =
     listOf(
@@ -281,6 +281,9 @@ object DomainLensQueries {
         }
     }
 
+    /**
+     * Domain matcher configuration for the finance lens, containing hardcoded matching rules.
+     */
     private val financeMatcher = DomainMatcher(
         maintenanceTypes = financeMaintenanceTypes,
         tagMarkers = financeTagMarkers,
@@ -289,6 +292,9 @@ object DomainLensQueries {
 
     private val healthNoteTypes = setOf("reflection", "journal")
 
+    /**
+     * Domain matcher configuration for the health lens, containing hardcoded matching rules.
+     */
     private val healthMatcher = DomainMatcher(
         maintenanceTypes = healthMaintenanceTypes,
         tagMarkers = healthTagMarkers,


### PR DESCRIPTION
Adds comprehensive KDoc documentation to resolve missing documentation for several public elements, including `NodeEntity`'s constructor parameters, `ModeQueryProfile`'s `modeProfileJson`, and `DomainLensQueries`' heuristics used for mapping implicit domains like health and finance. This reduces onboarding friction and clearly communicates intent and assumptions behind otherwise non-obvious configurations.

---
*PR created automatically by Jules for task [3727979539562141800](https://jules.google.com/task/3727979539562141800) started by @tajemniktv*