### PR TITLE
perf: optimize string matching performance in type checks

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -788,21 +788,33 @@ private fun SearchResultCard(
     }
 }
 
+/**
+ * Resolves the corresponding Material icon vector based on the normalized item type.
+ *
+ * @param type The raw string type to evaluate.
+ * @return The resolved [ImageVector] for the item type.
+ */
 private fun iconForType(type: String): ImageVector =
-    when (type.lowercase()) {
-        "task" -> Icons.Default.TaskAlt
-        "project" -> Icons.Default.Folder
-        "note" -> Icons.Default.Description
-        "record" -> Icons.AutoMirrored.Filled.InsertDriveFile
+    when {
+        type.equals("task", ignoreCase = true) -> Icons.Default.TaskAlt
+        type.equals("project", ignoreCase = true) -> Icons.Default.Folder
+        type.equals("note", ignoreCase = true) -> Icons.Default.Description
+        type.equals("record", ignoreCase = true) -> Icons.AutoMirrored.Filled.InsertDriveFile
         else -> Icons.Default.Search
     }
 
+/**
+ * Resolves the primary accent tint color based on the normalized item type.
+ *
+ * @param type The raw string type to evaluate.
+ * @return The [Color] corresponding to the item type.
+ */
 private fun iconTintForType(type: String): Color =
-    when (type.lowercase()) {
-        "task" -> TajsOSTheme.AccentRed
-        "project" -> TajsOSTheme.Primary
-        "note" -> TajsOSTheme.AccentBlue
-        "record" -> TajsOSTheme.AccentCyan
+    when {
+        type.equals("task", ignoreCase = true) -> TajsOSTheme.AccentRed
+        type.equals("project", ignoreCase = true) -> TajsOSTheme.Primary
+        type.equals("note", ignoreCase = true) -> TajsOSTheme.AccentBlue
+        type.equals("record", ignoreCase = true) -> TajsOSTheme.AccentCyan
         else -> TajsOSTheme.Primary
     }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2603,6 +2603,14 @@ class MainViewModel(
             calculateStudentBoardState(nodes, relations, sessions, templates)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), StudentBoardState())
 
+    /**
+     * Adds a new template to the system, normalizing the type to a supported base type.
+     *
+     * @param name The name of the template.
+     * @param type The raw type of the template to be normalized.
+     * @param title The optional default title for the template.
+     * @param content The optional default content for the template.
+     */
     fun addTemplate(
         name: String,
         type: String,
@@ -2611,25 +2619,26 @@ class MainViewModel(
     )
     {
         val normalizedType =
-            when (type.trim().lowercase())
-            {
-                "record"                                           -> "record"
-
-                // NON-NLS
-                "project"                                          -> "project"
-
-                // NON-NLS
-                    "area"                                             -> "area"
-
-                // NON-NLS
-                    "idea", "resource", "vault", "document" -> "note"
+            with(type.trim()) {
+                when {
+                    equals("record", ignoreCase = true) -> "record"
 
                     // NON-NLS
-                    "maintenance", "open_loop", "decision", "protocol" -> "task"
+                    equals("project", ignoreCase = true) -> "project"
+
+                    // NON-NLS
+                    equals("area", ignoreCase = true) -> "area"
+
+                    // NON-NLS
+                    equals("idea", ignoreCase = true) || equals("resource", ignoreCase = true) || equals("vault", ignoreCase = true) || equals("document", ignoreCase = true) -> "note"
+
+                    // NON-NLS
+                    equals("maintenance", ignoreCase = true) || equals("open_loop", ignoreCase = true) || equals("decision", ignoreCase = true) || equals("protocol", ignoreCase = true) -> "task"
 
                     // NON-NLS
                     else -> "task" // NON-NLS
                 }
+            }
             viewModelScope.launch {
                 repository.insertTemplate(
                     TemplateEntity(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
@@ -442,6 +442,15 @@ class RelationshipCommands(
         }
     }
 
+    /**
+     * Adds an entry to the vault with the specified parameters, normalizing its tag and base type.
+     *
+     * @param categoryTag The tag to apply to the vault entry.
+     * @param title The title of the vault entry.
+     * @param content The content of the vault entry.
+     * @param asType The raw base type of the vault entry, to be normalized.
+     * @param dueAt The optional due date timestamp.
+     */
     fun addVaultEntry(
         categoryTag: String,
         title: String,
@@ -452,11 +461,12 @@ class RelationshipCommands(
         scope.launch {
             val cleanTag = categoryTag.trim().lowercase()
             val type =
-                when (asType.trim().lowercase())
-                {
-                    "record" -> "record"
-                    "task", "maintenance" -> "task"
-                    else -> "note"
+                with(asType.trim()) {
+                    when {
+                        equals("record", ignoreCase = true) -> "record"
+                        equals("task", ignoreCase = true) || equals("maintenance", ignoreCase = true) -> "task"
+                        else -> "note"
+                    }
                 }
             val nodeId =
                 addNodeForResult(


### PR DESCRIPTION
Replaces chained string operations like `.trim().lowercase()` with `.trim()` and case-insensitive matching (`equals(..., ignoreCase = true)`) inside `when` blocks to avoid unnecessary string allocations across `MainViewModel`, `RelationshipCommands`, and `SearchDashboardBlocks`. KDocs were added to document the modified functions.

---
*PR created automatically by Jules for task [2854959371096295009](https://jules.google.com/task/2854959371096295009) started by @tajemniktv*