### PR TITLE
docs: add property KDocs to LifeObjectEntities and DomainMatcher

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
@@ -19,6 +19,18 @@ private fun currentEpochMillis(): Long =
  *
  * This is the primary "capture fast, structure later" primitive for the new LifeOS model.
  * Represents a raw capture entry inside the inbox before being structured or triaged.
+ *
+ * @property id The unique auto-generated database ID.
+ * @property rawText The raw, unprocessed text captured by the user.
+ * @property source The origin of the capture (e.g., 'manual').
+ * @property suggestedKind An optional suggested node kind (e.g., task, note) for future processing.
+ * @property homeAreaId An optional area ID this capture might belong to.
+ * @property activeProjectId An optional active project ID this capture might belong to.
+ * @property contextScreen An optional string recording what screen the user was on during capture.
+ * @property capturedAt The epoch timestamp in milliseconds when this entry was captured.
+ * @property processedAt An optional epoch timestamp in milliseconds when this entry was processed.
+ * @property dismissedAt An optional epoch timestamp in milliseconds when this entry was dismissed.
+ * @property triagedItemId The ID of the resulting node item after this capture was triaged.
  */
 @Entity(
     tableName = "inbox_entries",
@@ -48,6 +60,17 @@ data class InboxEntryEntity(
 
 /**
  * Task-specific execution and recurrence data associated with an item row.
+ *
+ * @property itemId The ID of the associated shared LifeOS item.
+ * @property state The execution state of the task (e.g., ACTIVE, COMPLETED).
+ * @property energyLevel An optional integer representing the estimated energy required.
+ * @property friction An optional string identifying potential blockers or friction points.
+ * @property nextStep An optional description of the immediate next action.
+ * @property estimatedMinutes An optional estimated time to completion in minutes.
+ * @property completionNote An optional note or reflection added when the task was completed.
+ * @property completedAt An optional epoch timestamp in milliseconds when the task was completed.
+ * @property isRecurring Boolean flag indicating if this task is a recurring template.
+ * @property recurringInterval The recurrence rule/interval string if the task is recurring.
  */
 @Entity(tableName = "task_facets")
 @Serializable
@@ -66,6 +89,13 @@ data class TaskFacetEntity(
 
 /**
  * Note-specific semantics stored beside the shared item row.
+ *
+ * @property itemId The ID of the associated shared LifeOS item.
+ * @property kind The specific category of the note (e.g., GENERAL).
+ * @property state The lifecycle state of the note.
+ * @property sourceTitle An optional string storing the title of referenced source material.
+ * @property sourceAuthor An optional string storing the author of referenced source material.
+ * @property lastReviewedAt An optional epoch timestamp in milliseconds when the note was last reviewed.
  */
 @Entity(tableName = "note_facets")
 @Serializable
@@ -80,6 +110,11 @@ data class NoteFacetEntity(
 
 /**
  * Project-specific coordination state stored separately from the shared item row.
+ *
+ * @property itemId The ID of the associated shared LifeOS item.
+ * @property state The execution state of the project (e.g., ACTIVE, COMPLETED).
+ * @property purpose An optional description of the project's goal or desired outcome.
+ * @property isFrozen Boolean flag indicating if the project is currently suspended or on hold.
  */
 @Entity(tableName = "project_facets")
 @Serializable
@@ -92,6 +127,11 @@ data class ProjectFacetEntity(
 
 /**
  * Area-specific stewardship data kept out of the shared node table.
+ *
+ * @property itemId The ID of the associated shared LifeOS item.
+ * @property healthStatus The current health status of the area (e.g., STABLE, ATTENTION_NEEDED).
+ * @property standardOfCare An optional description defining what "good" looks like for this area.
+ * @property vision An optional long-term vision or desired state for this area.
  */
 @Entity(tableName = "area_facets")
 @Serializable
@@ -104,6 +144,10 @@ data class AreaFacetEntity(
 
 /**
  * Record-specific chronological data attached to an item row.
+ *
+ * @property itemId The ID of the associated shared LifeOS item.
+ * @property kind The specific category of the record (e.g., GENERAL, HEALTH).
+ * @property occurredAt The epoch timestamp in milliseconds when the recorded event occurred.
  */
 @Entity(tableName = "record_facets")
 @Serializable
@@ -136,6 +180,11 @@ data class RecordFacetEntity(
  * Represents the cross-cutting assignment of a shared item to a first-class LifeOS domain.
  * NOTE: Current design prefers implicit categorization via `DomainLensQueries`,
  * but explicit database associations are preserved here for overrides and future expansion.
+ *
+ * @property itemId The ID of the associated shared LifeOS item.
+ * @property domainKey The specific domain key assigned to the item.
+ * @property isPrimary Boolean flag indicating if this domain is the primary domain for the item.
+ * @property assignedAt The epoch timestamp in milliseconds when the assignment was made.
  */
 @Serializable
 data class ItemDomainEntity(
@@ -157,6 +206,13 @@ data class ItemDomainEntity(
 /**
  * Stores long-form structured content (such as markdown bodies or embedded objects)
  * alongside a parent Node without bloating the primary generic node table.
+ *
+ * @property itemId The ID of the LifeOS item owning this document.
+ * @property format The format type of the rich content (e.g., Markdown).
+ * @property body The raw textual body of the document.
+ * @property structuredContentJson An optional JSON string representing a structured layout.
+ * @property schemaVersion The version of the content schema used.
+ * @property updatedAt The epoch timestamp in milliseconds when the document was last updated.
  */
 @Serializable
 data class RichContentDocumentEntity(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -256,6 +256,11 @@ object DomainLensQueries {
     /**
      * Configuration class to group matching heuristics. This avoids having functions with many string/collection
      * arguments, which can trigger code health violations.
+     *
+     * @property maintenanceTypes A set of explicit maintenance types that classify an item into this domain.
+     * @property tagMarkers A set of specific tag strings used to implicitly associate nodes with this domain.
+     * @property titleKeywords A list of keywords that trigger this domain's categorization when found in a node's title or content.
+     * @property validNoteTypes A set of specific note types that automatically qualify an item for this domain.
      */
     private class DomainMatcher(
         val maintenanceTypes: Set<String>,


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add missing @property KDocs for LifeObject entities and DomainMatcher
<code>📝 Documentation</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Adds missing KDocs to shared multiplatform entities (`LifeObjectEntities.kt`) and `DomainMatcher` class (`DomainLensQueries.kt`). The lack of property level documentation on these components made understanding non-obvious flows regarding heuristic matching and entity facets more difficult than necessary.

This pull request solely affects comments and introduces no architectural changes. Tests pass normally.

---
*PR created automatically by Jules for task [16922961305341030558](https://jules.google.com/task/16922961305341030558) started by @tajemniktv*

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Document entity properties in shared LifeOS database models to reduce onboarding friction.
• Add @property KDocs to DomainMatcher to clarify heuristic domain categorization inputs.
• No runtime behavior changes; comments-only update.
</pre>
</details>

<details>
<summary>High-Level Assessment</summary>

<br/>

The approach is appropriate: add KDoc @property entries directly on the source-of-truth entities and the matching configuration class. Alternatives like external documentation or higher-level overviews wouldn’t replace the need for property-level clarity at call sites.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>LifeObjectEntities.kt</strong> <code>Add @property KDocs for core multiplatform entities</code> <code>+56/-0</code></summary>

<br/>

>Add @property KDocs for core multiplatform entities
>
><pre>
>• Adds missing property-level KDocs for multiple shared entities (InboxEntryEntity and several facet/domain/content entities). Improves clarity around timestamps, ownership (itemId), and semantics (state/kind/domain fields) without changing data models.
></pre>
>
><a href='https://github.com/tajemniktv/TajsOS/pull/673/files#diff-b3e03f65afa26f045ffa7370d39a13e2d625fded08380aa7ccce5d0e434b2191'>shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>DomainLensQueries.kt</strong> <code>Document DomainMatcher heuristic configuration fields</code> <code>+5/-0</code></summary>

<br/>

>Document DomainMatcher heuristic configuration fields
>
><pre>
>• Adds @property KDocs to DomainMatcher to explain how maintenance types, tag markers, title keywords, and note types influence implicit domain categorization.
></pre>
>
><a href='https://github.com/tajemniktv/TajsOS/pull/673/files#diff-14a3d94ed7b99f11711c97465d27234566964e73c820c31280929c26aa2abf0d'>shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>