### PR TITLE
test: Add edge case tests for matchesItemFilter

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectModelsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectModelsTest.kt
@@ -150,4 +150,17 @@ class LifeObjectModelsTest {
         assertFalse(taskWithLocation.isPlaceAnchor())
         assertEquals(ItemKind.TASK, taskWithLocation.itemKindOrNull())
     }
+
+    @Test
+    fun matchesItemFilter_handlesNullFilter() {
+        val node = NodeEntity(type = "some_type", title = "Test")
+        assertTrue(node.matchesItemFilter(null))
+    }
+
+    @Test
+    fun matchesItemFilter_handlesUnknownFilterAndExactMatch() {
+        val node = NodeEntity(type = "custom_type", title = "Test")
+        assertTrue(node.matchesItemFilter("custom_type"))
+        assertFalse(node.matchesItemFilter("other_type"))
+    }
 }


### PR DESCRIPTION
Added tests for `matchesItemFilter` boundary conditions such as null and unknown filter matching.

---
*PR created automatically by Jules for task [257705810712391949](https://jules.google.com/task/257705810712391949) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

