### PR TITLE
perf: optimize string allocations in UI composition

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -114,9 +114,7 @@ fun NotesContextPanel(
             item {
                 ContextSection(title = "Domain", icon = Icons.Default.Category) {
                     Text(
-                        selectedNote.domain.name
-                            .lowercase()
-                            .replaceFirstChar(Char::titlecase),
+                        selectedNote.domain.displayName,
                         color = TajsOSTheme.Text,
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -109,7 +109,7 @@ fun NotesEditorPane(
                 Column(modifier = Modifier.fillMaxWidth().widthIn(max = 880.dp)) {
                     Text(
                         text = "NOTES > ${
-                            note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                            note.domain.displayName
                         }",
                         style = MaterialTheme.typography.labelSmall,
                         color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -297,7 +297,7 @@ fun NotesListItem(
                 )
                 Text(
                     text = "${
-                        note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                        note.domain.displayName
                     } • ${relativeDateLabel(note.updatedAt)}",
                     style = MaterialTheme.typography.labelSmall,
                     color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
@@ -11,12 +11,14 @@ import com.tajemniktv.tajsos.data.isTaskItem
 
 /**
  * Local domain grouping used by the Notes workspace left-rail filters.
+ *
+ * @property displayName The pre-computed display name to avoid string allocations during UI composition.
  */
-enum class NotesDomain {
-    PERSONAL,
-    STUDY,
-    WORK,
-    HEALTH,
+enum class NotesDomain(val displayName: String) {
+    PERSONAL("Personal"),
+    STUDY("Study"),
+    WORK("Work"),
+    HEALTH("Health"),
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -788,21 +788,35 @@ private fun SearchResultCard(
     }
 }
 
+/**
+ * Returns the appropriate [ImageVector] icon for a given domain/item type.
+ * Matching is performed case-insensitively to avoid intermediate string allocations.
+ *
+ * @param type The string representation of the item type (e.g., "task", "note").
+ * @return The corresponding material icon for the type.
+ */
 private fun iconForType(type: String): ImageVector =
-    when (type.lowercase()) {
-        "task" -> Icons.Default.TaskAlt
-        "project" -> Icons.Default.Folder
-        "note" -> Icons.Default.Description
-        "record" -> Icons.AutoMirrored.Filled.InsertDriveFile
+    when {
+        type.equals("task", ignoreCase = true) -> Icons.Default.TaskAlt
+        type.equals("project", ignoreCase = true) -> Icons.Default.Folder
+        type.equals("note", ignoreCase = true) -> Icons.Default.Description
+        type.equals("record", ignoreCase = true) -> Icons.AutoMirrored.Filled.InsertDriveFile
         else -> Icons.Default.Search
     }
 
+/**
+ * Returns the appropriate [Color] tint for a given domain/item type.
+ * Matching is performed case-insensitively to avoid intermediate string allocations.
+ *
+ * @param type The string representation of the item type (e.g., "task", "note").
+ * @return The associated theme color for the type.
+ */
 private fun iconTintForType(type: String): Color =
-    when (type.lowercase()) {
-        "task" -> TajsOSTheme.AccentRed
-        "project" -> TajsOSTheme.Primary
-        "note" -> TajsOSTheme.AccentBlue
-        "record" -> TajsOSTheme.AccentCyan
+    when {
+        type.equals("task", ignoreCase = true) -> TajsOSTheme.AccentRed
+        type.equals("project", ignoreCase = true) -> TajsOSTheme.Primary
+        type.equals("note", ignoreCase = true) -> TajsOSTheme.AccentBlue
+        type.equals("record", ignoreCase = true) -> TajsOSTheme.AccentCyan
         else -> TajsOSTheme.Primary
     }
 


### PR DESCRIPTION
This pull request implements performance optimizations in the Jetpack Compose UI to reduce unnecessary string allocations during recomposition:

- Replaced `.lowercase()` with `type.equals(..., ignoreCase = true)` inside utility functions (`iconForType` and `iconTintForType`) in `SearchDashboardBlocks.kt`.
- Replaced inline string formatting (`name.lowercase().replaceFirstChar(...)`) with a pre-computed `displayName` property on the `NotesDomain` enum inside `NotesWorkspaceModels.kt`, updating related `NotesListRail.kt`, `NotesContextPanel.kt`, and `NotesEditorPane.kt` files.
- Added KDocs detailing the intent of avoiding these string allocations during Compose operations.

---
*PR created automatically by Jules for task [8534028565306714072](https://jules.google.com/task/8534028565306714072) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

