### PR TITLE
fix(website): resolve 404 route collision warning

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "Docs",
+      disable404Route: true,
       description: "TajsOS Documentation",
 
       components: {


### PR DESCRIPTION
Sets `disable404Route: true` in the website's `astro.config.mjs` to resolve a warning about a route collision between Starlight's default 404 page and our custom `src/pages/404.astro` page. This cleans up the build and check output while maintaining the custom error page.

---
*PR created automatically by Jules for task [17844868789032731077](https://jules.google.com/task/17844868789032731077) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

