### PR TITLE
docs: add and improve KDocs for core data entities and filters

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
@@ -24,6 +24,7 @@ import kotlin.time.Duration.Companion.days
  *
  * @param repository The central data repository providing database operations for calendar objects.
  * @param httpClient The configured HTTP client to perform external API queries.
+ * @param providers A list of available [CalendarProvider] implementations to handle specific protocol synchronizations.
  */
 class CalendarManager(
     private val repository: AppRepository,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
@@ -99,6 +99,17 @@ import kotlinx.serialization.Serializable
  * @property timeWindowContext Optional duration requirement string (e.g., 10_minute).
  * @property areaHealthStatus Optional health descriptor for an area (e.g., stable, overloaded).
  * @property metadataJson Optional serialized envelope for extended typed facets and domain mappings.
+ *
+ * Core polymorphic entity representing primary system objects in TajsOS.
+ *
+ * This table stores the shared attributes (such as title, content, status, due dates) for all
+ * major life objects including tasks, notes, projects, records, and areas. It serves as the
+ * fundamental element in the relational graph.
+ *
+ * The [type] field maps directly to the [com.tajemniktv.tajsos.data.ItemKind] enum.
+ * Domain-specific data beyond these shared attributes is stored either in [metadataJson] or in
+ * typed companion facet tables (e.g., `TaskFacetEntity`, `ProjectFacetEntity`), ensuring the core schema
+ * remains slim and strictly typed.
  */
 data class NodeEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/FilterHelper.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/FilterHelper.kt
@@ -25,8 +25,8 @@ object FilterHelper {
      *
      * @param nodes The initial list of nodes with associated pins and tags to filter.
      * @param query A text query for partial-matching against titles, content, or tags (prefix with # to search tags only).
-     * @param type The specific type of node to include (e.g., "task", "project").
-     * @param status A comma-separated string of statuses to include (e.g., "active,on_hold").
+     * @param type The specific type of node to include based on [com.tajemniktv.tajsos.data.ItemKind] storage keys (e.g., "task", "project").
+     * @param status A comma-separated string of statuses to include. Evaluated as an OR condition against the node's status field (e.g., "active,on_hold").
      * @param projectId The ID of the project the node must belong to.
      * @param areaId The ID of the area the node must belong to.
      * @param linkedToId The ID of another node that this node must have a bidirectional relationship with.


### PR DESCRIPTION
This PR addresses missing and incomplete KDocs across critical core domain classes to reduce onboarding friction and clarify non-obvious data flows.

**Changes:**
1. **`CalendarManager.kt`**: Added `@param providers` documentation to explain how protocol synchronizations are injected.
2. **`Entities.kt`**: Added a comprehensive class-level KDoc to `NodeEntity` explaining its role as the root polymorphic entity in the LifeOS model, how it relates to `ItemKind`, and the expectation of typed companion facet tables over schema bloat.
3. **`FilterHelper.kt`**: Improved documentation for `filterAndSortNodes`, specifically clarifying how `type` maps to storage keys and how `status` evaluates as a comma-separated OR condition against the node's active status.

These changes are purely documentation-focused and do not alter any runtime behavior. Tests and builds have been successfully verified locally.

---
*PR created automatically by Jules for task [8793731926253438760](https://jules.google.com/task/8793731926253438760) started by @tajemniktv*