### PR TITLE
test: add safeDecode coroutine cancellation tests

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/NodeMetadataTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/NodeMetadataTest.kt
@@ -5,12 +5,14 @@
 package com.tajemniktv.tajsos.data
 
 import com.tajemniktv.tajsos.domain.DomainKind
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 
 class NodeMetadataTest {
     @Test
@@ -70,5 +72,19 @@ class NodeMetadataTest {
 
         val withoutDomain = withDomain.withoutAssociatedDomain(DomainKind.HEALTH)
         assertFalse(withoutDomain.isAssociatedWithDomain(DomainKind.HEALTH))
+    }
+
+    @Test
+    fun safeDecode_catchesGenericExceptions() {
+        val result = safeDecode<String> { throw IllegalArgumentException("Parse failed") }
+        assertNull(result, "safeDecode should swallow generic exceptions and return null")
+    }
+
+    @Test
+    fun safeDecode_rethrowsCancellationException() {
+        assertFailsWith<CancellationException>(
+            message = "safeDecode must rethrow CancellationException to avoid breaking coroutines",
+            block = { safeDecode<String> { throw CancellationException() } }
+        )
     }
 }


### PR DESCRIPTION
This PR improves test coverage and quality by adding explicit unit tests for the `safeDecode` utility function. 

`safeDecode` is designed to swallow generic parsing exceptions while re-throwing `CancellationException` to avoid breaking Kotlin Coroutine structured concurrency. This hidden assumption is now explicitly verified by two new unit tests, providing strong regression protection without modifying production code.

---
*PR created automatically by Jules for task [4863146415904600092](https://jules.google.com/task/4863146415904600092) started by @tajemniktv*