### PR TITLE
perf: pre-compute domain kind display names to avoid dynamic string allocation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -114,9 +114,7 @@ fun NotesContextPanel(
             item {
                 ContextSection(title = "Domain", icon = Icons.Default.Category) {
                     Text(
-                        selectedNote.domain.name
-                            .lowercase()
-                            .replaceFirstChar(Char::titlecase),
+                        selectedNote.domain.displayName,
                         color = TajsOSTheme.Text,
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -109,7 +109,7 @@ fun NotesEditorPane(
                 Column(modifier = Modifier.fillMaxWidth().widthIn(max = 880.dp)) {
                     Text(
                         text = "NOTES > ${
-                            note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                            note.domain.displayName
                         }",
                         style = MaterialTheme.typography.labelSmall,
                         color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -297,7 +297,7 @@ fun NotesListItem(
                 )
                 Text(
                     text = "${
-                        note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                        note.domain.displayName
                     } • ${relativeDateLabel(note.updatedAt)}",
                     style = MaterialTheme.typography.labelSmall,
                     color = TajsOSTheme.Muted,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/DomainKind.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/DomainKind.kt
@@ -23,24 +23,24 @@ import kotlinx.serialization.Serializable
  * by this heuristic design to ensure low-friction item capture.
  */
 @Serializable
-enum class DomainKind {
+enum class DomainKind(val displayName: String) {
     /**
      * Domain relating to financial responsibilities, tracking expenses, budgeting, and bills.
      */
-    FINANCES,
+    FINANCES("Finances"),
 
     /**
      * Domain relating to medical responsibilities, health tracking, appointments, and general wellbeing.
      */
-    HEALTH,
+    HEALTH("Health"),
 
     /**
      * Domain relating to learning, studies, classes, assignments, and educational resources.
      */
-    EDUCATION,
+    EDUCATION("Education"),
 
     /**
      * Domain relating to tracking social connections, context around individuals, and maintaining relationships.
      */
-    RELATIONSHIPS,
+    RELATIONSHIPS("Relationships"),
 }


### PR DESCRIPTION
Replaced expensive `.lowercase().replaceFirstChar(Char::titlecase)` string manipulations with a pre-computed `displayName` property in `DomainKind` enum to avoid dynamic string allocations during Compose UI recomposition.

---
*PR created automatically by Jules for task [9925328810443642003](https://jules.google.com/task/9925328810443642003) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

