### PR TITLE
test: add edge cases for matchesQuery in FilterHelper

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
@@ -43,4 +43,32 @@ class FilterHelperMatchesQueryEdgeTest {
         assertTrue(FilterHelper.matchesQuery(nodeTag, "tag"))
         assertFalse(FilterHelper.matchesQuery(nodeNone, "title"))
     }
+
+    @Test
+    fun testMatchesQuery_caseInsensitiveAndWhitespace() {
+        val nodeTitle = buildTestNode(1, "My Title", "content")
+        val nodeContent = buildTestNode(2, "other", "My Content")
+        val nodeTag = buildTestNode(3, "other", "other", tags = listOf("My Tag"))
+
+        // Case insensitivity
+        assertTrue(FilterHelper.matchesQuery(nodeTitle, "MY TITLE"))
+        assertTrue(FilterHelper.matchesQuery(nodeContent, "MY CONTENT"))
+        assertTrue(FilterHelper.matchesQuery(nodeTag, "MY TAG"))
+
+        // Whitespace trimming
+        assertTrue(FilterHelper.matchesQuery(nodeTitle, "  my title  "))
+        assertTrue(FilterHelper.matchesQuery(nodeContent, "  my content  "))
+        assertTrue(FilterHelper.matchesQuery(nodeTag, "  my tag  "))
+    }
+
+    @Test
+    fun testMatchesQuery_partialWordMatch() {
+        val nodeTitle = buildTestNode(1, "supercalifragilistic", "content")
+        val nodeContent = buildTestNode(2, "other", "expialidocious")
+        val nodeTag = buildTestNode(3, "other", "other", tags = listOf("unbelievable"))
+
+        assertTrue(FilterHelper.matchesQuery(nodeTitle, "califrag"))
+        assertTrue(FilterHelper.matchesQuery(nodeContent, "piali"))
+        assertTrue(FilterHelper.matchesQuery(nodeTag, "believ"))
+    }
 }


### PR DESCRIPTION
This pull request adds targeted edge-case test coverage for the `matchesQuery` method in `FilterHelper`. Specifically, it introduces new tests inside `FilterHelperMatchesQueryEdgeTest.kt` to explicitly verify:
- Case-insensitivity logic across titles, contents, and tags.
- Correct handling and trimming of trailing and leading whitespace around query strings.
- Partial substring word matching logic for titles, contents, and tags.

No production code changes were required; the tests were built safely on existing fixtures and methods.

---
*PR created automatically by Jules for task [2134979134297772920](https://jules.google.com/task/2134979134297772920) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

