### PR TITLE
test: expand edge case coverage for FilterHelper queries and scoring

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperEdgeTest.kt
@@ -1,6 +1,8 @@
 package com.tajemniktv.tajsos.ui
 
 import com.tajemniktv.tajsos.data.TodayPinEntity
+import com.tajemniktv.tajsos.data.RelationEntity
+import kotlin.test.assertTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 @OptIn(kotlin.time.ExperimentalTime::class)
@@ -271,4 +273,101 @@ class FilterHelperEdgeTest {
         )
         assertEquals(6, resultInvalid.size)
     }
+    @Test
+    fun testRelevanceScore_caseInsensitivity() {
+        val targetNode = buildTestNode(1, "TARGET ITEM", "SOME CONTENT TARGET", tags = listOf("MyTarget"))
+
+        val result = FilterHelper.filterAndSortNodes(
+            nodes = listOf(targetNode),
+            query = "target",
+            type = null, status = null, projectId = null, areaId = null, linkedToId = null,
+            maxMins = null, energy = null, friction = null, locationContext = null,
+            energyContext = null, deviceContext = null, socialContext = null,
+            timeWindowContext = null, timeHorizon = null, relations = emptyList(),
+            sortMode = "relevance"
+        )
+
+        assertEquals(1, result.size)
+        // Check sorting to ensure score is correctly calculated via ignoreCase = true
+        val betterNode = buildTestNode(2, "target", "content") // exact (100) + start (60) + contains (30) = 190
+
+        val result2 = FilterHelper.filterAndSortNodes(
+            nodes = listOf(targetNode, betterNode),
+            query = "target",
+            type = null, status = null, projectId = null, areaId = null, linkedToId = null,
+            maxMins = null, energy = null, friction = null, locationContext = null,
+            energyContext = null, deviceContext = null, socialContext = null,
+            timeWindowContext = null, timeHorizon = null, relations = emptyList(),
+            sortMode = "relevance"
+        )
+
+        assertEquals(2, result2.size)
+        assertEquals(2L, result2[0].node.id) // betterNode has higher score
+        assertEquals(1L, result2[1].node.id) // targetNode has lower score
+    }
+
+    @Test
+    fun testMatchesTimeHorizon_missingDueAt() {
+        // If dueAt is null, it only matches if timeHorizon is null or "all" (which is the else branch)
+        val nodeNullDue = buildTestNode(1, "null due", dueAt = null)
+
+        val horizons = listOf("today", "week", "month", "semester", "short", "long")
+        for (horizon in horizons) {
+            val result = FilterHelper.filterAndSortNodes(
+                nodes = listOf(nodeNullDue),
+                query = "",
+                type = null, status = null, projectId = null, areaId = null, linkedToId = null,
+                maxMins = null, energy = null, friction = null, locationContext = null,
+                energyContext = null, deviceContext = null, socialContext = null,
+                timeWindowContext = null, timeHorizon = horizon, relations = emptyList(),
+                sortMode = "updated"
+            )
+            assertEquals(0, result.size, "Failed for horizon: $horizon")
+        }
+
+        val resultElse = FilterHelper.filterAndSortNodes(
+            nodes = listOf(nodeNullDue),
+            query = "",
+            type = null, status = null, projectId = null, areaId = null, linkedToId = null,
+            maxMins = null, energy = null, friction = null, locationContext = null,
+            energyContext = null, deviceContext = null, socialContext = null,
+            timeWindowContext = null, timeHorizon = "unknown_horizon", relations = emptyList(),
+            sortMode = "updated"
+        )
+        assertEquals(1, resultElse.size)
+    }
+
+    @Test
+    fun testFilterStatus_emptyAndWhitespaces() {
+        val nodeActive = buildTestNode(1, "title", status = "active")
+        val nodeOnHold = buildTestNode(2, "title", status = "on_hold")
+
+        val result = FilterHelper.filterAndSortNodes(
+            nodes = listOf(nodeActive, nodeOnHold),
+            query = "",
+            type = null,
+            status = "  ,  ,,", // Should be filtered out by filter { it.isNotEmpty() } and become null
+            projectId = null,
+            areaId = null,
+            linkedToId = null,
+            maxMins = null,
+            energy = null,
+            friction = null,
+            locationContext = null,
+            energyContext = null,
+            deviceContext = null,
+            socialContext = null,
+            timeWindowContext = null,
+            timeHorizon = null,
+            relations = emptyList(),
+            sortMode = "relevance"
+        )
+
+        // statusSet will be null, so it should return all nodes
+        assertEquals(2, result.size)
+    }
+
+
+
+
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperEdgeTest.kt
@@ -2,35 +2,29 @@ package com.tajemniktv.tajsos.ui
 
 import com.tajemniktv.tajsos.data.TodayPinEntity
 import com.tajemniktv.tajsos.data.RelationEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
 import kotlin.test.assertTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 @OptIn(kotlin.time.ExperimentalTime::class)
 
 class FilterHelperEdgeTest {
+    private fun filterWithRelevance(nodes: List<NodeWithPin>, query: String, status: String? = null): List<NodeWithPin> {
+        return FilterHelper.filterAndSortNodes(
+            nodes = nodes,
+            query = query,
+            type = null, status = status, projectId = null, areaId = null, linkedToId = null,
+            maxMins = null, energy = null, friction = null, locationContext = null,
+            energyContext = null, deviceContext = null, socialContext = null,
+            timeWindowContext = null, timeHorizon = null, relations = emptyList(),
+            sortMode = "relevance"
+        )
+    }
+
     @Test
     fun testRelevanceScore_emptyQuery() {
         val node = buildTestNode(1, "Test Node")
-        val result = FilterHelper.filterAndSortNodes(
-            nodes = listOf(node),
-            query = "",
-            type = null,
-            status = null,
-            projectId = null,
-            areaId = null,
-            linkedToId = null,
-            maxMins = null,
-            energy = null,
-            friction = null,
-            locationContext = null,
-            energyContext = null,
-            deviceContext = null,
-            socialContext = null,
-            timeWindowContext = null,
-            timeHorizon = null,
-            relations = emptyList(),
-            sortMode = "relevance"
-        )
+        val result = filterWithRelevance(listOf(node), "")
         // Ensure that with empty query it still returns nodes and sort mode works without error
         assertEquals(1, result.size)
     }
@@ -88,15 +82,7 @@ class FilterHelperEdgeTest {
         val activeNode = buildTestNode(2, "query exact", "content", status = "active")
         val inactiveNode = buildTestNode(3, "query exact", "content", status = "on_hold")
 
-        val result = FilterHelper.filterAndSortNodes(
-            nodes = listOf(inactiveNode, activeNode, activePinnedNode),
-            query = "query exact",
-            type = null, status = null, projectId = null, areaId = null, linkedToId = null,
-            maxMins = null, energy = null, friction = null, locationContext = null,
-            energyContext = null, deviceContext = null, socialContext = null,
-            timeWindowContext = null, timeHorizon = null, relations = emptyList(),
-            sortMode = "relevance"
-        )
+        val result = filterWithRelevance(listOf(inactiveNode, activeNode, activePinnedNode), "query exact")
 
         assertEquals(3, result.size)
         // Score order: activePinnedNode (1), activeNode (2), inactiveNode (3)
@@ -111,15 +97,7 @@ class FilterHelperEdgeTest {
         val containsTagMatch = buildTestNode(2, "title", "content", tags = listOf("prefix query exact suffix"))
         val noTagMatch = buildTestNode(3, "title", "content", tags = listOf("other"))
 
-        val result = FilterHelper.filterAndSortNodes(
-            nodes = listOf(noTagMatch, containsTagMatch, exactTagMatch),
-            query = "query exact",
-            type = null, status = null, projectId = null, areaId = null, linkedToId = null,
-            maxMins = null, energy = null, friction = null, locationContext = null,
-            energyContext = null, deviceContext = null, socialContext = null,
-            timeWindowContext = null, timeHorizon = null, relations = emptyList(),
-            sortMode = "relevance"
-        )
+        val result = filterWithRelevance(listOf(noTagMatch, containsTagMatch, exactTagMatch), "query exact")
 
         assertEquals(2, result.size) // noTagMatch shouldn't match the query
         // Score order: exactTagMatch (1), containsTagMatch (2)
@@ -134,15 +112,7 @@ class FilterHelperEdgeTest {
         val containsMatch = buildTestNode(3, "prefix query exact", "content")
         val contentMatch = buildTestNode(4, "other title", "content query exact")
 
-        val result = FilterHelper.filterAndSortNodes(
-            nodes = listOf(contentMatch, containsMatch, startsWithMatch, exactMatch),
-            query = "query exact",
-            type = null, status = null, projectId = null, areaId = null, linkedToId = null,
-            maxMins = null, energy = null, friction = null, locationContext = null,
-            energyContext = null, deviceContext = null, socialContext = null,
-            timeWindowContext = null, timeHorizon = null, relations = emptyList(),
-            sortMode = "relevance"
-        )
+        val result = filterWithRelevance(listOf(contentMatch, containsMatch, startsWithMatch, exactMatch), "query exact")
 
         assertEquals(4, result.size)
         assertEquals(1L, result[0].node.id) // Exact
@@ -158,26 +128,7 @@ class FilterHelperEdgeTest {
         val node2 = buildTestNode(2, "title", "content", tags = listOf("exact match"), updatedAt = 200L)
         val node3 = buildTestNode(3, "title", "content", tags = listOf("exact match"), updatedAt = 100L)
 
-        val result = FilterHelper.filterAndSortNodes(
-            nodes = listOf(node1, node2, node3),
-            query = "exact match",
-            type = null,
-            status = null,
-            projectId = null,
-            areaId = null,
-            linkedToId = null,
-            maxMins = null,
-            energy = null,
-            friction = null,
-            locationContext = null,
-            energyContext = null,
-            deviceContext = null,
-            socialContext = null,
-            timeWindowContext = null,
-            timeHorizon = null,
-            relations = emptyList(),
-            sortMode = "relevance"
-        )
+        val result = filterWithRelevance(listOf(node1, node2, node3), "exact match")
         assertEquals(3, result.size)
         // Scores are identical.
         // Order: node2 (highest updatedAt), node3 (same updatedAt, higher id), node1 (lowest id)
@@ -194,26 +145,7 @@ class FilterHelperEdgeTest {
         val nodeOnHold = buildTestNode(2, "title", status = "on_hold")
         val nodeArchived = buildTestNode(3, "title", status = "archived")
 
-        val result = FilterHelper.filterAndSortNodes(
-            nodes = listOf(nodeActive, nodeOnHold, nodeArchived),
-            query = "",
-            type = null,
-            status = "active, on_hold",
-            projectId = null,
-            areaId = null,
-            linkedToId = null,
-            maxMins = null,
-            energy = null,
-            friction = null,
-            locationContext = null,
-            energyContext = null,
-            deviceContext = null,
-            socialContext = null,
-            timeWindowContext = null,
-            timeHorizon = null,
-            relations = emptyList(),
-            sortMode = "relevance"
-        )
+        val result = filterWithRelevance(listOf(nodeActive, nodeOnHold, nodeArchived), "", "active, on_hold")
 
         assertEquals(2, result.size)
         assertEquals(listOf(1L, 2L), result.map { it.node.id }.sorted())
@@ -277,29 +209,13 @@ class FilterHelperEdgeTest {
     fun testRelevanceScore_caseInsensitivity() {
         val targetNode = buildTestNode(1, "TARGET ITEM", "SOME CONTENT TARGET", tags = listOf("MyTarget"))
 
-        val result = FilterHelper.filterAndSortNodes(
-            nodes = listOf(targetNode),
-            query = "target",
-            type = null, status = null, projectId = null, areaId = null, linkedToId = null,
-            maxMins = null, energy = null, friction = null, locationContext = null,
-            energyContext = null, deviceContext = null, socialContext = null,
-            timeWindowContext = null, timeHorizon = null, relations = emptyList(),
-            sortMode = "relevance"
-        )
+        val result = filterWithRelevance(listOf(targetNode), "target")
 
         assertEquals(1, result.size)
         // Check sorting to ensure score is correctly calculated via ignoreCase = true
         val betterNode = buildTestNode(2, "target", "content") // exact (100) + start (60) + contains (30) = 190
 
-        val result2 = FilterHelper.filterAndSortNodes(
-            nodes = listOf(targetNode, betterNode),
-            query = "target",
-            type = null, status = null, projectId = null, areaId = null, linkedToId = null,
-            maxMins = null, energy = null, friction = null, locationContext = null,
-            energyContext = null, deviceContext = null, socialContext = null,
-            timeWindowContext = null, timeHorizon = null, relations = emptyList(),
-            sortMode = "relevance"
-        )
+        val result2 = filterWithRelevance(listOf(targetNode, betterNode), "target")
 
         assertEquals(2, result2.size)
         assertEquals(2L, result2[0].node.id) // betterNode has higher score
@@ -342,26 +258,7 @@ class FilterHelperEdgeTest {
         val nodeActive = buildTestNode(1, "title", status = "active")
         val nodeOnHold = buildTestNode(2, "title", status = "on_hold")
 
-        val result = FilterHelper.filterAndSortNodes(
-            nodes = listOf(nodeActive, nodeOnHold),
-            query = "",
-            type = null,
-            status = "  ,  ,,", // Should be filtered out by filter { it.isNotEmpty() } and become null
-            projectId = null,
-            areaId = null,
-            linkedToId = null,
-            maxMins = null,
-            energy = null,
-            friction = null,
-            locationContext = null,
-            energyContext = null,
-            deviceContext = null,
-            socialContext = null,
-            timeWindowContext = null,
-            timeHorizon = null,
-            relations = emptyList(),
-            sortMode = "relevance"
-        )
+        val result = filterWithRelevance(listOf(nodeActive, nodeOnHold), "", "  ,  ,,")
 
         // statusSet will be null, so it should return all nodes
         assertEquals(2, result.size)

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
@@ -43,4 +43,14 @@ class FilterHelperMatchesQueryEdgeTest {
         assertTrue(FilterHelper.matchesQuery(nodeTag, "tag"))
         assertFalse(FilterHelper.matchesQuery(nodeNone, "title"))
     }
+
+    @Test
+    fun testMatchesQuery_multipleNormalSearchTerms() {
+        // We only check if the entire query matches the text (so a multi-word query acts like a phrase)
+        val nodeTitle = buildTestNode(1, "my specific phrase", "content")
+        val nodeTitleMismatch = buildTestNode(2, "my phrase specific", "content")
+
+        assertTrue(FilterHelper.matchesQuery(nodeTitle, "specific phrase"))
+        assertFalse(FilterHelper.matchesQuery(nodeTitleMismatch, "specific phrase"))
+    }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperTest.kt
@@ -807,4 +807,41 @@ class FilterHelperTest {
         val result3 = filter(listOf(node1)) { linkedToId = 100L; this.relations = relations }
         assertEquals(1, result3.size)
     }
+
+    @Test
+    fun testRelevanceScore_emptyQueryReturnsZeroScoreForEveryone() {
+        val node1 = createTestNode(1, "title", "content", updatedAt = 100L)
+        val node2 = createTestNode(2, "title", "content", updatedAt = 200L)
+
+        val nodes = listOf(node1, node2)
+
+        // Given an empty query, filterAndSortNodes with "relevance"
+        // will assign 0 to all and fallback to updatedAt descending
+        val result = filter(nodes) { query = "   "; sortMode = "relevance" }
+
+        assertEquals(2, result.size)
+        // Tie breaks by highest updatedAt -> node2 then node1
+        assertEquals(2L, result[0].node.id)
+        assertEquals(1L, result[1].node.id)
+    }
+
+    @Test
+    fun testMatchesLinkedTo_bidirectionalEdgeCases() {
+        val node1 = createTestNode(1, "title")
+        val node2 = createTestNode(2, "title")
+        val node3 = createTestNode(3, "title")
+
+        // node1 -> 100, 100 -> node2
+        val relations = listOf(
+            RelationEntity(id = 1, fromNodeId = 1, toNodeId = 100, relationType = "RELATED"),
+            RelationEntity(id = 2, fromNodeId = 100, toNodeId = 2, relationType = "RELATED"),
+            RelationEntity(id = 3, fromNodeId = 3, toNodeId = 200, relationType = "RELATED")
+        )
+
+        val result1 = filter(listOf(node1, node2, node3)) { linkedToId = 100L; this.relations = relations }
+        assertEquals(2, result1.size)
+        assertTrue(result1.any { it.node.id == 1L })
+        assertTrue(result1.any { it.node.id == 2L })
+    }
+
 }


### PR DESCRIPTION
Added edge case tests for `FilterHelper.kt` to ensure correct case insensitivity in relevance scoring, correct matching behaviour for missing due dates, handling of whitespace query/status, and correct behaviour on bidirectional linkage.

---
*PR created automatically by Jules for task [8914687087135448938](https://jules.google.com/task/8914687087135448938) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

