### PR TITLE
test: add edge case tests for NodeCommands

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommandsEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommandsEdgeTest.kt
@@ -26,113 +26,105 @@ class NodeCommandsEdgeTest {
         )
     }
 
-    @Test
-    fun testUpdateMaintenanceTypeIgnoresNonMaintenanceNodes() = runTest {
+    private suspend fun TestScope.withTestEnv(
+        block: suspend (AppRepository, NodeCommands) -> Unit
+    ) {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val scope = TestScope(testDispatcher)
         val repo = buildTestRepository()
         val commands = createCommands(repo, scope)
+        block(repo, commands)
+    }
 
-        val taskNode = NodeEntity(id = 1L, type = "task", title = "A task")
-        repo.insertNode(taskNode)
+    @Test
+    fun testUpdateMaintenanceTypeIgnoresNonMaintenanceNodes() = runTest {
+        withTestEnv { repo, commands ->
+            val taskNode = NodeEntity(id = 1L, type = "task", title = "A task")
+            repo.insertNode(taskNode)
 
-        commands.updateMaintenanceType(taskNode, "vehicle")
-        advanceUntilIdle()
+            commands.updateMaintenanceType(taskNode, "vehicle")
+            advanceUntilIdle()
 
-        val updatedNode = repo.getNodeById(1L)
-        assertNull(updatedNode?.maintenanceType)
+            val updatedNode = repo.getNodeById(1L)
+            assertNull(updatedNode?.maintenanceType)
+        }
     }
 
     @Test
     fun testSetMaintenanceOverdueAtIgnoresNonMaintenanceNodes() = runTest {
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val scope = TestScope(testDispatcher)
-        val repo = buildTestRepository()
-        val commands = createCommands(repo, scope)
+        withTestEnv { repo, commands ->
+            val noteNode = NodeEntity(id = 1L, type = "note", title = "A note")
+            repo.insertNode(noteNode)
 
-        val noteNode = NodeEntity(id = 1L, type = "note", title = "A note")
-        repo.insertNode(noteNode)
+            commands.setMaintenanceOverdueAt(noteNode, 123456L)
+            advanceUntilIdle()
 
-        commands.setMaintenanceOverdueAt(noteNode, 123456L)
-        advanceUntilIdle()
-
-        val updatedNode = repo.getNodeById(1L)
-        assertNull(updatedNode?.maintenanceOverdueAt)
+            val updatedNode = repo.getNodeById(1L)
+            assertNull(updatedNode?.maintenanceOverdueAt)
+        }
     }
 
     @Test
     fun testSetMaintenanceRecurringIgnoresNonMaintenanceNodes() = runTest {
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val scope = TestScope(testDispatcher)
-        val repo = buildTestRepository()
-        val commands = createCommands(repo, scope)
+        withTestEnv { repo, commands ->
+            val projectNode = NodeEntity(id = 1L, type = "project", title = "A project")
+            repo.insertNode(projectNode)
 
-        val projectNode = NodeEntity(id = 1L, type = "project", title = "A project")
-        repo.insertNode(projectNode)
+            commands.setMaintenanceRecurring(projectNode, "1w")
+            advanceUntilIdle()
 
-        commands.setMaintenanceRecurring(projectNode, "1w")
-        advanceUntilIdle()
-
-        val updatedNode = repo.getNodeById(1L)
-        assertEquals(false, updatedNode?.isRecurring)
-        assertNull(updatedNode?.recurringInterval)
-        assertNull(updatedNode?.maintenanceInterval)
+            val updatedNode = repo.getNodeById(1L)
+            assertEquals(false, updatedNode?.isRecurring)
+            assertNull(updatedNode?.recurringInterval)
+            assertNull(updatedNode?.maintenanceInterval)
+        }
     }
 
     @Test
     fun testSetProjectActivePhaseIgnoresNonProjectNodes() = runTest {
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val scope = TestScope(testDispatcher)
-        val repo = buildTestRepository()
-        val commands = createCommands(repo, scope)
+        withTestEnv { repo, commands ->
+            val recordNode = NodeEntity(id = 1L, type = "record", title = "A record")
+            repo.insertNode(recordNode)
 
-        val recordNode = NodeEntity(id = 1L, type = "record", title = "A record")
-        repo.insertNode(recordNode)
+            commands.setProjectActivePhase(recordNode, true)
+            advanceUntilIdle()
 
-        commands.setProjectActivePhase(recordNode, true)
-        advanceUntilIdle()
-
-        val updatedNode = repo.getNodeById(1L)
-        assertNull(updatedNode?.projectStatus)
+            val updatedNode = repo.getNodeById(1L)
+            assertNull(updatedNode?.projectStatus)
+        }
     }
 
     @Test
     fun testSetWorkDateIgnoresNonTaskNodes() = runTest {
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val scope = TestScope(testDispatcher)
-        val repo = buildTestRepository()
-        val commands = createCommands(repo, scope)
+        withTestEnv { repo, commands ->
+            val noteNode = NodeEntity(id = 1L, type = "note", title = "A note")
+            repo.insertNode(noteNode)
 
-        val noteNode = NodeEntity(id = 1L, type = "note", title = "A note")
-        repo.insertNode(noteNode)
+            commands.setWorkDate(noteNode, 123456L)
+            advanceUntilIdle()
 
-        commands.setWorkDate(noteNode, 123456L)
-        advanceUntilIdle()
-
-        val updatedNode = repo.getNodeById(1L)
-        assertNull(updatedNode?.startAt)
+            val updatedNode = repo.getNodeById(1L)
+            assertNull(updatedNode?.startAt)
+        }
     }
 
     @Test
     fun testSetTemporaryFocusPeriodCoercesDaysToValidRange() = runTest {
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val scope = TestScope(testDispatcher)
-        val repo = buildTestRepository()
-        val commands = createCommands(repo, scope)
+        withTestEnv { repo, commands ->
+            val taskNode = NodeEntity(id = 1L, type = "task", title = "A task")
+            repo.insertNode(taskNode)
 
-        val taskNode = NodeEntity(id = 1L, type = "task", title = "A task")
-        repo.insertNode(taskNode)
+            commands.setTemporaryFocusPeriod(taskNode, -5)
+            advanceUntilIdle()
 
-        commands.setTemporaryFocusPeriod(taskNode, -5)
-        advanceUntilIdle()
+            var updatedNode = repo.getNodeById(1L)
+            assertEquals("active", updatedNode?.status)
 
-        var updatedNode = repo.getNodeById(1L)
-        assertEquals("active", updatedNode?.status)
+            commands.setTemporaryFocusPeriod(taskNode, 100)
+            advanceUntilIdle()
 
-        commands.setTemporaryFocusPeriod(taskNode, 100)
-        advanceUntilIdle()
-
-        updatedNode = repo.getNodeById(1L)
-        assertEquals("active", updatedNode?.status)
+            updatedNode = repo.getNodeById(1L)
+            assertEquals("active", updatedNode?.status)
+        }
     }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommandsEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommandsEdgeTest.kt
@@ -1,0 +1,138 @@
+package com.tajemniktv.tajsos.ui.main.actions
+
+import com.tajemniktv.tajsos.data.AppRepository
+import com.tajemniktv.tajsos.data.NodeEntity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NodeCommandsEdgeTest {
+
+    private fun createCommands(repository: AppRepository, scope: CoroutineScope): NodeCommands {
+        return NodeCommands(
+            repository = repository,
+            scope = scope,
+            currentTodayNodes = { emptyList() },
+            currentAllNodes = { emptyList() },
+            parseInternalLinks = {},
+            setTagOnNode = { _, _, _ -> }
+        )
+    }
+
+    @Test
+    fun testUpdateMaintenanceTypeIgnoresNonMaintenanceNodes() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val scope = TestScope(testDispatcher)
+        val repo = buildTestRepository()
+        val commands = createCommands(repo, scope)
+
+        val taskNode = NodeEntity(id = 1L, type = "task", title = "A task")
+        repo.insertNode(taskNode)
+
+        commands.updateMaintenanceType(taskNode, "vehicle")
+        advanceUntilIdle()
+
+        val updatedNode = repo.getNodeById(1L)
+        assertNull(updatedNode?.maintenanceType)
+    }
+
+    @Test
+    fun testSetMaintenanceOverdueAtIgnoresNonMaintenanceNodes() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val scope = TestScope(testDispatcher)
+        val repo = buildTestRepository()
+        val commands = createCommands(repo, scope)
+
+        val noteNode = NodeEntity(id = 1L, type = "note", title = "A note")
+        repo.insertNode(noteNode)
+
+        commands.setMaintenanceOverdueAt(noteNode, 123456L)
+        advanceUntilIdle()
+
+        val updatedNode = repo.getNodeById(1L)
+        assertNull(updatedNode?.maintenanceOverdueAt)
+    }
+
+    @Test
+    fun testSetMaintenanceRecurringIgnoresNonMaintenanceNodes() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val scope = TestScope(testDispatcher)
+        val repo = buildTestRepository()
+        val commands = createCommands(repo, scope)
+
+        val projectNode = NodeEntity(id = 1L, type = "project", title = "A project")
+        repo.insertNode(projectNode)
+
+        commands.setMaintenanceRecurring(projectNode, "1w")
+        advanceUntilIdle()
+
+        val updatedNode = repo.getNodeById(1L)
+        assertEquals(false, updatedNode?.isRecurring)
+        assertNull(updatedNode?.recurringInterval)
+        assertNull(updatedNode?.maintenanceInterval)
+    }
+
+    @Test
+    fun testSetProjectActivePhaseIgnoresNonProjectNodes() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val scope = TestScope(testDispatcher)
+        val repo = buildTestRepository()
+        val commands = createCommands(repo, scope)
+
+        val recordNode = NodeEntity(id = 1L, type = "record", title = "A record")
+        repo.insertNode(recordNode)
+
+        commands.setProjectActivePhase(recordNode, true)
+        advanceUntilIdle()
+
+        val updatedNode = repo.getNodeById(1L)
+        assertNull(updatedNode?.projectStatus)
+    }
+
+    @Test
+    fun testSetWorkDateIgnoresNonTaskNodes() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val scope = TestScope(testDispatcher)
+        val repo = buildTestRepository()
+        val commands = createCommands(repo, scope)
+
+        val noteNode = NodeEntity(id = 1L, type = "note", title = "A note")
+        repo.insertNode(noteNode)
+
+        commands.setWorkDate(noteNode, 123456L)
+        advanceUntilIdle()
+
+        val updatedNode = repo.getNodeById(1L)
+        assertNull(updatedNode?.startAt)
+    }
+
+    @Test
+    fun testSetTemporaryFocusPeriodCoercesDaysToValidRange() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val scope = TestScope(testDispatcher)
+        val repo = buildTestRepository()
+        val commands = createCommands(repo, scope)
+
+        val taskNode = NodeEntity(id = 1L, type = "task", title = "A task")
+        repo.insertNode(taskNode)
+
+        commands.setTemporaryFocusPeriod(taskNode, -5)
+        advanceUntilIdle()
+
+        var updatedNode = repo.getNodeById(1L)
+        assertEquals("active", updatedNode?.status)
+
+        commands.setTemporaryFocusPeriod(taskNode, 100)
+        advanceUntilIdle()
+
+        updatedNode = repo.getNodeById(1L)
+        assertEquals("active", updatedNode?.status)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommandsEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommandsEdgeTest.kt
@@ -26,105 +26,75 @@ class NodeCommandsEdgeTest {
         )
     }
 
