### PR TITLE
docs: clarify implicit domain categorization and zero-config heuristics

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
@@ -133,9 +133,16 @@ data class RecordFacetEntity(
     ],
 )
 /**
- * Represents the cross-cutting assignment of a shared item to a first-class LifeOS domain.
- * NOTE: Current design prefers implicit categorization via `DomainLensQueries`,
- * but explicit database associations are preserved here for overrides and future expansion.
+ * Explicit, relational assignment of a shared life object to a first-class LifeOS domain.
+ *
+ * Domains act as read-model classifications (lenses) over shared objects rather than strict hierarchical folders.
+ *
+ * **Important Architecture Note:**
+ * While this entity exists to provide durable, explicit domain assignments (e.g., forcing an item into Finances),
+ * the current product direction heavily prefers *zero-configuration implicit categorization* powered by
+ * heuristic matching (see `DomainLensQueries`). This entity is preserved for overrides and future expansion,
+ * but should not be treated as the mandatory or primary way items enter domains. Rely on heuristics first
+ * to reduce user friction during capture.
  */
 @Serializable
 data class ItemDomainEntity(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -12,8 +12,11 @@ import com.tajemniktv.tajsos.ui.MaintenanceStatusItem
 
 /**
  * Explicit maintenance item types that classify as financial responsibilities.
- * Used in heuristic matching to implicitly map items with these maintenance
- * types into the finance domain without requiring an explicit domain assignment.
+ *
+ * **Zero-Configuration Heuristic:**
+ * This constant is part of the heuristic matching engine that implicitly maps items
+ * into the finance domain. It intentionally bypasses explicit assignments (like `ItemDomainEntity`)
+ * to lower the friction of capturing tasks.
  */
 private val financeMaintenanceTypes = setOf("bill", "subscription", "renewal")
 


### PR DESCRIPTION
This PR updates the KDocs for `ItemDomainEntity` and `DomainLensQueries` to clearly explain the system's preference for zero-configuration, heuristic-based domain mapping over explicit relational assignments. This clarifies the intended architecture and reduces confusion around how items surface in product lenses.

---
*PR created automatically by Jules for task [8686246352029747926](https://jules.google.com/task/8686246352029747926) started by @tajemniktv*