### PR TITLE
docs: add missing KDocs to DomainMatcher in DomainLensQueries

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -256,6 +256,13 @@ object DomainLensQueries {
     /**
      * Configuration class to group matching heuristics. This avoids having functions with many string/collection
      * arguments, which can trigger code health violations.
+     *
+     * @property maintenanceTypes A set of specific maintenance item types (e.g., "bill", "appointment") that
+     *                            automatically categorize a node into this domain.
+     * @property tagMarkers A set of specific tags (e.g., "finance", "health") that explicitly flag a node
+     *                      as belonging to this domain.
+     * @property titleKeywords A list of substring keywords that trigger categorization if found in the node's title or content.
+     * @property validNoteTypes An optional set of note types (e.g., "reflection") that imply this domain.
      */
     private class DomainMatcher(
         val maintenanceTypes: Set<String>,
@@ -266,6 +273,9 @@ object DomainLensQueries {
         /**
          * Evaluates whether the given [node] matches this domain's configuration based on
          * explicit maintenance types, valid note types, tags, or title/content keywords.
+         *
+         * @param node The [NodeWithPin] wrapper representing the node to evaluate.
+         * @return `true` if the node matches any of the heuristics, `false` otherwise.
          */
         fun matches(node: NodeWithPin): Boolean {
             if (node.node.maintenanceType in maintenanceTypes) return true


### PR DESCRIPTION
Adds missing KDocs to DomainMatcher constructor parameters and its matches function, to improve maintainability and understanding of heuristic-based zero-configuration domain categorization.

---
*PR created automatically by Jules for task [16008181277006283162](https://jules.google.com/task/16008181277006283162) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

