### PR TITLE
docs: document domain lens heuristics and calendar sync intent

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
@@ -39,6 +39,9 @@ class CalendarManager(
      * (falling back to `"${title}_${startAt}"` when `externalId` is null), replaces that
      * provider's local events with the deduplicated set, and updates the provider's
      * `lastSyncedAt` timestamp.
+     *
+     * Note: This process is designed to run silently in the background, fully decoupled from
+     * user interface blocking, to adhere to TajsOS's strict local-first caching principles.
      */
     suspend fun syncAll() =
         coroutineScope {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -256,6 +256,14 @@ object DomainLensQueries {
     /**
      * Configuration class to group matching heuristics. This avoids having functions with many string/collection
      * arguments, which can trigger code health violations.
+     *
+     * By centralizing these heuristic collections, domains can be evaluated consistently. Adding a new domain
+     * requires defining parallel sets of these properties to feed into a new instance of this matcher.
+     *
+     * @property maintenanceTypes Specific `maintenanceType` strings (e.g. "bill", "appointment") that map to this domain.
+     * @property tagMarkers Explicit tag strings whose presence assigns a node to this domain.
+     * @property titleKeywords Case-insensitive substrings which, if found in the title or content, assign a node to this domain.
+     * @property validNoteTypes Specific `noteType` classifications (e.g. "reflection") that map to this domain.
      */
     private class DomainMatcher(
         val maintenanceTypes: Set<String>,


### PR DESCRIPTION
Added documentation addressing missing KDocs in DomainLensQueries and intent behind CalendarManager syncing.

---
*PR created automatically by Jules for task [11692302706748290371](https://jules.google.com/task/11692302706748290371) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

