### PR TITLE
fix(website): resolve 404 route collision in starlight

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
The automated build log revealed a route collision warning between `src/pages/404.astro` and Starlight's default 404 page:

`[WARN] [router] The route "/404" is defined in both "src/pages/404.astro" and "node_modules/@astrojs/starlight/routes/static/404.astro". A static route cannot be defined more than once.`

This PR fixes the warning by explicitly adding `disable404Route: true` to the Starlight integration configuration in `website/astro.config.mjs`, which tells Starlight to defer to the custom 404 page provided in the project instead of generating a fallback.

This change is safe and prevents the warning from becoming a hard error in future versions of Astro.

---
*PR created automatically by Jules for task [11123256680806220931](https://jules.google.com/task/11123256680806220931) started by @tajemniktv*