-    private suspend fun TestScope.withTestEnv(
-        block: suspend (AppRepository, NodeCommands) -> Unit
-    ) {
+    private fun testEdgeCase(
+        nodeType: String,
+        action: NodeCommands.(NodeEntity) -> Unit,
+        verify: (NodeEntity?) -> Unit
+    ) = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val scope = TestScope(testDispatcher)
         val repo = buildTestRepository()
         val commands = createCommands(repo, scope)
-        block(repo, commands)
+
+        val node = NodeEntity(id = 1L, type = nodeType, title = "Test Node")
+        repo.insertNode(node)
+
+        commands.action(node)
+        advanceUntilIdle()
+
+        verify(repo.getNodeById(1L))
     }
 
     @Test
-    fun testUpdateMaintenanceTypeIgnoresNonMaintenanceNodes() = runTest {
-        withTestEnv { repo, commands ->
-            val taskNode = NodeEntity(id = 1L, type = "task", title = "A task")
-            repo.insertNode(taskNode)
-
-            commands.updateMaintenanceType(taskNode, "vehicle")
-            advanceUntilIdle()
-
-            val updatedNode = repo.getNodeById(1L)
-            assertNull(updatedNode?.maintenanceType)
-        }
-    }
+    fun testUpdateMaintenanceTypeIgnoresNonMaintenanceNodes() = testEdgeCase(
+        nodeType = "task",
+        action = { updateMaintenanceType(it, "vehicle") },
+        verify = { assertNull(it?.maintenanceType) }
+    )
 
     @Test
