### PR TITLE
fix(website): disable starlight 404 route to prevent collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
This PR sets `disable404Route: true` in the `website/astro.config.mjs` Starlight configuration.

This resolves a build warning/error caused by a route collision between Starlight's default 404 page and the custom `src/pages/404.astro` page present in the codebase.

---
*PR created automatically by Jules for task [161441317287139332](https://jules.google.com/task/161441317287139332) started by @tajemniktv*