### PR TITLE
chore(website): fix starlight 404 route collision and biome config

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",

--- a/website/biome.json
+++ b/website/biome.json
@@ -6,7 +6,11 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["**", "!**/dist", "!**/*.css", "!**/*.astro"]
+    "ignore": [
+      "**/dist",
+      "**/*.css",
+      "**/*.astro"
+    ]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
This PR addresses minor configuration technical debt in the `/website` directory.

- **Astro Config:** Resolves an Astro build warning regarding route collisions by explicitly disabling Starlight's default 404 route (`disable404Route: true`). This correctly defers 404 handling to the project's custom `src/pages/404.astro` file.
- **Biome Config:** Corrects an invalid configuration in `biome.json` where negative globs were placed in the `files.includes` array. They have been correctly moved to the `files.ignore` array to prevent parsing errors and align with standard Biome configuration practices.

---
*PR created automatically by Jules for task [11522599548980260263](https://jules.google.com/task/11522599548980260263) started by @tajemniktv*