### PR TITLE
fix(ui): refine empty state and capture sheet interactions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
@@ -43,6 +43,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -147,6 +149,11 @@ fun CaptureSheet(
     var isSticky by remember { mutableStateOf(false) }
 
     var multiCaptureMode by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
     var brainDumpMode by remember { mutableStateOf(false) }
 
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -221,6 +228,7 @@ fun CaptureSheet(
                     onValueChange = { text = it },
                     modifier =
                         Modifier
+                            .focusRequester(focusRequester)
                             .weight(1f)
                             .padding(vertical = TajsOSTheme.SpacingMd),
                     textStyle =

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/EmptyState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/EmptyState.kt
@@ -62,7 +62,7 @@ fun EmptyState(
     description: String? = stringResource(Res.string.empty_state_default_desc),
     fillParent: Boolean = true,
     showContainer: Boolean = true,
-    pulseIcon: Boolean = showContainer,
+    pulseIcon: Boolean = false,
     content: @Composable ColumnScope.() -> Unit = {},
 ) {
     val infiniteTransition = rememberInfiniteTransition(label = "EmptyStatePulse")


### PR DESCRIPTION
Disabled default pulsing empty state icon to reduce visual noise, and added auto-focus to CaptureSheet input for faster user interactions when adding new items.

---
*PR created automatically by Jules for task [14191509766716404416](https://jules.google.com/task/14191509766716404416) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

