### PR TITLE
test: Add test for matchesQuery proxy in MainProtocolHelpers

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpersTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpersTest.kt
@@ -8,6 +8,9 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import com.tajemniktv.tajsos.ui.buildTestNode
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 import com.tajemniktv.tajsos.data.ModeEntity
 import com.tajemniktv.tajsos.data.TrackEntryEntity
 
@@ -235,4 +238,15 @@ class MainProtocolHelpersTest {
         assertEquals("Bad day protocol", suggestPlaybookLabel(cantThinkMode, emptyList()))
     }
 
+
+    @Test
+    fun testMatchesQuery_proxy() {
+        val node1 = buildTestNode(1, "my target title", "some content")
+
+        // Match found
+        assertTrue(matchesQuery(node1, "target"))
+
+        // No match found
+        assertFalse(matchesQuery(node1, "missing"))
+    }
 }


### PR DESCRIPTION
Adds test coverage for the matchesQuery proxy function in MainProtocolHelpers, which delegates to FilterHelper.

---
*PR created automatically by Jules for task [14417387314117014042](https://jules.google.com/task/14417387314117014042) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

