### PR TITLE
fix(ui): Remove unsafe null assertion in mouse forward routes

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -239,7 +239,7 @@ fun App(
                                 val canPop = navController.previousBackStackEntry != null
                                 if (!canPop) return@mouseButtons
                                 if (isForwardNavigable(currentRoute)) {
-                                    mouseForwardRoutes.addLast(currentRoute!!)
+                                    currentRoute?.let { mouseForwardRoutes.addLast(it) }
                                 }
                                 navController.popBackStack()
                             },


### PR DESCRIPTION
Replaced `mouseForwardRoutes.addLast(currentRoute!!)` with a safer `currentRoute?.let { mouseForwardRoutes.addLast(it) }` to prevent potential NullPointerExceptions during mouse navigation interactions.

---
*PR created automatically by Jules for task [13343752369320184781](https://jules.google.com/task/13343752369320184781) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

