### PR TITLE
test: Add test for MainProtocolHelpers matchesQuery delegation

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpersTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpersTest.kt
@@ -3,6 +3,8 @@ package com.tajemniktv.tajsos.ui.main.calculators
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 import kotlin.time.Duration.Companion.days
 
 import kotlin.time.Clock
@@ -235,4 +237,14 @@ class MainProtocolHelpersTest {
         assertEquals("Bad day protocol", suggestPlaybookLabel(cantThinkMode, emptyList()))
     }
 
+
+    @Test
+    fun testMatchesQuery_delegatesToFilterHelper() {
+        val node = com.tajemniktv.tajsos.ui.buildTestNode(id = 1, title = "Find This", content = "Hidden")
+
+        assertTrue(matchesQuery(node, "Find This"))
+        assertTrue(matchesQuery(node, "Hidden"))
+        assertFalse(matchesQuery(node, "Missing"))
+        assertFalse(matchesQuery(node, ""))
+    }
 }


### PR DESCRIPTION
Adds an edge test verifying that `MainProtocolHelpers.matchesQuery` correctly delegates to `FilterHelper.matchesQuery`.

---
*PR created automatically by Jules for task [14921639112116575082](https://jules.google.com/task/14921639112116575082) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

