### PR TITLE
perf: Optimize string allocations in sorting

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -233,10 +233,10 @@ fun buildTransitionProtocolsSnapshot(
                 )
             }.sortedWith(
                 compareByDescending<TransitionProtocolItem> { it.lastTriggeredAt ?: 0L }
-                    .thenBy {
-                        it.node.node.title
-                            .lowercase()
-                    },
+                    .then(
+                        // Avoid lowercase() allocation during O(N log N) sorting
+                        Comparator { a, b -> a.node.node.title.compareTo(b.node.node.title, ignoreCase = true) }
+                    ),
             )
 
     return TransitionProtocolsSnapshot(
@@ -297,10 +297,10 @@ fun buildPlaybookSnapshot(
                 )
             }.sortedWith(
                 compareByDescending<PlaybookItem> { it.triggerCount }
-                    .thenBy {
-                        it.node.node.title
-                            .lowercase()
-                    },
+                    .then(
+                        // Avoid lowercase() allocation during O(N log N) sorting
+                        Comparator { a, b -> a.node.node.title.compareTo(b.node.node.title, ignoreCase = true) }
+                    ),
             )
 
     return PlaybookSnapshot(


### PR DESCRIPTION
This PR addresses a performance optimization in the main state assemblers where `.lowercase()` was being called on strings during the sorting phase.

By switching from `compareBy { it.lowercase() }` to `.then(Comparator { a, b -> a.compareTo(b, ignoreCase = true) })`, we eliminate a string allocation per comparison step, significantly reducing GC overhead when rendering large lists of playbooks and transition protocols. KDoc comments have been added to explain this optimization.

---
*PR created automatically by Jules for task [8651160027890810630](https://jules.google.com/task/8651160027890810630) started by @tajemniktv*