### PR TITLE
docs: Explain destructive migration posture

### DIFF
--- a/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
+++ b/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
@@ -14,6 +14,10 @@ fun createDatabase(context: Context): AppDatabase {
             context = context,
             name = dbFile.absolutePath,
             factory = AppDatabaseConstructor::initialize,
-        ).fallbackToDestructiveMigration(true)
+        )
+        // Enables destructive migration as a pre-alpha safety posture.
+        // Any schema growth during this phase is high-risk but acceptable without strict migrations.
+        // Replace this with proper migrations once the architecture matures.
+        .fallbackToDestructiveMigration(true)
         .build()
 }

--- a/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
+++ b/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
@@ -16,6 +16,9 @@ fun createDatabase(): AppDatabase {
             name = dbFile.absolutePath,
             factory = AppDatabaseConstructor::initialize,
         ).setDriver(BundledSQLiteDriver())
+        // Enables destructive migration as a pre-alpha safety posture.
+        // Any schema growth during this phase is high-risk but acceptable without strict migrations.
+        // Replace this with proper migrations once the architecture matures.
         .fallbackToDestructiveMigration(true)
         .build()
 }


### PR DESCRIPTION
Added comments explaining the rationale behind fallbackToDestructiveMigration(true) aligning with the AGENTS.md rule that notes it is a pre-alpha safety posture.

---
*PR created automatically by Jules for task [14098951491797749959](https://jules.google.com/task/14098951491797749959) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

