### PR TITLE
docs: clarify heuristic domain categorization and ItemDomainEntity bypass

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
@@ -134,8 +134,12 @@ data class RecordFacetEntity(
 )
 /**
  * Represents the cross-cutting assignment of a shared item to a first-class LifeOS domain.
- * NOTE: Current design prefers implicit categorization via `DomainLensQueries`,
- * but explicit database associations are preserved here for overrides and future expansion.
+ *
+ * NOTE: The system employs 'zero-configuration implicit categorization' through heuristic
+ * matching (using tags, keywords, and maintenance types via `DomainLensQueries`) rather
+ * than strict, explicit database associations like `ItemDomainEntity`. Explicitly assigning
+ * a domain via this entity is essentially a legacy/override fallback that is largely bypassed
+ * by the primary UI lenses to lower the friction of capturing new items.
  */
 @Serializable
 data class ItemDomainEntity(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -266,6 +266,13 @@ object DomainLensQueries {
         /**
          * Evaluates whether the given [node] matches this domain's configuration based on
          * explicit maintenance types, valid note types, tags, or title/content keywords.
+         *
+         * Evaluation Order / Precedence:
+         * 1. Maintenance Type (e.g., 'bill' for finance)
+         * 2. Note Type (e.g., 'reflection' for health)
+         * 3. Tags (e.g., '#finance', '#health')
+         * 4. Title Keywords
+         * 5. Content Keywords
          */
         fun matches(node: NodeWithPin): Boolean {
             if (node.node.maintenanceType in maintenanceTypes) return true


### PR DESCRIPTION
This PR improves the repository's documentation by clarifying the intent and non-obvious behavior behind the `FINANCES` and `HEALTH` domain categorization in TajsOS.

It expands the KDoc for `ItemDomainEntity` to explicitly document that explicit database assignments are bypassed in favor of heuristic-based implicit categorization (`DomainLensQueries`) to reduce friction.
It also updates the KDoc for `DomainMatcher.matches()` to clearly spell out the precedence of these heuristic checks (maintenance types, note types, tags, title keywords, content keywords).

---
*PR created automatically by Jules for task [10047428089343277234](https://jules.google.com/task/10047428089343277234) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

