### PR TITLE
docs: clarify stale task calculation and sweep rules

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
@@ -57,11 +57,19 @@ class NodeCommands(
     }
 
     /**
-     * Automatically reviews the inbox and currently active task lists to identify items that have
-     * been ignored or deferred multiple times (based on [cutoffDays]). It sweeps these stale items
-     * back into the general inbox state to force a re-evaluation or triage.
+     * Automatically identifies and sweeps stale tasks out of the user's active view to prevent inbox clutter.
      *
-     * @param cutoffDays The number of days a task must sit un-updated before being considered stale.
+     * This function queries the active tasks against a time threshold (delegating the filtering logic
+     * to `calculateStaleTasks`). For every task identified as stale (i.e., overdue beyond the `cutoffDays`
+     * and not protected by pins or recurring rules), it applies the following state mutations:
+     * - The task's `status` is downgraded to `SOMEDAY`, effectively removing it from the active inbox.
+     * - The `postponeCount` is incremented to track that the system had to intervene.
+     * - The `updatedAt` timestamp is refreshed to the current time.
+     *
+     * Note: Swept tasks will no longer appear in standard active task lists and will require manual
+     * review (e.g., from a "Someday" or "Stale" view) to be reactivated.
+     *
+     * @param cutoffDays The number of days a task's due date must be past due before the system intervenes.
      */
     fun sweepStaleTasks(cutoffDays: Int = 3) {
         scope.launch {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -2848,12 +2848,23 @@ fun calculateStudentBoardState(
 }
 
 /**
- * Calculates a list of stale tasks that are overdue by more than the threshold.
- * Excludes completed, archived, already someday, pinned, and recurring tasks.
+ * Calculates a list of stale tasks that have been ignored or overdue for an extended period.
+ *
+ * A task is considered "stale" if all of the following conditions are met:
+ * 1. It is a valid task item (`isTaskItem() == true`).
+ * 2. It is currently active (`status == "active"` and `taskStateOrNull() == TaskState.ACTIVE`).
+ * 3. It is **not** explicitly pinned to the user's immediate attention.
+ * 4. It is **not** a recurring task (these have their own lifecycle rules).
+ * 5. It has an explicit due date (`dueAt != null`).
+ * 6. That due date is older than the calculated `cutoffThreshold` (which is exactly `now` minus `cutoffDays`).
+ *
+ * By excluding completed, archived, 'someday', pinned, and recurring tasks, this function
+ * isolates standard, scheduled tasks that have slipped past their due dates without being addressed,
+ * ensuring they can be automatically swept away to reduce inbox clutter.
  *
  * @param nodes The complete list of nodes in the system.
- * @param now The current time to use for calculations.
- * @param cutoffDays The threshold in days before a task is considered stale.
+ * @param now The current time to use as the baseline for the cutoff calculation.
+ * @param cutoffDays The threshold in days before a task's due date is considered critically overdue and stale.
  */
 fun calculateStaleTasks(
     nodes: List<NodeEntity>,


### PR DESCRIPTION
Improves KDocs for stale task sweep logic in `MainSnapshotCalculators.kt` and `NodeCommands.kt`, explaining the exact heuristic rules for what constitutes a stale task, and the specific node mutations applied during a sweep (e.g., status downgrade to SOMEDAY, incrementing postponeCount).

---
*PR created automatically by Jules for task [12920056566069504933](https://jules.google.com/task/12920056566069504933) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

