### PR TITLE
perf: optimize case insensitive string comparisons

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -788,21 +788,35 @@ private fun SearchResultCard(
     }
 }
 
+/**
+ * Resolves the appropriate icon for a given node type.
+ * Uses case-insensitive comparison to avoid allocating a new lowercased string on each recomposition.
+ *
+ * @param type The string representing the node type (e.g., "task", "project").
+ * @return The corresponding [ImageVector] for the UI.
+ */
 private fun iconForType(type: String): ImageVector =
-    when (type.lowercase()) {
-        "task" -> Icons.Default.TaskAlt
-        "project" -> Icons.Default.Folder
-        "note" -> Icons.Default.Description
-        "record" -> Icons.AutoMirrored.Filled.InsertDriveFile
+    when {
+        type.equals("task", ignoreCase = true) -> Icons.Default.TaskAlt
+        type.equals("project", ignoreCase = true) -> Icons.Default.Folder
+        type.equals("note", ignoreCase = true) -> Icons.Default.Description
+        type.equals("record", ignoreCase = true) -> Icons.AutoMirrored.Filled.InsertDriveFile
         else -> Icons.Default.Search
     }
 
+/**
+ * Resolves the appropriate icon tint color for a given node type.
+ * Uses case-insensitive comparison to avoid allocating a new lowercased string on each recomposition.
+ *
+ * @param type The string representing the node type (e.g., "task", "project").
+ * @return The corresponding [Color] for the UI.
+ */
 private fun iconTintForType(type: String): Color =
-    when (type.lowercase()) {
-        "task" -> TajsOSTheme.AccentRed
-        "project" -> TajsOSTheme.Primary
-        "note" -> TajsOSTheme.AccentBlue
-        "record" -> TajsOSTheme.AccentCyan
+    when {
+        type.equals("task", ignoreCase = true) -> TajsOSTheme.AccentRed
+        type.equals("project", ignoreCase = true) -> TajsOSTheme.Primary
+        type.equals("note", ignoreCase = true) -> TajsOSTheme.AccentBlue
+        type.equals("record", ignoreCase = true) -> TajsOSTheme.AccentCyan
         else -> TajsOSTheme.Primary
     }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2603,6 +2603,15 @@ class MainViewModel(
             calculateStudentBoardState(nodes, relations, sessions, templates)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), StudentBoardState())
 
+    /**
+     * Adds a new template to the repository.
+     * Uses case-insensitive comparison on the type to avoid allocating a new lowercased string.
+     *
+     * @param name The template name.
+     * @param type The template type.
+     * @param title The default title for the template.
+     * @param content The default content for the template.
+     */
     fun addTemplate(
         name: String,
         type: String,
@@ -2610,26 +2619,27 @@ class MainViewModel(
         content: String? = null,
     )
     {
+        val cleanType = type.trim()
         val normalizedType =
-            when (type.trim().lowercase())
+            when
             {
-                "record"                                           -> "record"
+                cleanType.equals("record", ignoreCase = true) -> "record"
 
                 // NON-NLS
-                "project"                                          -> "project"
+                cleanType.equals("project", ignoreCase = true) -> "project"
 
                 // NON-NLS
-                    "area"                                             -> "area"
+                cleanType.equals("area", ignoreCase = true) -> "area"
 
                 // NON-NLS
-                    "idea", "resource", "vault", "document" -> "note"
+                cleanType.equals("idea", ignoreCase = true) || cleanType.equals("resource", ignoreCase = true) || cleanType.equals("vault", ignoreCase = true) || cleanType.equals("document", ignoreCase = true) -> "note"
 
-                    // NON-NLS
-                    "maintenance", "open_loop", "decision", "protocol" -> "task"
+                // NON-NLS
+                cleanType.equals("maintenance", ignoreCase = true) || cleanType.equals("open_loop", ignoreCase = true) || cleanType.equals("decision", ignoreCase = true) || cleanType.equals("protocol", ignoreCase = true) -> "task"
 
-                    // NON-NLS
-                    else -> "task" // NON-NLS
-                }
+                // NON-NLS
+                else -> "task" // NON-NLS
+            }
             viewModelScope.launch {
                 repository.insertTemplate(
                     TemplateEntity(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
@@ -107,13 +107,21 @@ class RelationshipCommands(
         }
     }
 
+    /**
+     * Sets the relationship type for a person node.
+     * Evaluates the type using case-insensitive equality to avoid allocating a new lowercased string if it is not supported.
+     *
+     * @param person The person node.
+     * @param type The type to set.
+     */
     fun setPersonRelationshipType(
         person: NodeEntity,
         type: String?,
     ) {
         if (person.type != "person") return
         val supported = setOf("professor", "friend", "family")
-        val normalized = type?.trim()?.lowercase()?.takeIf { it in supported }
+        val cleanType = type?.trim()
+        val normalized = cleanType?.takeIf { t -> supported.any { it.equals(t, ignoreCase = true) } }?.lowercase()
         scope.launch {
             supported.forEach { tag -> setTagOnNode(person.id, tag, false) }
             if (normalized != null) setTagOnNode(person.id, normalized, true)
@@ -442,6 +450,17 @@ class RelationshipCommands(
         }
     }
 
+    /**
+     * Adds a vault entry to the repository.
+     * Uses case-insensitive comparison on asType to avoid allocating a new lowercased string.
+     * The categoryTag is still lowercased for long-term storage normalization.
+     *
+     * @param categoryTag The category tag.
+     * @param title The entry title.
+     * @param content The entry content.
+     * @param asType The type of the entry.
+     * @param dueAt An optional due date.
+     */
     fun addVaultEntry(
         categoryTag: String,
         title: String,
@@ -450,12 +469,13 @@ class RelationshipCommands(
         dueAt: Long? = null,
     ) {
         scope.launch {
-            val cleanTag = categoryTag.trim().lowercase()
+            val cleanTag = categoryTag.trim().lowercase() // Needs to be lowercased for tag normalization / storage
+            val cleanType = asType.trim()
             val type =
-                when (asType.trim().lowercase())
+                when
                 {
-                    "record" -> "record"
-                    "task", "maintenance" -> "task"
+                    cleanType.equals("record", ignoreCase = true) -> "record"
+                    cleanType.equals("task", ignoreCase = true) || cleanType.equals("maintenance", ignoreCase = true) -> "task"
                     else -> "note"
                 }
             val nodeId =


### PR DESCRIPTION
Replaced `.lowercase()` string allocations with case-insensitive comparisons (`equals(..., ignoreCase = true)`) in frequently called functions `iconForType`, `iconTintForType` (UI rendering), `addTemplate`, `addVaultEntry`, and `setPersonRelationshipType`. This avoids unnecessary object allocations, especially beneficial for UI recompositions.

Also added KDocs to the modified functions to explain the performance optimization. Note that `.lowercase()` allocations used for inserting data into databases or long-term normalized state were intentionally kept to prevent functional regressions.

---
*PR created automatically by Jules for task [2927308058103280100](https://jules.google.com/task/2927308058103280100) started by @tajemniktv*