### PR TITLE
fix(website): disable Starlight's default 404 route to prevent collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
Sets `disable404Route: true` in the Starlight integration options in `astro.config.mjs` to fix the route collision warning between the default 404 page and our custom `src/pages/404.astro` page.

---
*PR created automatically by Jules for task [2585920613724132711](https://jules.google.com/task/2585920613724132711) started by @tajemniktv*