### PR TITLE
fix: Enable R8 code minification and obfuscation for security

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -57,7 +57,12 @@ android {
     }
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
             // Firebase App Distribution configuration for release builds
             configure<com.google.firebase.appdistribution.gradle.AppDistributionExtension> {
                 artifactType = "APK"


### PR DESCRIPTION
Enables R8 code minification and resource shrinking in the `release` build configuration for the Android application. This is a crucial security hardening measure that obfuscates the compiled APK, making reverse-engineering significantly more difficult while also reducing the overall application size. An empty `proguard-rules.pro` file is provided for future custom keep rules if necessary.

---
*PR created automatically by Jules for task [5648543653118444878](https://jules.google.com/task/5648543653118444878) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