-    fun testSetMaintenanceOverdueAtIgnoresNonMaintenanceNodes() = runTest {
-        withTestEnv { repo, commands ->
-            val noteNode = NodeEntity(id = 1L, type = "note", title = "A note")
-            repo.insertNode(noteNode)
-
-            commands.setMaintenanceOverdueAt(noteNode, 123456L)
-            advanceUntilIdle()
-
-            val updatedNode = repo.getNodeById(1L)
-            assertNull(updatedNode?.maintenanceOverdueAt)
-        }
-    }
+    fun testSetMaintenanceOverdueAtIgnoresNonMaintenanceNodes() = testEdgeCase(
+        nodeType = "note",
+        action = { setMaintenanceOverdueAt(it, 123456L) },
+        verify = { assertNull(it?.maintenanceOverdueAt) }
+    )
 
     @Test
-    fun testSetMaintenanceRecurringIgnoresNonMaintenanceNodes() = runTest {
-        withTestEnv { repo, commands ->
-            val projectNode = NodeEntity(id = 1L, type = "project", title = "A project")
-            repo.insertNode(projectNode)
-
-            commands.setMaintenanceRecurring(projectNode, "1w")
-            advanceUntilIdle()
-
-            val updatedNode = repo.getNodeById(1L)
-            assertEquals(false, updatedNode?.isRecurring)
-            assertNull(updatedNode?.recurringInterval)
-            assertNull(updatedNode?.maintenanceInterval)
+    fun testSetMaintenanceRecurringIgnoresNonMaintenanceNodes() = testEdgeCase(
+        nodeType = "project",
+        action = { setMaintenanceRecurring(it, "1w") },
+        verify = {
+            assertEquals(false, it?.isRecurring)
+            assertNull(it?.recurringInterval)
+            assertNull(it?.maintenanceInterval)
         }
-    }
+    )
 
     @Test
-    fun testSetProjectActivePhaseIgnoresNonProjectNodes() = runTest {
-        withTestEnv { repo, commands ->
-            val recordNode = NodeEntity(id = 1L, type = "record", title = "A record")
-            repo.insertNode(recordNode)
-
-            commands.setProjectActivePhase(recordNode, true)
-            advanceUntilIdle()
-
-            val updatedNode = repo.getNodeById(1L)
-            assertNull(updatedNode?.projectStatus)
-        }
-    }
+    fun testSetProjectActivePhaseIgnoresNonProjectNodes() = testEdgeCase(
+        nodeType = "record",
+        action = { setProjectActivePhase(it, true) },
+        verify = { assertNull(it?.projectStatus) }
+    )
 
     @Test
-    fun testSetWorkDateIgnoresNonTaskNodes() = runTest {
-        withTestEnv { repo, commands ->
-            val noteNode = NodeEntity(id = 1L, type = "note", title = "A note")
-            repo.insertNode(noteNode)
-
-            commands.setWorkDate(noteNode, 123456L)
-            advanceUntilIdle()
-
-            val updatedNode = repo.getNodeById(1L)
-            assertNull(updatedNode?.startAt)
-        }
-    }
+    fun testSetWorkDateIgnoresNonTaskNodes() = testEdgeCase(
+        nodeType = "note",
+        action = { setWorkDate(it, 123456L) },
+        verify = { assertNull(it?.startAt) }
+    )
 
     @Test
-    fun testSetTemporaryFocusPeriodCoercesDaysToValidRange() = runTest {
-        withTestEnv { repo, commands ->
-            val taskNode = NodeEntity(id = 1L, type = "task", title = "A task")
-            repo.insertNode(taskNode)
+    fun testSetTemporaryFocusPeriodCoercesNegativeDays() = testEdgeCase(
+        nodeType = "task",
+        action = { setTemporaryFocusPeriod(it, -5) },
+        verify = { assertEquals("active", it?.status) }
+    )
 
-            commands.setTemporaryFocusPeriod(taskNode, -5)
-            advanceUntilIdle()
-
-            var updatedNode = repo.getNodeById(1L)
-            assertEquals("active", updatedNode?.status)
-
-            commands.setTemporaryFocusPeriod(taskNode, 100)
-            advanceUntilIdle()
-
-            updatedNode = repo.getNodeById(1L)
-            assertEquals("active", updatedNode?.status)
-        }
-    }
+    @Test
+    fun testSetTemporaryFocusPeriodCoercesLargeDays() = testEdgeCase(
+        nodeType = "task",
+        action = { setTemporaryFocusPeriod(it, 100) },
+        verify = { assertEquals("active", it?.status) }
+    )
 }


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add edge-case tests for NodeCommands precondition guards
<code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Adds edge case testing to `NodeCommands.kt` for functions like `updateMaintenanceType`, `setMaintenanceOverdueAt`, `setMaintenanceRecurring`, `setProjectActivePhase`, `setWorkDate`, and `setTemporaryFocusPeriod`. This ensures that they properly ignore or coerce inputs that do not meet expected preconditions (like mismatched node types or out-of-bounds days).

