### PR TITLE
fix(ui): optimize scale animation in cards and buttons

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -72,7 +72,7 @@ fun ActionButton(
         onClick = onClick,
         enabled = enabled,
         interactionSource = interactionSource,
-        modifier = finalModifier.graphicsLayer(scaleX = scale, scaleY = scale),
+        modifier = finalModifier.graphicsLayer { scaleX = scale; scaleY = scale },
         colors =
             resolveActionButtonColors(
                 isPrimary = isPrimary,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/ModuleCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/ModuleCard.kt
@@ -55,7 +55,7 @@ fun ModuleCard(
     Surface(
         modifier =
             modifier
-                .graphicsLayer(scaleX = scale, scaleY = scale)
+                .graphicsLayer { scaleX = scale; scaleY = scale }
                 .glassChrome(
                     shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                     material = GlassMaterial.REGULAR,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
@@ -106,7 +106,7 @@ fun NodeCard(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .graphicsLayer(scaleX = animatedScale, scaleY = animatedScale)
+                        .graphicsLayer { scaleX = animatedScale; scaleY = animatedScale }
                         .glassChrome(
                             shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                             material = GlassMaterial.REGULAR,


### PR DESCRIPTION
This PR optimizes tactile feedback animations across several UI components (`ActionButton`, `ModuleCard`, `NodeCards`). 

By converting the `Modifier.graphicsLayer` value arguments to the lambda block syntax, Jetpack Compose can defer the read of the `scale` animation state to the draw phase. This prevents the composable functions from unnecessarily recomposing on every single frame of the animation, resulting in smoother performance and reduced CPU overhead.

Changes:
- `ActionButton.kt`
- `ModuleCard.kt`
- `NodeCards.kt`

---
*PR created automatically by Jules for task [10946238143606949107](https://jules.google.com/task/10946238143606949107) started by @tajemniktv*