### PR TITLE
perf: optimize string allocations in string comparisons

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -788,21 +788,29 @@ private fun SearchResultCard(
     }
 }
 
+/**
+ * Resolves the appropriate icon for a given node type.
+ * Uses case-insensitive comparisons to avoid string allocations during UI recomposition.
+ */
 private fun iconForType(type: String): ImageVector =
-    when (type.lowercase()) {
-        "task" -> Icons.Default.TaskAlt
-        "project" -> Icons.Default.Folder
-        "note" -> Icons.Default.Description
-        "record" -> Icons.AutoMirrored.Filled.InsertDriveFile
+    when {
+        type.equals("task", ignoreCase = true) -> Icons.Default.TaskAlt
+        type.equals("project", ignoreCase = true) -> Icons.Default.Folder
+        type.equals("note", ignoreCase = true) -> Icons.Default.Description
+        type.equals("record", ignoreCase = true) -> Icons.AutoMirrored.Filled.InsertDriveFile
         else -> Icons.Default.Search
     }
 
+/**
+ * Resolves the appropriate icon tint color for a given node type.
+ * Uses case-insensitive comparisons to avoid string allocations during UI recomposition.
+ */
 private fun iconTintForType(type: String): Color =
-    when (type.lowercase()) {
-        "task" -> TajsOSTheme.AccentRed
-        "project" -> TajsOSTheme.Primary
-        "note" -> TajsOSTheme.AccentBlue
-        "record" -> TajsOSTheme.AccentCyan
+    when {
+        type.equals("task", ignoreCase = true) -> TajsOSTheme.AccentRed
+        type.equals("project", ignoreCase = true) -> TajsOSTheme.Primary
+        type.equals("note", ignoreCase = true) -> TajsOSTheme.AccentBlue
+        type.equals("record", ignoreCase = true) -> TajsOSTheme.AccentCyan
         else -> TajsOSTheme.Primary
     }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -2603,6 +2603,15 @@ class MainViewModel(
             calculateStudentBoardState(nodes, relations, sessions, templates)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), StudentBoardState())
 
+    /**
+     * Adds a new user-defined template to the database.
+     * Uses case-insensitive comparison on the type parameter to avoid unnecessary string allocations.
+     *
+     * @param name The display name of the template.
+     * @param type The raw type string provided by the user.
+     * @param title An optional default title to apply when the template is used.
+     * @param content An optional default content body to apply when the template is used.
+     */
     fun addTemplate(
         name: String,
         type: String,
@@ -2610,26 +2619,22 @@ class MainViewModel(
         content: String? = null,
     )
     {
+        val cleanType = type.trim()
         val normalizedType =
-            when (type.trim().lowercase())
-            {
-                "record"                                           -> "record"
-
-                // NON-NLS
-                "project"                                          -> "project"
-
-                // NON-NLS
-                    "area"                                             -> "area"
-
-                // NON-NLS
-                    "idea", "resource", "vault", "document" -> "note"
-
-                    // NON-NLS
-                    "maintenance", "open_loop", "decision", "protocol" -> "task"
-
-                    // NON-NLS
-                    else -> "task" // NON-NLS
-                }
+            when {
+                cleanType.equals("record", ignoreCase = true) -> "record"
+                cleanType.equals("project", ignoreCase = true) -> "project"
+                cleanType.equals("area", ignoreCase = true) -> "area"
+                cleanType.equals("idea", ignoreCase = true) ||
+                    cleanType.equals("resource", ignoreCase = true) ||
+                    cleanType.equals("vault", ignoreCase = true) ||
+                    cleanType.equals("document", ignoreCase = true) -> "note"
+                cleanType.equals("maintenance", ignoreCase = true) ||
+                    cleanType.equals("open_loop", ignoreCase = true) ||
+                    cleanType.equals("decision", ignoreCase = true) ||
+                    cleanType.equals("protocol", ignoreCase = true) -> "task"
+                else -> "task"
+            }
             viewModelScope.launch {
                 repository.insertTemplate(
                     TemplateEntity(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommands.kt
@@ -442,6 +442,16 @@ class RelationshipCommands(
         }
     }
 
+    /**
+     * Adds a new vault entry and tags it with the specified category.
+     * Uses case-insensitive comparison on the type parameter to avoid unnecessary string allocations.
+     *
+     * @param categoryTag The raw category tag string to attach.
+     * @param title The title of the vault entry.
+     * @param content The optional content body.
+     * @param asType The raw string representation of the target node type.
+     * @param dueAt An optional due date epoch timestamp.
+     */
     fun addVaultEntry(
         categoryTag: String,
         title: String,
@@ -451,11 +461,12 @@ class RelationshipCommands(
     ) {
         scope.launch {
             val cleanTag = categoryTag.trim().lowercase()
+            val cleanAsType = asType.trim()
             val type =
-                when (asType.trim().lowercase())
-                {
-                    "record" -> "record"
-                    "task", "maintenance" -> "task"
+                when {
+                    cleanAsType.equals("record", ignoreCase = true) -> "record"
+                    cleanAsType.equals("task", ignoreCase = true) ||
+                        cleanAsType.equals("maintenance", ignoreCase = true) -> "task"
                     else -> "note"
                 }
             val nodeId =


### PR DESCRIPTION
Optimize string allocations during type equality comparisons to prevent creating garbage during UI recomposition.

---
*PR created automatically by Jules for task [8963599898160730597](https://jules.google.com/task/8963599898160730597) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

