### PR TITLE
fix(website): disable starlight 404 route to fix build collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
This PR resolves a build warning in the Astro website project regarding a route collision for `/404`. 

Starlight injects its own static 404 route by default, which conflicts with the project's custom `src/pages/404.astro` file. By setting `disable404Route: true` in the Starlight configuration within `astro.config.mjs`, we instruct Starlight to back off, allowing Astro to solely use the project's custom 404 page, thereby eliminating the warning and ensuring correct routing behavior.

---
*PR created automatically by Jules for task [5445789327950596851](https://jules.google.com/task/5445789327950596851) started by @tajemniktv*