### PR TITLE
test: add edge cases for matchesItemFilter

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectModelsEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectModelsEdgeTest.kt
@@ -1,0 +1,21 @@
+package com.tajemniktv.tajsos.data
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class LifeObjectModelsEdgeTest {
+
+    @Test
+    fun matchesItemFilter_returns_true_for_null_filter() {
+        val node = NodeEntity(type = "task", title = "Test")
+        assertTrue(node.matchesItemFilter(null))
+    }
+
+    @Test
+    fun matchesItemFilter_matches_exact_type_for_unrecognized_filter() {
+        val node = NodeEntity(type = "custom_type", title = "Test")
+        assertTrue(node.matchesItemFilter("custom_type"))
+        assertFalse(node.matchesItemFilter("other_type"))
+    }
+}


### PR DESCRIPTION
Added edge cases for matchesItemFilter.

---
*PR created automatically by Jules for task [2780720137966464131](https://jules.google.com/task/2780720137966464131) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

