### PR TITLE
fix(ui): add pointer hover icons to interactive elements

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AlertCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AlertCards.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Alert card
@@ -47,7 +49,7 @@ fun AlertCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
         color = color.copy(alpha = 0.05f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DashboardCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DashboardCards.kt
@@ -47,6 +47,8 @@ import com.tajemniktv.tajsos.ui.components.nodes.TaskBrief
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import kotlinx.coroutines.delay
 import kotlin.time.Clock
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * A sticky note style card for quick information.
@@ -65,7 +67,7 @@ fun StickyNoteCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier.width(200.dp),
+        modifier = modifier.width(200.dp).pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.Accent.copy(alpha = 0.1f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
@@ -408,7 +410,7 @@ fun VaultCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/GeneralCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/GeneralCards.kt
@@ -35,6 +35,8 @@ import com.tajemniktv.tajsos.ui.components.common.GlassMaterial
 import com.tajemniktv.tajsos.ui.components.common.glassChrome
 import com.tajemniktv.tajsos.ui.components.common.glassContainerColor
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun InfoCard(
@@ -51,7 +53,7 @@ fun InfoCard(
             modifier.glassChrome(
                 shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                 material = GlassMaterial.REGULAR,
-            ),
+            ).pointerHoverIcon(PointerIcon.Hand),
         color = glassContainerColor(TajsOSTheme.Surface),
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
@@ -99,7 +101,7 @@ fun StatusCard(
             modifier.fillMaxWidth().glassChrome(
                 shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                 material = GlassMaterial.REGULAR,
-            ),
+            ).pointerHoverIcon(PointerIcon.Hand),
         color = glassContainerColor(TajsOSTheme.Surface),
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
@@ -140,7 +142,7 @@ fun LinkedNodeItem(
             modifier.fillMaxWidth().glassChrome(
                 shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                 material = GlassMaterial.REGULAR,
-            ),
+            ).pointerHoverIcon(PointerIcon.Hand),
         color = glassContainerColor(TajsOSTheme.Surface),
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
@@ -198,7 +200,7 @@ fun ConnectionCard(
             modifier.fillMaxWidth().glassChrome(
                 shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                 material = GlassMaterial.THIN,
-            ),
+            ).pointerHoverIcon(PointerIcon.Hand),
         color = glassContainerColor(Color.Transparent),
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/ModuleCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/ModuleCard.kt
@@ -37,6 +37,8 @@ import com.tajemniktv.tajsos.ui.components.common.glassChrome
 import com.tajemniktv.tajsos.ui.components.common.glassContainerColor
 import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun ModuleCard(
@@ -67,7 +69,7 @@ fun ModuleCard(
                     },
                     onSecondaryClick = onClick,
                     middleClickFallbackToPrimary = true,
-                ),
+                ).pointerHoverIcon(PointerIcon.Hand),
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
         color = glassContainerColor(TajsOSTheme.Surface),
         shadowElevation = 2.dp,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
@@ -63,6 +63,8 @@ import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
 import kotlin.time.Clock
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun NodeCard(
@@ -115,7 +117,7 @@ fun NodeCard(
                             onLongClick = onLongClick,
                             onSecondaryClickAt = { contextMenuState.showAt(it) },
                             middleClickFallbackToPrimary = true,
-                        ),
+                        ).pointerHoverIcon(PointerIcon.Hand),
                 color = glassContainerColor(TajsOSTheme.Surface),
                 shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
                 border =

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun DashCard(
@@ -35,7 +37,7 @@ fun DashCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
         content = content,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/RecoveryCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/RecoveryCards.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun BasicSurvivalCard(
@@ -34,7 +36,7 @@ fun BasicSurvivalCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/SystemOverviewCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/SystemOverviewCards.kt
@@ -38,6 +38,8 @@ import tajsos.composeapp.generated.resources.dash_capacity
 import tajsos.composeapp.generated.resources.dash_fragmentation
 import tajsos.composeapp.generated.resources.dash_load
 import tajsos.composeapp.generated.resources.dash_system_status
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun SystemStatusCard(
@@ -49,7 +51,7 @@ fun SystemStatusCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
         color = if (warning != null) TajsOSTheme.Error.copy(alpha = 0.05f) else TajsOSTheme.Surface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         border =
@@ -163,7 +165,7 @@ fun AreaHealthCard(
 
     Surface(
         onClick = onClick,
-        modifier = modifier.width(190.dp),
+        modifier = modifier.width(190.dp).pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/TrackCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/TrackCards.kt
@@ -88,8 +88,8 @@ fun MedicationSyncCard(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { onToggleMed(med.id) }
-                                .pointerHoverIcon(PointerIcon.Hand)
+                                .clickable { onToggleMed(med.id) }.pointerHoverIcon(PointerIcon.Hand)
+
                                 .padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/SelectorDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/SelectorDialog.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Displays a full-screen selector dialog presenting a grid of selectable options.
@@ -139,7 +141,7 @@ fun <T> SelectorDialog(
                             onClick = { onSelect(option) },
                             color = if (isSelected) TajsOSTheme.Primary else TajsOSTheme.Surface,
                             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                            modifier = Modifier.height(140.dp),
+                            modifier = Modifier.height(140.dp).pointerHoverIcon(PointerIcon.Hand),
                             border =
                                 if (isSelected) {
                                     null

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -69,6 +69,8 @@ import tajsos.composeapp.generated.resources.header_mode_label
 import tajsos.composeapp.generated.resources.header_notifications
 import tajsos.composeapp.generated.resources.header_notifications_title
 import tajsos.composeapp.generated.resources.header_search_placeholder
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Mode option model shown by the header mode switcher.
@@ -403,7 +405,7 @@ fun HeaderModeSwitcher(
                     .glassChrome(
                         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                         material = GlassMaterial.REGULAR,
-                    ),
+                    ).pointerHoverIcon(PointerIcon.Hand),
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             color = glassContainerColor(TajsOSTheme.SurfaceHigh),
             tonalElevation = 0.dp,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
@@ -95,6 +95,8 @@ import tajsos.composeapp.generated.resources.common_open
 import tajsos.composeapp.generated.resources.sidebar_brand
 import tajsos.composeapp.generated.resources.sidebar_new_entry
 import kotlin.math.roundToInt
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 private const val MinExpandedSidebarWidthDp = 220f
 private const val MaxExpandedSidebarWidthDp = 360f
@@ -449,7 +451,7 @@ fun ExpandableNavSection(
                                 onClick = rootClickAction,
                                 onSecondaryClickAt = { contextMenuState.showAt(it) },
                                 middleClickFallbackToPrimary = true,
-                            ),
+                            ).pointerHoverIcon(PointerIcon.Hand),
                     shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                     color =
                         if (isActiveBranch) {
@@ -638,7 +640,7 @@ fun ExpandableNavSection(
                                         onClick = { onChildNavigate(child) },
                                         onSecondaryClickAt = { childContextMenuState.showAt(it) },
                                         middleClickFallbackToPrimary = true,
-                                    ),
+                                    ).pointerHoverIcon(PointerIcon.Hand),
                             color =
                                 if (isActiveChild) {
                                     TajsOSTheme.Primary.copy(alpha = 0.12f)
@@ -744,7 +746,7 @@ fun NewEntryButton(
                     ).graphicsLayer {
                         scaleX = scale
                         scaleY = scale
-                    },
+                    }.pointerHoverIcon(PointerIcon.Hand),
             interactionSource = interactionSource,
             tonalElevation = 0.dp,
             shadowElevation = 0.dp,
@@ -797,7 +799,7 @@ fun UserProfileSidebarSection(
                 Modifier.fillMaxWidth().mouseButtons(
                     onSecondaryClick = onClick,
                     onMiddleClick = onClick,
-                ),
+                ).pointerHoverIcon(PointerIcon.Hand),
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             color = TajsOSTheme.CardNestedSurface,
             tonalElevation = 0.dp,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/ProtocolTrigger.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/ProtocolTrigger.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Displays a fixed-width clickable card containing an icon above an uppercase label,
@@ -51,7 +53,7 @@ fun ProtocolTrigger(
 ) {
     Surface(
         onClick = onClick,
-        modifier = Modifier.width(120.dp),
+        modifier = Modifier.width(120.dp).pointerHoverIcon(PointerIcon.Hand),
         color = color.copy(alpha = 0.1f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSwitcherHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSwitcherHeader.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.data.ModeEntity
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a header labeled "OPERATING MODE" with a horizontally scrollable row of selectable mode chips.
@@ -62,6 +64,7 @@ fun ModeSwitcherHeader(
                 val isSelected = mode.id == currentMode?.id
                 val color = mode.themeColor?.let { Color(it) } ?: TajsOSTheme.Primary
                 Surface(
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     onClick = { onModeSelect(mode.id) },
                     color = if (isSelected) color.copy(alpha = 0.15f) else Color.Transparent,
                     shape = RoundedCornerShape(TajsOSTheme.RadiusSm),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/StateAwareActionsGrid.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/StateAwareActionsGrid.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.ui.MainViewModel
 import com.tajemniktv.tajsos.ui.Screen
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a horizontal row of three equally sized actionable cards that apply preset search filters and navigate to the Search screen.
@@ -73,7 +75,7 @@ fun StateAwareActionsGrid(
                     }
                     onNavigateTo(Screen.Search)
                 },
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1f).pointerHoverIcon(PointerIcon.Hand),
                 color = TajsOSTheme.CardSurface,
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -426,8 +426,8 @@ fun DecisionDetailContent(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { selectedOptionId = option.id }
-                                    .pointerHoverIcon(PointerIcon.Hand),
+                                    .clickable { selectedOptionId = option.id }.pointerHoverIcon(PointerIcon.Hand)
+                                    ,
                         ) {
                             RadioButton(
                                 selected = selectedOptionId == option.id,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/ProjectItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/ProjectItem.kt
@@ -29,6 +29,8 @@ import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.common_open
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a clickable project card for a NodeEntity, optionally showing a percentage and a thin progress bar.
@@ -70,7 +72,7 @@ fun ProjectItem(
                         onLongClick = onLongClick,
                         onSecondaryClickAt = { contextMenuState.showAt(it) },
                         middleClickFallbackToPrimary = true,
-                    ),
+                    ).pointerHoverIcon(PointerIcon.Hand),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
             border =

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/SuggestionGroup.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/SuggestionGroup.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.data.NodeWithPin
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a titled suggestion section displaying up to two clickable node entries with an optional description.
@@ -66,7 +68,7 @@ fun SuggestionGroup(
         nodes.take(2).forEach { nodeWithPin ->
             Surface(
                 onClick = { onEditNode(nodeWithPin.node.id) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
                 color = TajsOSTheme.CardSurface,
                 shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                 border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
@@ -57,7 +57,7 @@ fun TaskBrief(
         onClick = onClick,
         color = Color.Black.copy(alpha = 0.2f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
@@ -45,6 +45,8 @@ import tajsos.composeapp.generated.resources.dash_heavy
 import tajsos.composeapp.generated.resources.dash_unclear
 import tajsos.composeapp.generated.resources.detail_archive
 import tajsos.composeapp.generated.resources.task_row_unpin_desc
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a single task row for the given node, showing its title, metadata and action controls.
@@ -106,7 +108,7 @@ fun TaskRow(
                         onLongClick = onLongClick,
                         onSecondaryClickAt = { contextMenuState.showAt(it) },
                         middleClickFallbackToPrimary = true,
-                    ),
+                    ).pointerHoverIcon(PointerIcon.Hand),
             color = TajsOSTheme.CardSurface,
         ) {
             Row(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
@@ -71,8 +71,8 @@ fun TajsNotificationCard(
             modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(TajsOSTheme.RadiusMd))
-                .clickable { notification.onClick() }
-                .pointerHoverIcon(PointerIcon.Hand),
+                .clickable { notification.onClick() }.pointerHoverIcon(PointerIcon.Hand)
+                ,
         color = TajsOSTheme.SurfaceLow,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
@@ -84,6 +84,8 @@ import tajsos.composeapp.generated.resources.areas_recent_activity
 import tajsos.composeapp.generated.resources.areas_title
 import tajsos.composeapp.generated.resources.areas_upcoming_deadlines
 import tajsos.composeapp.generated.resources.common_open
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object AreasDashboardBlocks {
     private val renderers: Map<String, AreasDashboardBlockRenderer> =
@@ -363,7 +365,7 @@ private fun AreaCard(
                     onClick = onClick,
                     onSecondaryClickAt = { contextMenuState.showAt(it) },
                     middleClickFallbackToPrimary = true,
-                ),
+                ).pointerHoverIcon(PointerIcon.Hand),
             color = TajsOSTheme.CardSurface,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
@@ -416,8 +416,8 @@ private fun renderAreaSidebar(context: AreaDetailContext) {
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clickable { context.onEditNode(node.id) }
-                            .pointerHoverIcon(PointerIcon.Hand),
+                            .clickable { context.onEditNode(node.id) }.pointerHoverIcon(PointerIcon.Hand)
+                            ,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
@@ -94,6 +94,8 @@ import tajsos.composeapp.generated.resources.briefing_resume_hint
 import tajsos.composeapp.generated.resources.briefing_upcoming
 import kotlin.time.Clock
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Calm, desktop-first orientation screen showing a lightweight daily briefing.
@@ -647,7 +649,7 @@ private fun BriefingActionCard(action: BriefingAction) {
         color = TajsOSTheme.SurfaceLow.copy(alpha = 0.72f),
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
-        modifier = Modifier.width(188.dp).height(144.dp),
+        modifier = Modifier.width(188.dp).height(144.dp).pointerHoverIcon(PointerIcon.Hand),
     ) {
         Column(
             modifier = Modifier.fillMaxSize().padding(16.dp),
@@ -698,7 +700,7 @@ private fun BriefingCaptureField(onClick: () -> Unit) {
         onClick = onClick,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceHighest.copy(alpha = 0.9f),
-        modifier = Modifier.widthIn(max = 720.dp).fillMaxWidth().height(58.dp),
+        modifier = Modifier.widthIn(max = 720.dp).fillMaxWidth().height(58.dp).pointerHoverIcon(PointerIcon.Hand),
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -261,8 +261,8 @@ fun MonthView(
                                         } else {
                                             TajsOSTheme.CalendarIdleDay
                                         },
-                                    ).clickable { onDateSelected(date) }
-                                        .pointerHoverIcon(PointerIcon.Hand),
+                                    ).clickable { onDateSelected(date) }.pointerHoverIcon(PointerIcon.Hand)
+                                        ,
                             contentAlignment = Alignment.Center,
                         ) {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -389,7 +389,7 @@ fun AgendaRow(
                 1.dp,
                 TajsOSTheme.GhostBorder.copy(alpha = 0.15f),
             ),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
     ) {
         Row(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
@@ -444,8 +444,8 @@ private fun RenderDashboardBlock(
                     Row(
                         modifier =
                             Modifier
-                                .clickable { context.onNewEntry() }
-                                .pointerHoverIcon(PointerIcon.Hand)
+                                .clickable { context.onNewEntry() }.pointerHoverIcon(PointerIcon.Hand)
+
                                 .background(TajsOSTheme.Primary, RoundedCornerShape(TajsOSTheme.RadiusXs))
                                 .padding(horizontal = 12.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -607,8 +607,8 @@ private fun DashboardOperationsOverview(
                                 1.dp,
                                 TajsOSTheme.Border,
                                 RoundedCornerShape(TajsOSTheme.RadiusMd),
-                            ).clickable { onNavigate(module.screen.route) }
-                                .pointerHoverIcon(PointerIcon.Hand)
+                            ).clickable { onNavigate(module.screen.route) }.pointerHoverIcon(PointerIcon.Hand)
+
                               .padding(TajsOSTheme.SpacingMd),
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
@@ -216,8 +216,8 @@ internal fun renderFinanceActivityBlock(context: FinanceDashboardContext) {
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clickable { context.onEditNode(item.node.id) }
-                            .pointerHoverIcon(PointerIcon.Hand)
+                            .clickable { context.onEditNode(item.node.id) }.pointerHoverIcon(PointerIcon.Hand)
+
                             .padding(vertical = 4.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/health/HealthDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/health/HealthDashboardBlocks.kt
@@ -23,6 +23,8 @@ import com.tajemniktv.tajsos.ui.MainViewModel
 import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.screens.GroupedOpenLoopSection
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object HealthDashboardBlockRegistry {
     private val renderers: Map<String, HealthDashboardBlockRenderer> =
@@ -114,7 +116,7 @@ internal fun HealthMainBlock(
         Column(verticalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
             healthQueue.forEach { item ->
                 Surface(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
                     color = TajsOSTheme.CardSurface,
                     shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                     onClick = { onEditNode(item.node.node.id) },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsScreen.kt
@@ -41,6 +41,8 @@ import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.insights_needs_attention
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Central insights entry point that collects system state and coordinates layout.
@@ -118,7 +120,7 @@ fun ProjectEntropyItem(
     onClick: () -> Unit,
 ) {
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
         border =
@@ -217,7 +219,7 @@ fun NeglectedProjectItem(
     onClick: () -> Unit,
 ) {
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
         border =

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -138,8 +138,8 @@ fun NotesContextPanel(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onOpenNode(task.id) }
-                                        .pointerHoverIcon(PointerIcon.Hand)
+                                        .clickable { onOpenNode(task.id) }.pointerHoverIcon(PointerIcon.Hand)
+
                                         .padding(vertical = 2.dp),
                             )
                         }
@@ -163,8 +163,8 @@ fun NotesContextPanel(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onOpenNode(note.id) }
-                                        .pointerHoverIcon(PointerIcon.Hand)
+                                        .clickable { onOpenNode(note.id) }.pointerHoverIcon(PointerIcon.Hand)
+
                                         .padding(vertical = 2.dp),
                             )
                         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -53,6 +53,8 @@ import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.common_open
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Notes workspace left rail with creation, search, filtering, sorting, and note list navigation.
@@ -253,7 +255,7 @@ fun NotesListItem(
                         onClick = onClick,
                         onSecondaryClickAt = { contextMenuState.showAt(it) },
                         middleClickFallbackToPrimary = true,
-                    ),
+                    ).pointerHoverIcon(PointerIcon.Hand),
             color = surfaceColor,
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -247,8 +247,8 @@ fun NotesWorkspaceDetail(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { onNavigateToNode(item.id) }
-                                    .pointerHoverIcon(PointerIcon.Hand),
+                                    .clickable { onNavigateToNode(item.id) }.pointerHoverIcon(PointerIcon.Hand)
+                                    ,
                             shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                             color =
                                 if (item.id ==
@@ -422,8 +422,8 @@ fun NotesWorkspaceDetail(
                             "• ${linkedNode.title}",
                             modifier =
                                 Modifier
-                                    .clickable { onNavigateToNode(linkedNode.id) }
-                                    .pointerHoverIcon(PointerIcon.Hand),
+                                    .clickable { onNavigateToNode(linkedNode.id) }.pointerHoverIcon(PointerIcon.Hand)
+                                    ,
                             color = TajsOSTheme.Text,
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
@@ -356,8 +356,8 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowEstimateDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .clickable { context.onShowEstimateDialog() }.pointerHoverIcon(PointerIcon.Hand)
+                                ,
                     ) {
                         Text(
                             "ESTIMATE",
@@ -460,8 +460,8 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowMediaTypeDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .clickable { context.onShowMediaTypeDialog() }.pointerHoverIcon(PointerIcon.Hand)
+                                ,
                     ) {
                         Text(
                             "MEDIA TYPE",
@@ -479,8 +479,8 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowRatingDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .clickable { context.onShowRatingDialog() }.pointerHoverIcon(PointerIcon.Hand)
+                                ,
                     ) {
                         Text(
                             "RATING",
@@ -821,8 +821,8 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .clickable { context.onShowAreaDialog() }
-                            .pointerHoverIcon(PointerIcon.Hand),
+                            .clickable { context.onShowAreaDialog() }.pointerHoverIcon(PointerIcon.Hand)
+                            ,
                 ) {
                     Text(
                         "AREA",
@@ -840,8 +840,8 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .clickable { context.onShowProjectDialog() }
-                            .pointerHoverIcon(PointerIcon.Hand),
+                            .clickable { context.onShowProjectDialog() }.pointerHoverIcon(PointerIcon.Hand)
+                            ,
                 ) {
                     Text(
                         "PROJECT",
@@ -911,8 +911,8 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowNoteTypeDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .clickable { context.onShowNoteTypeDialog() }.pointerHoverIcon(PointerIcon.Hand)
+                                ,
                     ) {
                         Text(
                             "NOTE TYPE",
@@ -930,8 +930,8 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowNoteStateDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .clickable { context.onShowNoteStateDialog() }.pointerHoverIcon(PointerIcon.Hand)
+                                ,
                     ) {
                         Text(
                             "STATE",

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
@@ -495,8 +495,8 @@ private fun renderProjectSidebar(context: ProjectDetailContext) {
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { context.onEditNode(node.id) }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .clickable { context.onEditNode(node.id) }.pointerHoverIcon(PointerIcon.Hand)
+                                ,
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -84,8 +84,6 @@ import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
 import kotlin.math.max
 import kotlin.math.min
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object SearchDashboardBlocks {
     private val renderers: Map<String, SearchDashboardBlockRenderer> =
@@ -433,6 +431,7 @@ private fun renderSearchResultsList(context: SearchDashboardContext) {
         ) {
             items(context.searchResults, key = { it.node.id }) { nodeWithPin ->
                 SearchResultCard(
+                    config = SearchResultCardConfig(
                     nodeWithPin = nodeWithPin,
                     projectName = context.projectsById[nodeWithPin.node.projectId]?.title,
                     areaName = context.areasById[nodeWithPin.node.areaId]?.title,
@@ -451,6 +450,7 @@ private fun renderSearchResultsList(context: SearchDashboardContext) {
                         )
                     },
                     onArchive = { context.viewModel.archiveNode(nodeWithPin.node) },
+                ),
                 )
             }
         }
@@ -488,7 +488,6 @@ private fun RecentQueriesRow(
         LazyRow(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
             items(queries.distinct(), key = { it }) { query ->
                 Surface(
-                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     shape = RoundedCornerShape(999.dp),
                     color = TajsOSTheme.SurfaceHigh,
                     onClick = { onQueryClick(query) },
@@ -648,17 +647,29 @@ private fun SearchSupportPanel(
 /**
  * Renders one search result row with title, metadata, excerpt, and quick actions.
  */
+
+data class SearchResultCardConfig(
+    val nodeWithPin: NodeWithPin,
+    val projectName: String?,
+    val areaName: String?,
+    val nowMs: Long,
+    val onOpen: () -> Unit,
+    val onToggleDone: (String) -> Unit,
+    val onTogglePin: (Boolean) -> Unit,
+    val onArchive: () -> Unit,
+)
 @Composable
 private fun SearchResultCard(
-    nodeWithPin: NodeWithPin,
-    projectName: String?,
-    areaName: String?,
-    nowMs: Long,
-    onOpen: () -> Unit,
-    onToggleDone: (String) -> Unit,
-    onTogglePin: (Boolean) -> Unit,
-    onArchive: () -> Unit,
+    config: SearchResultCardConfig,
 ) {
+    val nodeWithPin = config.nodeWithPin
+    val projectName = config.projectName
+    val areaName = config.areaName
+    val nowMs = config.nowMs
+    val onOpen = config.onOpen
+    val onToggleDone = config.onToggleDone
+    val onTogglePin = config.onTogglePin
+    val onArchive = config.onArchive
     val node = nodeWithPin.node
     val subtitle =
         buildString {
@@ -670,7 +681,6 @@ private fun SearchResultCard(
         }
 
     Surface(
-        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
         onClick = onOpen,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceLow,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -84,6 +84,8 @@ import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
 import kotlin.math.max
 import kotlin.math.min
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object SearchDashboardBlocks {
     private val renderers: Map<String, SearchDashboardBlockRenderer> =
@@ -681,6 +683,7 @@ private fun SearchResultCard(
         }
 
     Surface(
+        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
         onClick = onOpen,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceLow,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -490,6 +490,7 @@ private fun RecentQueriesRow(
         LazyRow(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
             items(queries.distinct(), key = { it }) { query ->
                 Surface(
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     shape = RoundedCornerShape(999.dp),
                     color = TajsOSTheme.SurfaceHigh,
                     onClick = { onQueryClick(query) },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -84,6 +84,8 @@ import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
 import kotlin.math.max
 import kotlin.math.min
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object SearchDashboardBlocks {
     private val renderers: Map<String, SearchDashboardBlockRenderer> =
@@ -486,6 +488,7 @@ private fun RecentQueriesRow(
         LazyRow(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
             items(queries.distinct(), key = { it }) { query ->
                 Surface(
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     shape = RoundedCornerShape(999.dp),
                     color = TajsOSTheme.SurfaceHigh,
                     onClick = { onQueryClick(query) },
@@ -667,6 +670,7 @@ private fun SearchResultCard(
         }
 
     Surface(
+        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
         onClick = onOpen,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceLow,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
@@ -62,6 +62,8 @@ import tajsos.composeapp.generated.resources.time_architecture_temporal_anchors
 import tajsos.composeapp.generated.resources.time_architecture_title
 import tajsos.composeapp.generated.resources.time_architecture_weekly_alignment
 import tajsos.composeapp.generated.resources.time_architecture_weekly_detail
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object TimeArchitectureDashboardBlocks {
     private val renderers: Map<String, TimeArchitectureDashboardBlockRenderer> =
@@ -610,7 +612,7 @@ private fun HorizonQueueRow(
                     onClick = onOpen,
                     onSecondaryClick = onOpen,
                     middleClickFallbackToPrimary = true,
-                ),
+                ).pointerHoverIcon(PointerIcon.Hand),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),


### PR DESCRIPTION
Explicitly added `Modifier.pointerHoverIcon(PointerIcon.Hand)` to custom clickable or interactive elements (like `Surface(onClick = ...)` and `.clickable`) across the `:composeApp` module to provide clear visual interaction cues on desktop and web targets. Also fixed duplicate modifier insertions.

---
*PR created automatically by Jules for task [776474805102745798](https://jules.google.com/task/776474805102745798) started by @tajemniktv*