### PR TITLE
perf: Optimize type string matching in Search UI to prevent allocations

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -788,21 +788,35 @@ private fun SearchResultCard(
     }
 }
 
+/**
+ * Returns the appropriate icon for a given node type.
+ * Uses case-insensitive comparison to avoid string allocations during composition.
+ *
+ * @param type The node type as a string.
+ * @return The corresponding [ImageVector].
+ */
 private fun iconForType(type: String): ImageVector =
-    when (type.lowercase()) {
-        "task" -> Icons.Default.TaskAlt
-        "project" -> Icons.Default.Folder
-        "note" -> Icons.Default.Description
-        "record" -> Icons.AutoMirrored.Filled.InsertDriveFile
+    when {
+        type.equals("task", ignoreCase = true) -> Icons.Default.TaskAlt
+        type.equals("project", ignoreCase = true) -> Icons.Default.Folder
+        type.equals("note", ignoreCase = true) -> Icons.Default.Description
+        type.equals("record", ignoreCase = true) -> Icons.AutoMirrored.Filled.InsertDriveFile
         else -> Icons.Default.Search
     }
 
+/**
+ * Returns the appropriate icon tint color for a given node type.
+ * Uses case-insensitive comparison to avoid string allocations during composition.
+ *
+ * @param type The node type as a string.
+ * @return The corresponding [Color].
+ */
 private fun iconTintForType(type: String): Color =
-    when (type.lowercase()) {
-        "task" -> TajsOSTheme.AccentRed
-        "project" -> TajsOSTheme.Primary
-        "note" -> TajsOSTheme.AccentBlue
-        "record" -> TajsOSTheme.AccentCyan
+    when {
+        type.equals("task", ignoreCase = true) -> TajsOSTheme.AccentRed
+        type.equals("project", ignoreCase = true) -> TajsOSTheme.Primary
+        type.equals("note", ignoreCase = true) -> TajsOSTheme.AccentBlue
+        type.equals("record", ignoreCase = true) -> TajsOSTheme.AccentCyan
         else -> TajsOSTheme.Primary
     }
 


### PR DESCRIPTION
Identified a performance optimization in the Search UI where the `type.lowercase()` method was called during every search item rendering, causing unnecessary garbage collection. Refactored the `when` blocks to use case-insensitive `.equals` to avoid string allocations. Also added KDocs to the functions. Tests pass for both `composeApp` and `shared` modules.

---
*PR created automatically by Jules for task [12786206773831653142](https://jules.google.com/task/12786206773831653142) started by @tajemniktv*