### PR TITLE
perf: avoid redundant string allocations in case-insensitive when blocks

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -788,21 +788,29 @@ private fun SearchResultCard(
     }
 }
 
+/**
+ * Returns the appropriate [ImageVector] icon for a given node [type].
+ * Uses case-insensitive string matching to avoid unnecessary allocations.
+ */
 private fun iconForType(type: String): ImageVector =
-    when (type.lowercase()) {
-        "task" -> Icons.Default.TaskAlt
-        "project" -> Icons.Default.Folder
-        "note" -> Icons.Default.Description
-        "record" -> Icons.AutoMirrored.Filled.InsertDriveFile
+    when {
+        type.equals("task", ignoreCase = true) -> Icons.Default.TaskAlt
+        type.equals("project", ignoreCase = true) -> Icons.Default.Folder
+        type.equals("note", ignoreCase = true) -> Icons.Default.Description
+        type.equals("record", ignoreCase = true) -> Icons.AutoMirrored.Filled.InsertDriveFile
         else -> Icons.Default.Search
     }
 
+/**
+ * Returns the appropriate tint [Color] for a given node [type].
+ * Uses case-insensitive string matching to avoid unnecessary allocations.
+ */
 private fun iconTintForType(type: String): Color =
-    when (type.lowercase()) {
-        "task" -> TajsOSTheme.AccentRed
-        "project" -> TajsOSTheme.Primary
-        "note" -> TajsOSTheme.AccentBlue
-        "record" -> TajsOSTheme.AccentCyan
+    when {
+        type.equals("task", ignoreCase = true) -> TajsOSTheme.AccentRed
+        type.equals("project", ignoreCase = true) -> TajsOSTheme.Primary
+        type.equals("note", ignoreCase = true) -> TajsOSTheme.AccentBlue
+        type.equals("record", ignoreCase = true) -> TajsOSTheme.AccentCyan
         else -> TajsOSTheme.Primary
     }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2603,6 +2603,10 @@ class MainViewModel(
             calculateStudentBoardState(nodes, relations, sessions, templates)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), StudentBoardState())
 
+    /**
+     * Adds a new template with the given [name] and [type].
+     * Normalizes the [type] using case-insensitive string matching for efficient memory allocation.
+     */
     fun addTemplate(
         name: String,
         type: String,
@@ -2611,25 +2615,27 @@ class MainViewModel(
     )
     {
         val normalizedType =
-            when (type.trim().lowercase())
+            with(type.trim())
             {
-                "record"                                           -> "record"
+                when {
+                    equals("record", ignoreCase = true) -> "record"
 
                 // NON-NLS
-                "project"                                          -> "project"
+                equals("project", ignoreCase = true) -> "project"
 
                 // NON-NLS
-                    "area"                                             -> "area"
+                    equals("area", ignoreCase = true) -> "area"
 
                 // NON-NLS
-                    "idea", "resource", "vault", "document" -> "note"
+                    equals("idea", ignoreCase = true) || equals("resource", ignoreCase = true) || equals("vault", ignoreCase = true) || equals("document", ignoreCase = true) -> "note"
 
                     // NON-NLS
-                    "maintenance", "open_loop", "decision", "protocol" -> "task"
+                    equals("maintenance", ignoreCase = true) || equals("open_loop", ignoreCase = true) || equals("decision", ignoreCase = true) || equals("protocol", ignoreCase = true) -> "task"
 
                     // NON-NLS
                     else -> "task" // NON-NLS
                 }
+            }
             viewModelScope.launch {
                 repository.insertTemplate(
                     TemplateEntity(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
@@ -442,6 +442,10 @@ class RelationshipCommands(
         }
     }
 
+    /**
+     * Adds a new vault entry with the specified [categoryTag] and [title].
+     * Normalizes the [asType] using case-insensitive matching to avoid temporary string allocations.
+     */
     fun addVaultEntry(
         categoryTag: String,
         title: String,
@@ -452,11 +456,12 @@ class RelationshipCommands(
         scope.launch {
             val cleanTag = categoryTag.trim().lowercase()
             val type =
-                when (asType.trim().lowercase())
-                {
-                    "record" -> "record"
-                    "task", "maintenance" -> "task"
-                    else -> "note"
+                with(asType.trim()) {
+                    when {
+                        equals("record", ignoreCase = true) -> "record"
+                        equals("task", ignoreCase = true) || equals("maintenance", ignoreCase = true) -> "task"
+                        else -> "note"
+                    }
                 }
             val nodeId =
                 addNodeForResult(


### PR DESCRIPTION
Replaces `.lowercase()` allocations inside multiple when blocks with case-insensitive `equals()` matches or `with(str)` blocks, improving performance by avoiding unnecessary temporary object allocations. Added missing KDocs as requested.

---
*PR created automatically by Jules for task [15312398544899415146](https://jules.google.com/task/15312398544899415146) started by @tajemniktv*