### PR TITLE
docs: add missing KDocs to StudentCommands

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/StudentCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/StudentCommands.kt
@@ -86,6 +86,18 @@ class StudentCommands(
         }
     }
 
+    /**
+     * Assigns course and academic context details to a student-focused node.
+     *
+     * This safely deserializes, mutates, and re-serializes the `StudentMetadata`
+     * embedded within the node's JSON envelope, applying the provided course identifiers.
+     *
+     * @param node The node entity representing the academic item being modified.
+     * @param courseId The formal course identifier or code (e.g., "CS101").
+     * @param courseName The human-readable name of the course.
+     * @param semester The academic term during which the course is taken.
+     * @param assignmentType An optional string defining the structural type of the assignment.
+     */
     fun setStudentCourse(
         node: NodeEntity,
         courseId: String?,
@@ -103,6 +115,22 @@ class StudentCommands(
         }
     }
 
+    /**
+     * Creates a new academic note node with attached student metadata context.
+     *
+     * This orchestrates the creation of a standard note node, then packages the provided
+     * academic identifiers (course code, name, semester, and topic) into a `NodeMetadataEnvelope`.
+     * The serialized envelope is embedded in the note's metadata JSON, cementing its
+     * role within the student module.
+     *
+     * @param title The primary heading or subject of the note.
+     * @param content The internal text contents or markdown payload of the note.
+     * @param noteType The structural classification (e.g., "lecture", "reading").
+     * @param courseId The formal identifier for the related course.
+     * @param courseName The readable name of the course.
+     * @param semester The academic term context.
+     * @param topic A specific conceptual subject the note covers.
+     */
     fun addStudentNote(
         title: String,
         content: String,


### PR DESCRIPTION
Adds missing documentation for `setStudentCourse` and `addStudentNote` methods in `StudentCommands.kt` to clarify intent, parameters, and interactions with metadata JSON payloads.

---
*PR created automatically by Jules for task [1151047781270065074](https://jules.google.com/task/1151047781270065074) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

