### PR TITLE
perf: Optimize case-insensitive sorting to avoid redundant lowercase string allocations

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
@@ -137,7 +137,8 @@ internal fun TasksAllView(
                 }
 
                 TaskSort.TITLE -> {
-                    filtered.sortedBy { it.title.lowercase() }
+                    // Optimized case-insensitive sorting to avoid string allocations
+                    filtered.sortedWith { a, b -> a.title.compareTo(b.title, ignoreCase = true) }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
@@ -105,10 +105,12 @@ fun TaskDetailRoute(
     val attachments by viewModel.getAttachmentsForNode(taskId).collectAsState(initial = emptyList())
 
     val allNodeById = remember(nodes) { nodes.associateBy { it.node.id } }
+    // Optimized case-insensitive sorting to avoid string allocations
     val areaOptions =
-        remember(areas) { areas.map { it.id to it.title }.sortedBy { it.second.lowercase() } }
+        remember(areas) { areas.map { it.id to it.title }.sortedWith { a, b -> a.second.compareTo(b.second, ignoreCase = true) } }
+    // Optimized case-insensitive sorting to avoid string allocations
     val projectOptions =
-        remember(projects) { projects.map { it.id to it.title }.sortedBy { it.second.lowercase() } }
+        remember(projects) { projects.map { it.id to it.title }.sortedWith { a, b -> a.second.compareTo(b.second, ignoreCase = true) } }
     val areaById = remember(areas) { areas.associate { it.id to it.title } }
     val projectById = remember(projects) { projects.associate { it.id to it.title } }
 


### PR DESCRIPTION
This pull request implements a performance improvement by optimizing how items are sorted case-insensitively in Compose UI screens. 

**Changes:**
- In `composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt`, replaced `.sortedBy { it.title.lowercase() }` with `.sortedWith { a, b -> a.title.compareTo(b.title, ignoreCase = true) }`.
- In `composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt`, replaced `.sortedBy { it.second.lowercase() }` with `.sortedWith { a, b -> a.second.compareTo(b.second, ignoreCase = true) }`.

**Reasoning:**
The original code using `.lowercase()` inside the `sortedBy` lambda is inefficient because it allocates a new lowercase string for every element on every comparison step. This results in $O(N \log N)$ string allocations, unnecessarily consuming memory and increasing garbage collection overhead, which is particularly harmful in UI components. By using `compareTo(..., ignoreCase = true)`, we perform an in-place character-by-character comparison without allocating any new strings.

These changes are entirely internal to the UI logic, preserve the exact same user-facing behavior (case-insensitive alphabetical sorting), and introduce zero regressions (as verified by the `composeApp` and `shared` test suites). Comments have also been added to clarify the optimization.

---
*PR created automatically by Jules for task [6377002881640749648](https://jules.google.com/task/6377002881640749648) started by @tajemniktv*