### PR TITLE
perf: Avoid string allocations on type normalization checks

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2603,6 +2603,10 @@ class MainViewModel(
             calculateStudentBoardState(nodes, relations, sessions, templates)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), StudentBoardState())
 
+    /**
+     * Adds a new template, avoiding unnecessary string allocations by using case-insensitive
+     * string comparisons for determining normalized template types.
+     */
     fun addTemplate(
         name: String,
         type: String,
@@ -2611,25 +2615,28 @@ class MainViewModel(
     )
     {
         val normalizedType =
-            when (type.trim().lowercase())
-            {
-                "record"                                           -> "record"
-
-                // NON-NLS
-                "project"                                          -> "project"
-
-                // NON-NLS
-                    "area"                                             -> "area"
-
-                // NON-NLS
-                    "idea", "resource", "vault", "document" -> "note"
+            with(type.trim()) {
+                when {
+                    equals("record", ignoreCase = true) -> "record"
 
                     // NON-NLS
-                    "maintenance", "open_loop", "decision", "protocol" -> "task"
+                    equals("project", ignoreCase = true) -> "project"
+
+                    // NON-NLS
+                    equals("area", ignoreCase = true) -> "area"
+
+                    // NON-NLS
+                    equals("idea", ignoreCase = true) || equals("resource", ignoreCase = true) ||
+                    equals("vault", ignoreCase = true) || equals("document", ignoreCase = true) -> "note"
+
+                    // NON-NLS
+                    equals("maintenance", ignoreCase = true) || equals("open_loop", ignoreCase = true) ||
+                    equals("decision", ignoreCase = true) || equals("protocol", ignoreCase = true) -> "task"
 
                     // NON-NLS
                     else -> "task" // NON-NLS
                 }
+            }
             viewModelScope.launch {
                 repository.insertTemplate(
                     TemplateEntity(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
@@ -442,6 +442,10 @@ class RelationshipCommands(
         }
     }
 
+    /**
+     * Adds a new vault entry and tags it. Replaces the type lowercase calculation with
+     * an inline check to reduce unnecessary string allocations in frequently executed code paths.
+     */
     fun addVaultEntry(
         categoryTag: String,
         title: String,
@@ -452,11 +456,12 @@ class RelationshipCommands(
         scope.launch {
             val cleanTag = categoryTag.trim().lowercase()
             val type =
-                when (asType.trim().lowercase())
-                {
-                    "record" -> "record"
-                    "task", "maintenance" -> "task"
-                    else -> "note"
+                with(asType.trim()) {
+                    when {
+                        equals("record", ignoreCase = true) -> "record"
+                        equals("task", ignoreCase = true) || equals("maintenance", ignoreCase = true) -> "task"
+                        else -> "note"
+                    }
                 }
             val nodeId =
                 addNodeForResult(


### PR DESCRIPTION
Refactored chained trim().lowercase() string operations inside when expressions to use case-insensitive matching in with(trim()) to minimize unnecessary string allocations during type determination checks.

---
*PR created automatically by Jules for task [5360058088661123614](https://jules.google.com/task/5360058088661123614) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

