### PR TITLE
feat(ui): add tactile feedback animation to TactileCard

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
@@ -4,8 +4,12 @@
 
 package com.tajemniktv.tajsos.ui.components.cards
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,8 +17,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
@@ -40,18 +47,30 @@ fun TactileCard(
     onClick: (() -> Unit)? = null,
     content: @Composable BoxScope.() -> Unit,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.98f else 1f,
+        label = "tactile_scale",
+        animationSpec = spring(
+            stiffness = 180f,
+            dampingRatio = 0.22f // matching Fast feedback: stiffness 180, damping 22
+        )
+    )
+
     Box(
         modifier =
             modifier
                 .fillMaxWidth()
+                .graphicsLayer { scaleX = scale; scaleY = scale }
                 .background(TajsOSTheme.CardSurface, RoundedCornerShape(TajsOSTheme.RadiusXl))
-
                 .then(
                     if (onClick != null) {
                         Modifier.mouseClickable(
                             onClick = onClick,
                             onSecondaryClick = onClick,
                             middleClickFallbackToPrimary = true,
+                            interactionSource = interactionSource,
                         )
                     } else {
                         Modifier

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.components.common.mouseClickable


### PR DESCRIPTION
Adds a scale-down animation to `0.98` on press to `TactileCard` to adhere to the `DESIGN.md` physical feedback guidelines for interactive components.

Uses the lambda version of `graphicsLayer` to avoid unnecessary recompositions during animation.

---
*PR created automatically by Jules for task [7615062284824145170](https://jules.google.com/task/7615062284824145170) started by @tajemniktv*