### PR TITLE
test: Add tests for nextMonthlyResetDate, matchesItemFilter, and matchesLinkedTo

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/NodeEntityItemFilterTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/NodeEntityItemFilterTest.kt
@@ -1,0 +1,72 @@
+package com.tajemniktv.tajsos.data
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class NodeEntityItemFilterTest {
+    @Test
+    fun testMatchesItemFilter_nullFilter() {
+        val node = NodeEntity(id = 1, title = "test", type = "task")
+        assertTrue(node.matchesItemFilter(null))
+    }
+
+    @Test
+    fun testMatchesItemFilter_task() {
+        val node = NodeEntity(id = 1, title = "test", type = "task")
+        val nodeOpenLoop = NodeEntity(id = 2, title = "test", type = "open_loop")
+        val nodeNote = NodeEntity(id = 3, title = "test", type = "note")
+
+        assertTrue(node.matchesItemFilter("task"))
+        assertTrue(nodeOpenLoop.matchesItemFilter("task"))
+        assertFalse(nodeNote.matchesItemFilter("task"))
+    }
+
+    @Test
+    fun testMatchesItemFilter_note() {
+        val nodeNote = NodeEntity(id = 1, title = "test", type = "note")
+        val nodeIdea = NodeEntity(id = 2, title = "test", type = "idea")
+        val nodeTask = NodeEntity(id = 3, title = "test", type = "task")
+
+        assertTrue(nodeNote.matchesItemFilter("note"))
+        assertTrue(nodeIdea.matchesItemFilter("note"))
+        assertFalse(nodeTask.matchesItemFilter("note"))
+    }
+
+    @Test
+    fun testMatchesItemFilter_record() {
+        val nodeRecord = NodeEntity(id = 1, title = "test", type = "record")
+        val nodeTask = NodeEntity(id = 2, title = "test", type = "task")
+
+        assertTrue(nodeRecord.matchesItemFilter("record"))
+        assertFalse(nodeTask.matchesItemFilter("record"))
+    }
+
+    @Test
+    fun testMatchesItemFilter_project() {
+        val nodeProject = NodeEntity(id = 1, title = "test", type = "project")
+        val nodeTask = NodeEntity(id = 2, title = "test", type = "task")
+
+        assertTrue(nodeProject.matchesItemFilter("project"))
+        assertFalse(nodeTask.matchesItemFilter("project"))
+    }
+
+    @Test
+    fun testMatchesItemFilter_area() {
+        val nodeArea = NodeEntity(id = 1, title = "test", type = "area")
+        val nodeTask = NodeEntity(id = 2, title = "test", type = "task")
+
+        assertTrue(nodeArea.matchesItemFilter("area"))
+        assertFalse(nodeTask.matchesItemFilter("area"))
+    }
+
+    @Test
+    fun testMatchesItemFilter_customType() {
+        val nodeCustom = NodeEntity(id = 1, title = "test", type = "custom_type")
+        val nodeTask = NodeEntity(id = 2, title = "test", type = "task")
+
+        assertTrue(nodeCustom.matchesItemFilter("custom_type"))
+        assertFalse(nodeTask.matchesItemFilter("custom_type"))
+        assertFalse(nodeCustom.matchesItemFilter("other_type"))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesLinkedToTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesLinkedToTest.kt
@@ -1,0 +1,71 @@
+package com.tajemniktv.tajsos.ui
+
+import com.tajemniktv.tajsos.data.RelationEntity
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class FilterHelperMatchesLinkedToTest {
+    private fun matchesLinkedToProxy(nodeId: Long, linkedToId: Long?, relations: List<RelationEntity>): Boolean {
+        val nodeWithPin1 = buildTestNode(nodeId, "title1")
+        val result = FilterHelper.filterAndSortNodes(
+            nodes = listOf(nodeWithPin1),
+            query = "",
+            type = null,
+            status = null,
+            projectId = null,
+            areaId = null,
+            linkedToId = linkedToId,
+            maxMins = null,
+            energy = null,
+            friction = null,
+            locationContext = null,
+            energyContext = null,
+            deviceContext = null,
+            socialContext = null,
+            timeWindowContext = null,
+            timeHorizon = null,
+            relations = relations,
+            sortMode = "relevance"
+        )
+        return result.isNotEmpty()
+    }
+
+    @Test
+    fun testMatchesLinkedTo_nullLinkedToId() {
+        assertTrue(matchesLinkedToProxy(1L, null, emptyList()))
+    }
+
+    @Test
+    fun testMatchesLinkedTo_matchFromNodeId() {
+        val relations = listOf(
+            RelationEntity(id = 1L, fromNodeId = 1L, toNodeId = 2L, relationType = "RELATED")
+        )
+        assertTrue(matchesLinkedToProxy(1L, 2L, relations))
+    }
+
+    @Test
+    fun testMatchesLinkedTo_matchToNodeId() {
+        val relations = listOf(
+            RelationEntity(id = 1L, fromNodeId = 2L, toNodeId = 1L, relationType = "RELATED")
+        )
+        assertTrue(matchesLinkedToProxy(1L, 2L, relations))
+    }
+
+    @Test
+    fun testMatchesLinkedTo_noMatch() {
+        val relations = listOf(
+            RelationEntity(id = 1L, fromNodeId = 3L, toNodeId = 4L, relationType = "RELATED")
+        )
+        assertFalse(matchesLinkedToProxy(1L, 2L, relations))
+    }
+
+    @Test
+    fun testMatchesLinkedTo_multipleRelationsMatch() {
+        val relations = listOf(
+            RelationEntity(id = 1L, fromNodeId = 3L, toNodeId = 4L, relationType = "RELATED"),
+            RelationEntity(id = 2L, fromNodeId = 1L, toNodeId = 2L, relationType = "RELATED")
+        )
+        assertTrue(matchesLinkedToProxy(1L, 2L, relations))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/NextMonthlyResetDateTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/NextMonthlyResetDateTest.kt
@@ -1,0 +1,12 @@
+package com.tajemniktv.tajsos.ui.main.calculators
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class NextMonthlyResetDateTest {
+    @Test
+    fun testNextMonthlyResetDate() {
+        val result = nextMonthlyResetDate()
+        assertTrue(result.matches(Regex("\\d{4}-\\d{2}-01")))
+    }
+}


### PR DESCRIPTION
Improves test coverage for un-tested boundary filters and calculation parameters.

---
*PR created automatically by Jules for task [15740950070920422934](https://jules.google.com/task/15740950070920422934) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

