### PR TITLE
perf: optimize string comparisons

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2610,26 +2610,36 @@ class MainViewModel(
         content: String? = null,
     )
     {
+        /**
+         * Match the type string case-insensitively without allocating a new lowercase string.
+         * The result is always a standardized, lowercase string literal.
+         */
+        val cleanType = type.trim()
         val normalizedType =
-            when (type.trim().lowercase())
-            {
-                "record"                                           -> "record"
+            when {
+                cleanType.equals("record", ignoreCase = true) -> "record"
 
                 // NON-NLS
-                "project"                                          -> "project"
+                cleanType.equals("project", ignoreCase = true) -> "project"
 
                 // NON-NLS
-                    "area"                                             -> "area"
+                cleanType.equals("area", ignoreCase = true) -> "area"
 
                 // NON-NLS
-                    "idea", "resource", "vault", "document" -> "note"
+                cleanType.equals("idea", ignoreCase = true) ||
+                    cleanType.equals("resource", ignoreCase = true) ||
+                    cleanType.equals("vault", ignoreCase = true) ||
+                    cleanType.equals("document", ignoreCase = true) -> "note"
 
-                    // NON-NLS
-                    "maintenance", "open_loop", "decision", "protocol" -> "task"
+                // NON-NLS
+                cleanType.equals("maintenance", ignoreCase = true) ||
+                    cleanType.equals("open_loop", ignoreCase = true) ||
+                    cleanType.equals("decision", ignoreCase = true) ||
+                    cleanType.equals("protocol", ignoreCase = true) -> "task"
 
-                    // NON-NLS
-                    else -> "task" // NON-NLS
-                }
+                // NON-NLS
+                else -> "task" // NON-NLS
+            }
             viewModelScope.launch {
                 repository.insertTemplate(
                     TemplateEntity(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
@@ -451,11 +451,16 @@ class RelationshipCommands(
     ) {
         scope.launch {
             val cleanTag = categoryTag.trim().lowercase()
+
+            /**
+             * Match the asType string case-insensitively without allocating a new lowercase string.
+             */
+            val cleanAsType = asType.trim()
             val type =
-                when (asType.trim().lowercase())
-                {
-                    "record" -> "record"
-                    "task", "maintenance" -> "task"
+                when {
+                    cleanAsType.equals("record", ignoreCase = true) -> "record"
+                    cleanAsType.equals("task", ignoreCase = true) ||
+                        cleanAsType.equals("maintenance", ignoreCase = true) -> "task"
                     else -> "note"
                 }
             val nodeId =


### PR DESCRIPTION
Replaced `.trim().lowercase()` chained calls with case-insensitive `equals` checks in `when` blocks to reduce unnecessary lowercase string allocations in `MainViewModel` and `RelationshipCommands`.

---
*PR created automatically by Jules for task [6353735136697023405](https://jules.google.com/task/6353735136697023405) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

