### PR TITLE
feat(ui): add pricing link to navbar and resolve 404 route collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -17,6 +17,7 @@ export const NAV_LINKS = [
   { label: "LOCAL-FIRST", href: "local-first" },
   { label: "FEATURES", href: "features" },
   { label: "ARCHITECTURE", href: "architecture" },
+  { label: "PRICING", href: "pricing" },
 ] as const;
 
 export const FOOTER_LINKS = {


### PR DESCRIPTION
This pull request enhances the main website navigation by adding the previously orphaned "PRICING" link to the global `NAV_LINKS`. 

Additionally, it configures Starlight to disable its default 404 route generation (`disable404Route: true`), which resolves a persistent build warning regarding route collisions with the custom Astro 404 page.

Visual verification via Playwright confirms the Pricing link correctly renders in the Navbar across endpoints. Build tests pass cleanly.

---
*PR created automatically by Jules for task [15634469358258647809](https://jules.google.com/task/15634469358258647809) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