---
*PR created automatically by Jules for task [16491957690079440075](https://jules.google.com/task/16491957690079440075) started by @tajemniktv*

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add edge-case tests to ensure NodeCommands ignores updates for mismatched node types.
• Verify maintenance/project/work-date commands do not mutate unrelated node kinds.
• Exercise temporary focus period with out-of-range day inputs under coroutine scheduling.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  T["NodeCommandsEdgeTest"] --> C["NodeCommands"] --> R[("AppRepository (fake)")] --> D[("Fake DAOs")]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Table-driven/parameterized guard tests</b></summary>

- ➕ Cuts repeated setup (dispatcher/scope/repo) across similar cases
- ➕ Makes it easier to add new guarded commands and node-type permutations
- ➖ Can be less readable when each case asserts different fields
- ➖ May require additional test helpers/abstractions in commonTest

</details>

<details>
<summary><b>2. Assert repository update calls instead of reloading nodes</b></summary>

- ➕ More direct verification that updates are skipped (no write attempted)
- ➕ Potentially faster and more isolated from FakeDao behavior
- ➖ Requires injecting/spying on updateNode/updateNodes (test-only wiring)
- ➖ Less integration-like than verifying persisted state via repository reads

</details>

**Recommendation:** The PR’s approach (integration-style tests asserting persisted state via the fake repository) is appropriate and aligns with existing patterns. If this edge suite grows, consider a table-driven structure to reduce duplication while keeping per-field assertions explicit.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>NodeCommandsEdgeTest.kt</strong> <code>Add edge-case coverage for NodeCommands type guards and day bounds</code> <code>+138/-0</code></summary>

<br/>

>Add edge-case coverage for NodeCommands type guards and day bounds
>
><pre>
>• Adds tests for updateMaintenanceType, setMaintenanceOverdueAt, setMaintenanceRecurring, setProjectActivePhase, and setWorkDate to confirm they ignore nodes of the wrong type. Adds a test for setTemporaryFocusPeriod with invalid day values (negative/too large) to ensure days are coerced and the node is activated as expected.
></pre>
>
><a href='https://github.com/tajemniktv/TajsOS/pull/672/files#diff-2f901fb72bd0773c0052f456b3e6c98884aa7adf95c7faa089adf824456d8d35'>shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommandsEdgeTest.kt</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>