### PR TITLE
perf: pre-compute NotesDomain display names

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -114,9 +114,7 @@ fun NotesContextPanel(
             item {
                 ContextSection(title = "Domain", icon = Icons.Default.Category) {
                     Text(
-                        selectedNote.domain.name
-                            .lowercase()
-                            .replaceFirstChar(Char::titlecase),
+                        selectedNote.domain.displayName,
                         color = TajsOSTheme.Text,
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -109,7 +109,7 @@ fun NotesEditorPane(
                 Column(modifier = Modifier.fillMaxWidth().widthIn(max = 880.dp)) {
                     Text(
                         text = "NOTES > ${
-                            note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                            note.domain.displayName
                         }",
                         style = MaterialTheme.typography.labelSmall,
                         color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -176,10 +176,10 @@ private fun NotesDomainRow(
     ) {
         listOf(
             null to "Any",
-            NotesDomain.PERSONAL to "Personal",
-            NotesDomain.STUDY to "Study",
-            NotesDomain.WORK to "Work",
-            NotesDomain.HEALTH to "Health",
+            NotesDomain.PERSONAL to NotesDomain.PERSONAL.displayName,
+            NotesDomain.STUDY to NotesDomain.STUDY.displayName,
+            NotesDomain.WORK to NotesDomain.WORK.displayName,
+            NotesDomain.HEALTH to NotesDomain.HEALTH.displayName,
         ).forEach { (domain, label) ->
             NotesTokenButton(
                 label = label,
@@ -297,7 +297,7 @@ fun NotesListItem(
                 )
                 Text(
                     text = "${
-                        note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                        note.domain.displayName
                     } • ${relativeDateLabel(note.updatedAt)}",
                     style = MaterialTheme.typography.labelSmall,
                     color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
@@ -12,11 +12,17 @@ import com.tajemniktv.tajsos.data.isTaskItem
 /**
  * Local domain grouping used by the Notes workspace left-rail filters.
  */
-enum class NotesDomain {
-    PERSONAL,
-    STUDY,
-    WORK,
-    HEALTH,
+enum class NotesDomain(
+    /**
+     * Pre-computed, UI-ready display name for the domain.
+     * Prevents unnecessary string allocations during recomposition.
+     */
+    val displayName: String,
+) {
+    PERSONAL("Personal"),
+    STUDY("Study"),
+    WORK("Work"),
+    HEALTH("Health"),
 }
 
 /**


### PR DESCRIPTION
Optimizes NotesDomain formatting in composeApp by pre-computing a displayName property. This avoids unnecessary string allocations and transformations (.lowercase().replaceFirstChar) during recomposition in NotesListRail, NotesEditorPane, and NotesContextPanel.

---
*PR created automatically by Jules for task [17712104945133597974](https://jules.google.com/task/17712104945133597974) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

