### PR TITLE
fix: remove non-null assertions to prevent runtime crashes

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -238,8 +238,8 @@ fun App(
                                 val currentRoute = currentDestination?.route
                                 val canPop = navController.previousBackStackEntry != null
                                 if (!canPop) return@mouseButtons
-                                if (isForwardNavigable(currentRoute)) {
-                                    mouseForwardRoutes.addLast(currentRoute!!)
+                                currentRoute?.takeIf { isForwardNavigable(it) }?.let {
+                                    mouseForwardRoutes.addLast(it)
                                 }
                                 navController.popBackStack()
                             },

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserEdgeTest.kt
@@ -12,41 +12,41 @@ class InetAddressParserEdgeTest {
     @Test
     fun testIpv4SiteLocalEdges() {
         // 10.x.x.x boundary
-        assertTrue(parseIpAddress("10.0.0.0")!!.isSiteLocal())
-        assertTrue(parseIpAddress("10.255.255.255")!!.isSiteLocal())
+        assertTrue(requireNotNull(parseIpAddress("10.0.0.0")).isSiteLocal())
+        assertTrue(requireNotNull(parseIpAddress("10.255.255.255")).isSiteLocal())
 
         // 172.16.x.x - 172.31.x.x boundaries
-        assertTrue(parseIpAddress("172.16.0.0")!!.isSiteLocal())
-        assertTrue(parseIpAddress("172.31.255.255")!!.isSiteLocal())
-        assertFalse(parseIpAddress("172.15.255.255")!!.isSiteLocal())
-        assertFalse(parseIpAddress("172.32.0.0")!!.isSiteLocal())
+        assertTrue(requireNotNull(parseIpAddress("172.16.0.0")).isSiteLocal())
+        assertTrue(requireNotNull(parseIpAddress("172.31.255.255")).isSiteLocal())
+        assertFalse(requireNotNull(parseIpAddress("172.15.255.255")).isSiteLocal())
+        assertFalse(requireNotNull(parseIpAddress("172.32.0.0")).isSiteLocal())
 
         // 192.168.x.x boundary
-        assertTrue(parseIpAddress("192.168.0.0")!!.isSiteLocal())
-        assertTrue(parseIpAddress("192.168.255.255")!!.isSiteLocal())
-        assertFalse(parseIpAddress("192.167.255.255")!!.isSiteLocal())
+        assertTrue(requireNotNull(parseIpAddress("192.168.0.0")).isSiteLocal())
+        assertTrue(requireNotNull(parseIpAddress("192.168.255.255")).isSiteLocal())
+        assertFalse(requireNotNull(parseIpAddress("192.167.255.255")).isSiteLocal())
     }
 
     @Test
     fun testIpv6SiteLocalEdges() {
         // fc00::/7 (fc00:: to fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff)
-        assertTrue(parseIpAddress("fc00::")!!.isSiteLocal())
-        assertTrue(parseIpAddress("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isSiteLocal())
+        assertTrue(requireNotNull(parseIpAddress("fc00::")).isSiteLocal())
+        assertTrue(requireNotNull(parseIpAddress("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")).isSiteLocal())
 
         // Edge out of bounds
-        assertFalse(parseIpAddress("fbff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isSiteLocal())
-        assertFalse(parseIpAddress("fe00::")!!.isSiteLocal())
+        assertFalse(requireNotNull(parseIpAddress("fbff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")).isSiteLocal())
+        assertFalse(requireNotNull(parseIpAddress("fe00::")).isSiteLocal())
     }
 
     @Test
     fun testIpv6LinkLocalEdges() {
         // fe80::/10 (fe80:: to febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff)
-        assertTrue(parseIpAddress("fe80::")!!.isLinkLocal())
-        assertTrue(parseIpAddress("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isLinkLocal())
+        assertTrue(requireNotNull(parseIpAddress("fe80::")).isLinkLocal())
+        assertTrue(requireNotNull(parseIpAddress("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff")).isLinkLocal())
 
         // Out of bounds
-        assertFalse(parseIpAddress("fe7f:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isLinkLocal())
-        assertFalse(parseIpAddress("fec0::")!!.isLinkLocal())
+        assertFalse(requireNotNull(parseIpAddress("fe7f:ffff:ffff:ffff:ffff:ffff:ffff:ffff")).isLinkLocal())
+        assertFalse(requireNotNull(parseIpAddress("fec0::")).isLinkLocal())
     }
 
     @Test
@@ -54,6 +54,6 @@ class InetAddressParserEdgeTest {
         val ipv6A = parseIpAddress("2001:db8::1")
         val ipv6B = parseIpAddress("2001:db8:0:0:0:0:0:1")
         assertEquals(ipv6A, ipv6B)
-        assertEquals(ipv6A!!.hashCode(), ipv6B!!.hashCode())
+        assertEquals(requireNotNull(ipv6A).hashCode(), requireNotNull(ipv6B).hashCode())
     }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/ProtocolCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/ProtocolCommandsTest.kt
@@ -165,7 +165,7 @@ class ProtocolCommandsTest {
         val nodeId = repo.insertNode(node)
         testScheduler.advanceUntilIdle()
 
-        val insertedNode = repo.getNodeById(nodeId)!!
+        val insertedNode = requireNotNull(repo.getNodeById(nodeId))
         commands.toggleProtocolChecklistStep(insertedNode, 0, true)
         testScheduler.advanceUntilIdle()
 

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/RelationshipCommandsTest.kt
@@ -49,12 +49,12 @@ class RelationshipCommandsTest {
 
         val personNode = NodeEntity(type = "person", title = "Alice")
         val nodeId = repo.insertNode(personNode)
-        val initialNode = repo.getNodeById(nodeId)!!
+        val initialNode = requireNotNull(repo.getNodeById(nodeId))
 
         commands.setPersonLastContactNow(initialNode)
         testScheduler.advanceUntilIdle()
 
-        val updatedNode = repo.getNodeById(nodeId)!!
+        val updatedNode = requireNotNull(repo.getNodeById(nodeId))
         assertNotNull(updatedNode.lastContactAt)
     }
 
@@ -66,12 +66,12 @@ class RelationshipCommandsTest {
 
         val personNode = NodeEntity(type = "person", title = "Alice")
         val nodeId = repo.insertNode(personNode)
-        val initialNode = repo.getNodeById(nodeId)!!
+        val initialNode = requireNotNull(repo.getNodeById(nodeId))
 
         commands.setPersonFollowUpInDays(initialNode, 7)
         testScheduler.advanceUntilIdle()
 
-        val updatedNode = repo.getNodeById(nodeId)!!
+        val updatedNode = requireNotNull(repo.getNodeById(nodeId))
         assertNotNull(updatedNode.dueAt)
     }
 

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/StudentCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/actions/StudentCommandsTest.kt
@@ -66,19 +66,19 @@ class StudentCommandsTest {
         // Test normal value
         commands.setReadingProgress(node, 50)
         testScheduler.advanceUntilIdle()
-        var updatedNode = repo.getNodeById(1)!!
+        var updatedNode = requireNotNull(repo.getNodeById(1))
         assertEquals(50, updatedNode.metadataEnvelopeOrNull()?.student?.readingProgressPercent)
 
         // Test below 0 clamping
         commands.setReadingProgress(updatedNode, -10)
         testScheduler.advanceUntilIdle()
-        updatedNode = repo.getNodeById(1)!!
+        updatedNode = requireNotNull(repo.getNodeById(1))
         assertEquals(0, updatedNode.metadataEnvelopeOrNull()?.student?.readingProgressPercent)
 
         // Test above 100 clamping
         commands.setReadingProgress(updatedNode, 150)
         testScheduler.advanceUntilIdle()
-        updatedNode = repo.getNodeById(1)!!
+        updatedNode = requireNotNull(repo.getNodeById(1))
         assertEquals(100, updatedNode.metadataEnvelopeOrNull()?.student?.readingProgressPercent)
     }
 
@@ -107,14 +107,14 @@ class StudentCommandsTest {
 
         commands.setTopicMastery(node, "Calculus", 75)
         testScheduler.advanceUntilIdle()
-        var updatedNode = repo.getNodeById(1)!!
+        var updatedNode = requireNotNull(repo.getNodeById(1))
         assertEquals("Calculus", updatedNode.metadataEnvelopeOrNull()?.student?.topic)
         assertEquals(75, updatedNode.metadataEnvelopeOrNull()?.student?.masteryPercent)
 
         // Clamping and blank topic to null
         commands.setTopicMastery(updatedNode, "   ", 120)
         testScheduler.advanceUntilIdle()
-        updatedNode = repo.getNodeById(1)!!
+        updatedNode = requireNotNull(repo.getNodeById(1))
         assertEquals(null, updatedNode.metadataEnvelopeOrNull()?.student?.topic)
         assertEquals(100, updatedNode.metadataEnvelopeOrNull()?.student?.masteryPercent)
     }
@@ -145,7 +145,7 @@ class StudentCommandsTest {
         commands.setStudentCourse(node, "CS101", "Intro to CS", "Fall2026", "Essay")
         testScheduler.advanceUntilIdle()
 
-        val updatedNode = repo.getNodeById(1)!!
+        val updatedNode = requireNotNull(repo.getNodeById(1))
         val studentMeta = updatedNode.metadataEnvelopeOrNull()?.student
         assertEquals("CS101", studentMeta?.courseId)
         assertEquals("Intro to CS", studentMeta?.courseName)
@@ -179,7 +179,7 @@ class StudentCommandsTest {
         commands.toggleFlashcardCandidate(node, true)
         testScheduler.advanceUntilIdle()
 
-        var updatedNode = repo.getNodeById(1)!!
+        var updatedNode = requireNotNull(repo.getNodeById(1))
         assertEquals(true, updatedNode.metadataEnvelopeOrNull()?.student?.flashcardCandidate)
 
         val tagsOnNode = repo.getTagsForNode(1).first()
@@ -188,7 +188,7 @@ class StudentCommandsTest {
         commands.toggleFlashcardCandidate(updatedNode, false)
         testScheduler.advanceUntilIdle()
 
-        updatedNode = repo.getNodeById(1)!!
+        updatedNode = requireNotNull(repo.getNodeById(1))
         assertEquals(false, updatedNode.metadataEnvelopeOrNull()?.student?.flashcardCandidate)
 
         val tagsOnNodeAfter = repo.getTagsForNode(1).first()
@@ -221,7 +221,7 @@ class StudentCommandsTest {
         commands.toggleRevisitBeforeExam(node, true)
         testScheduler.advanceUntilIdle()
 
-        var updatedNode = repo.getNodeById(1)!!
+        var updatedNode = requireNotNull(repo.getNodeById(1))
         assertEquals(true, updatedNode.metadataEnvelopeOrNull()?.student?.revisitBeforeExam)
 
         val tagsOnNode = repo.getTagsForNode(1).first()
@@ -230,7 +230,7 @@ class StudentCommandsTest {
         commands.toggleRevisitBeforeExam(updatedNode, false)
         testScheduler.advanceUntilIdle()
 
-        updatedNode = repo.getNodeById(1)!!
+        updatedNode = requireNotNull(repo.getNodeById(1))
         assertEquals(false, updatedNode.metadataEnvelopeOrNull()?.student?.revisitBeforeExam)
 
         val tagsOnNodeAfter = repo.getTagsForNode(1).first()

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblersDashboardTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblersDashboardTest.kt
@@ -150,7 +150,7 @@ class MainStateAssemblersDashboardTest {
         val state = assembleState(repo, nodes)
 
         assertNotNull(state.capacityWarning)
-        assertTrue(state.capacityWarning!!.contains("SYSTEM OVERLOADED"))
+        assertTrue(requireNotNull(state.capacityWarning).contains("SYSTEM OVERLOADED"))
     }
 
     @Test
@@ -161,7 +161,7 @@ class MainStateAssemblersDashboardTest {
         val state = assembleState(repo, nodes)
 
         assertNotNull(state.capacityWarning)
-        assertTrue(state.capacityWarning!!.contains("ATTENTION FRAGMENTED"))
+        assertTrue(requireNotNull(state.capacityWarning).contains("ATTENTION FRAGMENTED"))
     }
 
     @Test
@@ -175,7 +175,7 @@ class MainStateAssemblersDashboardTest {
 
         assertEquals(12, state.openLoops.size)
         assertNotNull(state.openLoopsOverloadWarning)
-        assertTrue(state.openLoopsOverloadWarning!!.contains("OPEN LOOPS OVERLOAD"))
+        assertTrue(requireNotNull(state.openLoopsOverloadWarning).contains("OPEN LOOPS OVERLOAD"))
     }
 
     @Test


### PR DESCRIPTION
Replaced non-null assertions (`!!`) with `requireNotNull(...)` and safe operators across the codebase to improve reliability and prevent NullPointerExceptions.

---
*PR created automatically by Jules for task [10656170342454005313](https://jules.google.com/task/10656170342454005313) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

