### PR TITLE
test: improve LifeObjectModels edge case coverage

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectModelsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectModelsTest.kt
@@ -150,4 +150,38 @@ class LifeObjectModelsTest {
         assertFalse(taskWithLocation.isPlaceAnchor())
         assertEquals(ItemKind.TASK, taskWithLocation.itemKindOrNull())
     }
+
+    @Test
+    fun matchesItemFilter_handles_all_cases_including_null_and_unknown() {
+        val taskNode = NodeEntity(type = "task", title = "T")
+        val projectNode = NodeEntity(type = "project", title = "P")
+        val areaNode = NodeEntity(type = "area", title = "A")
+        val unknownNode = NodeEntity(type = "unknown_type", title = "U")
+
+        assertTrue(taskNode.matchesItemFilter(null))
+        assertTrue(projectNode.matchesItemFilter("project"))
+        assertTrue(areaNode.matchesItemFilter("area"))
+        assertTrue(unknownNode.matchesItemFilter("unknown_type"))
+        assertFalse(unknownNode.matchesItemFilter("task"))
+    }
+
+    @Test
+    fun projectStateFromNodeStatus_handles_archived_and_other_states() {
+        assertEquals(ProjectState.ARCHIVED, projectStateFromNodeStatus("archived"))
+        assertEquals(ProjectState.COMPLETED, projectStateFromNodeStatus("done"))
+        assertEquals(ProjectState.COMPLETED, projectStateFromNodeStatus("completed"))
+        assertEquals(ProjectState.ACTIVE, projectStateFromNodeStatus("active"))
+        assertEquals(null, projectStateFromNodeStatus(null as String?))
+    }
+
+    @Test
+    fun taskStateOrNull_handles_non_task_items() {
+        val nonTaskNode = NodeEntity(type = "note", title = "N", status = "active")
+        val taskNodeNullStatus = NodeEntity(type = "task", title = "T", status = "some_random")
+        val taskNodeNoneStatus = NodeEntity(type = "task", title = "T", status = "null")
+
+        assertEquals(null, nonTaskNode.taskStateOrNull())
+        assertEquals(null, taskNodeNullStatus.taskStateOrNull())
+        assertEquals(null, taskNodeNoneStatus.taskStateOrNull())
+    }
 }


### PR DESCRIPTION
This pull request improves test coverage for the core `LifeObjectModels` domain mappers. It adds tests that target explicit edge cases and hidden assumptions, particularly focusing on how functions like `matchesItemFilter`, `projectStateFromNodeStatus`, and `taskStateOrNull` respond to boundary conditions (e.g., null values, unknown status strings, and non-task items). 

These tests provide regression protection against brittle parsing scenarios and increase confidence in the node state transformers without changing any production code.

---
*PR created automatically by Jules for task [829269170513892557](https://jules.google.com/task/829269170513892557) started by @tajemniktv*