### PR TITLE
fix(website): disable default starlight 404 to fix collision warning

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
This PR updates the `astro.config.mjs` to disable Starlight's default 404 route to prevent build warnings related to route collision with the top-level 404 page in `website/src/pages/404.astro`.

---
*PR created automatically by Jules for task [6081594659245054628](https://jules.google.com/task/6081594659245054628) started by @tajemniktv*