### PR TITLE
test: Add boundary edge case tests for IP address site-local and link-local parsing

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserTest.kt
@@ -146,4 +146,43 @@ class InetAddressParserTest {
         assertNull(parseIpAddress(":1:2:3:4:5:6:7"), "Should reject starting with single colon")
         assertNull(parseIpAddress("1:2:3:4:5:6:7:"), "Should reject ending with single colon")
     }
+
+    @Test
+    fun testIpv4SiteLocalBoundaries() {
+        // 10.x.x.x
+        assertTrue(parseIpAddress("10.0.0.0")!!.isSiteLocal())
+        assertTrue(parseIpAddress("10.255.255.255")!!.isSiteLocal())
+        assertFalse(parseIpAddress("9.255.255.255")!!.isSiteLocal())
+        assertFalse(parseIpAddress("11.0.0.0")!!.isSiteLocal())
+
+        // 172.16.x.x - 172.31.x.x
+        assertTrue(parseIpAddress("172.16.0.0")!!.isSiteLocal())
+        assertTrue(parseIpAddress("172.31.255.255")!!.isSiteLocal())
+        assertFalse(parseIpAddress("172.15.255.255")!!.isSiteLocal())
+        assertFalse(parseIpAddress("172.32.0.0")!!.isSiteLocal())
+
+        // 192.168.x.x
+        assertTrue(parseIpAddress("192.168.0.0")!!.isSiteLocal())
+        assertTrue(parseIpAddress("192.168.255.255")!!.isSiteLocal())
+        assertFalse(parseIpAddress("192.167.255.255")!!.isSiteLocal())
+        assertFalse(parseIpAddress("192.169.0.0")!!.isSiteLocal())
+    }
+
+    @Test
+    fun testIpv6SiteLocalBoundaries() {
+        // fc00::/7 => fc00 to fdff
+        assertTrue(parseIpAddress("fc00::")!!.isSiteLocal())
+        assertTrue(parseIpAddress("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isSiteLocal())
+        assertFalse(parseIpAddress("fbff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isSiteLocal())
+        assertFalse(parseIpAddress("fe00::")!!.isSiteLocal())
+    }
+
+    @Test
+    fun testIpv6LinkLocalBoundaries() {
+        // fe80::/10 => fe80 to febf
+        assertTrue(parseIpAddress("fe80::")!!.isLinkLocal())
+        assertTrue(parseIpAddress("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isLinkLocal())
+        assertFalse(parseIpAddress("fe7f:ffff:ffff:ffff:ffff:ffff:ffff:ffff")!!.isLinkLocal())
+        assertFalse(parseIpAddress("fec0::")!!.isLinkLocal())
+    }
 }


### PR DESCRIPTION
Appends boundary edge case tests for `isSiteLocal()` and `isLinkLocal()` bounds check for IPv4 and IPv6 to ensure proper regression coverage over shifting logic.

---
*PR created automatically by Jules for task [17409520869641158742](https://jules.google.com/task/17409520869641158742) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

