### PR TITLE
perf: optimize case-insensitive string matching

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -788,21 +788,29 @@ private fun SearchResultCard(
     }
 }
 
+/**
+ * Maps string type labels to standard icons.
+ * Performance optimization: uses case-insensitive comparison to avoid string allocations.
+ */
 private fun iconForType(type: String): ImageVector =
-    when (type.lowercase()) {
-        "task" -> Icons.Default.TaskAlt
-        "project" -> Icons.Default.Folder
-        "note" -> Icons.Default.Description
-        "record" -> Icons.AutoMirrored.Filled.InsertDriveFile
+    when {
+        type.equals("task", ignoreCase = true) -> Icons.Default.TaskAlt
+        type.equals("project", ignoreCase = true) -> Icons.Default.Folder
+        type.equals("note", ignoreCase = true) -> Icons.Default.Description
+        type.equals("record", ignoreCase = true) -> Icons.AutoMirrored.Filled.InsertDriveFile
         else -> Icons.Default.Search
     }
 
+/**
+ * Maps string type labels to standard UI theme colors.
+ * Performance optimization: uses case-insensitive comparison to avoid string allocations.
+ */
 private fun iconTintForType(type: String): Color =
-    when (type.lowercase()) {
-        "task" -> TajsOSTheme.AccentRed
-        "project" -> TajsOSTheme.Primary
-        "note" -> TajsOSTheme.AccentBlue
-        "record" -> TajsOSTheme.AccentCyan
+    when {
+        type.equals("task", ignoreCase = true) -> TajsOSTheme.AccentRed
+        type.equals("project", ignoreCase = true) -> TajsOSTheme.Primary
+        type.equals("note", ignoreCase = true) -> TajsOSTheme.AccentBlue
+        type.equals("record", ignoreCase = true) -> TajsOSTheme.AccentCyan
         else -> TajsOSTheme.Primary
     }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2603,6 +2603,10 @@ class MainViewModel(
             calculateStudentBoardState(nodes, relations, sessions, templates)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), StudentBoardState())
 
+    /**
+     * Adds a new template for the specified type.
+     * Performance optimization: uses case-insensitive comparison to avoid string allocations when mapping node types.
+     */
     fun addTemplate(
         name: String,
         type: String,
@@ -2610,22 +2614,23 @@ class MainViewModel(
         content: String? = null,
     )
     {
+        val cleanType = type.trim()
         val normalizedType =
-            when (type.trim().lowercase())
+            when
             {
-                "record"                                           -> "record"
+                cleanType.equals("record", ignoreCase = true)                                           -> "record"
 
                 // NON-NLS
-                "project"                                          -> "project"
+                cleanType.equals("project", ignoreCase = true)                                          -> "project"
 
                 // NON-NLS
-                    "area"                                             -> "area"
+                    cleanType.equals("area", ignoreCase = true)                                             -> "area"
 
                 // NON-NLS
-                    "idea", "resource", "vault", "document" -> "note"
+                    cleanType.equals("idea", ignoreCase = true) || cleanType.equals("resource", ignoreCase = true) || cleanType.equals("vault", ignoreCase = true) || cleanType.equals("document", ignoreCase = true) -> "note"
 
                     // NON-NLS
-                    "maintenance", "open_loop", "decision", "protocol" -> "task"
+                    cleanType.equals("maintenance", ignoreCase = true) || cleanType.equals("open_loop", ignoreCase = true) || cleanType.equals("decision", ignoreCase = true) || cleanType.equals("protocol", ignoreCase = true) -> "task"
 
                     // NON-NLS
                     else -> "task" // NON-NLS

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
@@ -442,6 +442,10 @@ class RelationshipCommands(
         }
     }
 
+    /**
+     * Adds a new vault entry to the database.
+     * Performance optimization: uses case-insensitive comparison to avoid string allocations when parsing type.
+     */
     fun addVaultEntry(
         categoryTag: String,
         title: String,
@@ -451,11 +455,12 @@ class RelationshipCommands(
     ) {
         scope.launch {
             val cleanTag = categoryTag.trim().lowercase()
+            val cleanAsType = asType.trim()
             val type =
-                when (asType.trim().lowercase())
+                when
                 {
-                    "record" -> "record"
-                    "task", "maintenance" -> "task"
+                    cleanAsType.equals("record", ignoreCase = true) -> "record"
+                    cleanAsType.equals("task", ignoreCase = true) || cleanAsType.equals("maintenance", ignoreCase = true) -> "task"
                     else -> "note"
                 }
             val nodeId =


### PR DESCRIPTION
This pull request introduces a safe, low-risk performance improvement by optimizing case-insensitive string comparisons in hot paths.

**Changes:**
- Modified `iconForType` and `iconTintForType` in `SearchDashboardBlocks.kt` to use `ignoreCase = true`.
- Modified `addTemplate` in `MainViewModel.kt` to use `ignoreCase = true` for template type parsing.
- Modified `addVaultEntry` in `RelationshipCommands.kt` to use `ignoreCase = true` for vault type parsing.
- Ensured stored properties (like `cleanTag`) retain their necessary `.lowercase()` normalization.
- Added KDocs documenting the performance purpose of the refactor.

**Reasoning:**
In Kotlin, calling `.lowercase()` creates a new string in memory. By using `equals(..., ignoreCase = true)`, we can evaluate the equality without triggering an allocation. This is a standard micro-optimization that reduces GC pressure, especially useful in UI lists where string mapping happens frequently.

---
*PR created automatically by Jules for task [2284978900978751365](https://jules.google.com/task/2284978900978751365) started by @tajemniktv*