### PR TITLE
fix/feat(ui): Add hover effects to features cards and resolve 404 warning

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -32,7 +32,7 @@ const title = "FEATURES";
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-32">
       {
         FEATURES.map((feature) => (
-          <div class="bg-surface-container-low p-8 rounded-3xl border border-transparent hover:border-primary/30 transition-all group">
+          <div class="bg-surface-container-low p-8 rounded-3xl border border-transparent hover:border-primary/30 transition-all hover:-translate-y-2 duration-300 group">
             <span
               class="material-symbols-outlined text-4xl text-primary mb-6"
               style="font-variation-settings: 'FILL' 1;"


### PR DESCRIPTION
This pull request addresses UX improvements and configuration warnings in the `/website` Astro project:\n\n1.  **UI/UX Improvement:** Added `hover:-translate-y-2 duration-300` utility classes to the feature cards on the `features.astro` page. This creates a smooth vertical translation effect on hover, providing better visual feedback and interactivity for users browsing the core features.\n2.  **Configuration Fix:** Resolved a known Starlight build warning regarding route collisions with a custom `/404` page. Setting `disable404Route: true` in `astro.config.mjs` safely disables the default Starlight 404 route to favor our custom page.\n\nAll changes have been successfully type-checked (`npm run check`) and built (`npm run build`). The hover effects were visually verified via a local preview server (`npm run preview`) and captured via Playwright screenshots.

---
*PR created automatically by Jules for task [16208119435683210373](https://jules.google.com/task/16208119435683210373) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

