### PR TITLE
docs: add missing KDoc to NodeEntity.metadataEnvelopeOrNull

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
@@ -110,6 +110,11 @@ inline fun <T> safeDecode(block: () -> T): T? =
         null
     }
 
+/**
+ * Safely decodes the underlying JSON string (`metadataJson`) into a typed [NodeMetadataEnvelope].
+ *
+ * Returns `null` if the string is empty, malformed, or if parsing fails.
+ */
 fun NodeEntity.metadataEnvelopeOrNull(): NodeMetadataEnvelope? =
     metadataJson?.takeIf { it.isNotBlank() }?.let {
         safeDecode { nodeMetadataJson.decodeFromString<NodeMetadataEnvelope>(it) }


### PR DESCRIPTION
This PR adds a missing KDoc to the `NodeEntity.metadataEnvelopeOrNull` helper function in the `shared` module. It clarifies the function's safety guarantees and return behavior for malformed or empty metadata payloads.

---
*PR created automatically by Jules for task [6292698520418675180](https://jules.google.com/task/6292698520418675180) started by @tajemniktv*