### PR TITLE
perf: optimize case-insensitive string comparisons to reduce GC pressure

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -788,21 +788,29 @@ private fun SearchResultCard(
     }
 }
 
+/**
+ * Resolves the appropriate icon for a given node type.
+ * Uses case-insensitive comparison to avoid string allocations during UI rendering.
+ */
 private fun iconForType(type: String): ImageVector =
-    when (type.lowercase()) {
-        "task" -> Icons.Default.TaskAlt
-        "project" -> Icons.Default.Folder
-        "note" -> Icons.Default.Description
-        "record" -> Icons.AutoMirrored.Filled.InsertDriveFile
+    when {
+        type.equals("task", ignoreCase = true) -> Icons.Default.TaskAlt
+        type.equals("project", ignoreCase = true) -> Icons.Default.Folder
+        type.equals("note", ignoreCase = true) -> Icons.Default.Description
+        type.equals("record", ignoreCase = true) -> Icons.AutoMirrored.Filled.InsertDriveFile
         else -> Icons.Default.Search
     }
 
+/**
+ * Resolves the appropriate tint color for a given node type.
+ * Uses case-insensitive comparison to avoid string allocations during UI rendering.
+ */
 private fun iconTintForType(type: String): Color =
-    when (type.lowercase()) {
-        "task" -> TajsOSTheme.AccentRed
-        "project" -> TajsOSTheme.Primary
-        "note" -> TajsOSTheme.AccentBlue
-        "record" -> TajsOSTheme.AccentCyan
+    when {
+        type.equals("task", ignoreCase = true) -> TajsOSTheme.AccentRed
+        type.equals("project", ignoreCase = true) -> TajsOSTheme.Primary
+        type.equals("note", ignoreCase = true) -> TajsOSTheme.AccentBlue
+        type.equals("record", ignoreCase = true) -> TajsOSTheme.AccentCyan
         else -> TajsOSTheme.Primary
     }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2610,26 +2610,26 @@ class MainViewModel(
         content: String? = null,
     )
     {
+        val cleanType = type.trim()
         val normalizedType =
-            when (type.trim().lowercase())
-            {
-                "record"                                           -> "record"
+            when {
+                cleanType.equals("record", ignoreCase = true) -> "record"
 
                 // NON-NLS
-                "project"                                          -> "project"
+                cleanType.equals("project", ignoreCase = true) -> "project"
 
                 // NON-NLS
-                    "area"                                             -> "area"
+                cleanType.equals("area", ignoreCase = true) -> "area"
 
                 // NON-NLS
-                    "idea", "resource", "vault", "document" -> "note"
+                cleanType.equals("idea", ignoreCase = true) || cleanType.equals("resource", ignoreCase = true) || cleanType.equals("vault", ignoreCase = true) || cleanType.equals("document", ignoreCase = true) -> "note"
 
-                    // NON-NLS
-                    "maintenance", "open_loop", "decision", "protocol" -> "task"
+                // NON-NLS
+                cleanType.equals("maintenance", ignoreCase = true) || cleanType.equals("open_loop", ignoreCase = true) || cleanType.equals("decision", ignoreCase = true) || cleanType.equals("protocol", ignoreCase = true) -> "task"
 
-                    // NON-NLS
-                    else -> "task" // NON-NLS
-                }
+                // NON-NLS
+                else -> "task" // NON-NLS
+            }
             viewModelScope.launch {
                 repository.insertTemplate(
                     TemplateEntity(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
@@ -451,11 +451,11 @@ class RelationshipCommands(
     ) {
         scope.launch {
             val cleanTag = categoryTag.trim().lowercase()
+            val cleanAsType = asType.trim()
             val type =
-                when (asType.trim().lowercase())
-                {
-                    "record" -> "record"
-                    "task", "maintenance" -> "task"
+                when {
+                    cleanAsType.equals("record", ignoreCase = true) -> "record"
+                    cleanAsType.equals("task", ignoreCase = true) || cleanAsType.equals("maintenance", ignoreCase = true) -> "task"
                     else -> "note"
                 }
             val nodeId =


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Perf: replace lowercase allocations with case-insensitive comparisons in hot paths
<code>✨ Enhancement</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

This PR replaces `.lowercase()` allocations with case-insensitive comparisons across critical conditional blocks to reduce GC pressure and avoid unnecessary object creations during rendering and state updates.

Modifications include:
- `SearchDashboardBlocks.kt` (UI rendering)
- `RelationshipCommands.kt` (Action processing)
- `MainViewModel.kt` (State preparation)

These changes are purely internal, preserving the existing logic while improving performance.

---
*PR created automatically by Jules for task [5766747498258597884](https://jules.google.com/task/5766747498258597884) started by @tajemniktv*

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Replace <b><i>lowercase()</i></b>-based matching with <b><i>equals(..., ignoreCase = true)</i></b> in hot conditionals.
• Trim input types once and reuse to avoid repeated string allocations.
• Add KDoc explaining the rendering-time allocation avoidance.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Search UI"] --> B["Type string"] --> C["Icon + tint mapping"]
  D["MainViewModel"] --> B --> E["Template type normalize"] --> F[("Repository")]
  G["RelationshipCommands"] --> B --> H["Vault type normalize"] --> F

  subgraph Legend
    direction LR
    _ui["UI/Compose"] ~~~ _vm["ViewModel/Actions"] ~~~ _db[("Data store")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Introduce a typed NodeType/TemplateType (enum/sealed) end-to-end</b></summary>

- ➕ Eliminates repeated string comparisons entirely
- ➕ Avoids case/locale edge cases by canonicalizing at boundaries
- ➕ Improves maintainability and discoverability of allowed values
- ➖ Likely requires broader refactors (DB schema, serialization, API contracts)
- ➖ Higher migration/testing cost than a localized perf fix

</details>

<details>
<summary><b>2. Normalize once at ingestion boundaries (store canonical lowercase)</b></summary>

- ➕ Keeps comparisons cheap (`==`) throughout the app
- ➕ Avoids repeated ignoreCase comparisons across hot paths
- ➖ Still requires one allocation per boundary normalization (unless done differently)
- ➖ Needs audit to ensure all write paths normalize consistently

</details>

<details>
<summary><b>3. Use small helper for multi-value ignoreCase matches</b></summary>

- ➕ Reduces long `a || b || c` chains and risk of missing variants
- ➕ Centralizes perf rationale and matching behavior
- ➖ Still string-based; mostly readability/maintainability gain
- ➖ Adds an extra abstraction if only used in one or two places

</details>

**Recommendation:** The PR’s approach is a good low-risk, localized perf win for known hot paths (Compose rendering and type normalization) by removing `lowercase()` allocations. Longer-term, consider moving to a typed node/template kind (or strict boundary normalization) to prevent stringly-typed drift and to simplify matching logic, but that’s appropriately out of scope for this targeted optimization.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>SearchDashboardBlocks.kt</strong> <code>Avoid &#x27;lowercase()&#x27; allocations in icon/tint type mapping</code> <code>+18/-10</code></summary>

<br/>

>Avoid &#x27;lowercase()&#x27; allocations in icon/tint type mapping
>
><pre>
>• Replaces &#x27;when(type.lowercase())&#x27; with &#x27;equals(ignoreCase = true)&#x27; checks for icon and tint resolution. Adds KDoc documenting the allocation-avoidance rationale during UI rendering.
></pre>
>
><a href='https://github.com/tajemniktv/TajsOS/pull/671/files#diff-725dc381b6208d4ddc95d917f1010f5a523d67a5380cf64e21d7e5c809cefeaa'>composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>MainViewModel.kt</strong> <code>Normalize template type without allocating lowercase strings</code> <code>+11/-11</code></summary>

<br/>

>Normalize template type without allocating lowercase strings
>
><pre>
>• Introduces a trimmed &#x27;cleanType&#x27; and replaces &#x27;type.trim().lowercase()&#x27; matching with allocation-free &#x27;equals(ignoreCase = true)&#x27; branches. Preserves existing canonicalization outputs (record/project/area/note/task).
></pre>
>
><a href='https://github.com/tajemniktv/TajsOS/pull/671/files#diff-662f5807b2221827a7cc84669c04e8582a53a4297c1be59b5e7f557edbb39a2a'>shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>RelationshipCommands.kt</strong> <code>Normalize vault entry &#x27;asType&#x27; using ignoreCase comparisons</code> <code>+4/-4</code></summary>

<br/>

>Normalize vault entry &#x27;asType&#x27; using ignoreCase comparisons
>
><pre>
>• Avoids &#x27;asType.trim().lowercase()&#x27; by trimming once and using &#x27;equals(ignoreCase = true)&#x27; for type selection (record/task/maintenance). Keeps existing behavior for tag normalization and defaulting to note.
></pre>
>
><a href='https://github.com/tajemniktv/TajsOS/pull/671/files#diff-3a9e6cb41c61cc0be28d3feee58ccf89a9277de78a88287619bc36ed44f7de82'>shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>