### PR TITLE
fix(ui): Add hand pointer cursor on hover for ActionButton

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -72,7 +74,7 @@ fun ActionButton(
         onClick = onClick,
         enabled = enabled,
         interactionSource = interactionSource,
-        modifier = finalModifier.graphicsLayer { scaleX = scale; scaleY = scale },
+        modifier = finalModifier.graphicsLayer { scaleX = scale; scaleY = scale }.pointerHoverIcon(PointerIcon.Hand),
         colors =
             resolveActionButtonColors(
                 isPrimary = isPrimary,


### PR DESCRIPTION
This pull request enhances the `ActionButton` component by explicitly adding a `pointerHoverIcon(PointerIcon.Hand)` modifier. In Compose Multiplatform (especially on desktop and web targets), clickable elements don't inherently change the mouse cursor. This change adds the expected visual affordance (a hand cursor) when a user hovers over a button, improving the general UX feel without altering the product logic or component usage.

---
*PR created automatically by Jules for task [13191341799874426459](https://jules.google.com/task/13191341799874426459) started by @tajemniktv*