### PR TITLE
fix(ui): optimize string allocations during recomposition

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.TaskState
 import com.tajemniktv.tajsos.ui.components.common.MouseContextMenuHost
 import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import com.tajemniktv.tajsos.ui.components.common.rememberMouseContextMenuState
@@ -169,7 +170,7 @@ fun TaskRow(
                                     else -> TajsOSTheme.Primary
                                 }
                             Text(
-                                text = node.status.uppercase().replace("_", " "),
+                                text = TaskState.fromStorageKey(node.status)?.displayName ?: node.status.uppercase().replace("_", " "),
                                 style = MaterialTheme.typography.labelSmall,
                                 color = statusColor,
                             )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
@@ -384,7 +384,7 @@ private fun AreaCard(
                         fontWeight = FontWeight.Bold,
                     )
                     Text(
-                        status.replace("_", " ").uppercase(),
+                        com.tajemniktv.tajsos.data.AreaHealthStatus.fromStorageKey(status)?.displayName ?: status.replace("_", " ").uppercase(),
                         style = MaterialTheme.typography.labelSmall,
                         color = color,
                         fontWeight = FontWeight.Bold,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -114,9 +114,7 @@ fun NotesContextPanel(
             item {
                 ContextSection(title = "Domain", icon = Icons.Default.Category) {
                     Text(
-                        selectedNote.domain.name
-                            .lowercase()
-                            .replaceFirstChar(Char::titlecase),
+                        selectedNote.domain.displayName,
                         color = TajsOSTheme.Text,
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -109,7 +109,7 @@ fun NotesEditorPane(
                 Column(modifier = Modifier.fillMaxWidth().widthIn(max = 880.dp)) {
                     Text(
                         text = "NOTES > ${
-                            note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                            note.domain.displayName
                         }",
                         style = MaterialTheme.typography.labelSmall,
                         color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -297,7 +297,7 @@ fun NotesListItem(
                 )
                 Text(
                     text = "${
-                        note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                        note.domain.displayName
                     } • ${relativeDateLabel(note.updatedAt)}",
                     style = MaterialTheme.typography.labelSmall,
                     color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
@@ -17,6 +17,9 @@ enum class NotesDomain {
     STUDY,
     WORK,
     HEALTH,
+    ;
+
+    val displayName: String = name.lowercase().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -789,21 +789,23 @@ private fun SearchResultCard(
 }
 
 private fun iconForType(type: String): ImageVector =
-    when (type.lowercase()) {
-        "task" -> Icons.Default.TaskAlt
-        "project" -> Icons.Default.Folder
-        "note" -> Icons.Default.Description
-        "record" -> Icons.AutoMirrored.Filled.InsertDriveFile
+    when {
+        type.equals("task", ignoreCase = true) -> Icons.Default.TaskAlt
+        type.equals("project", ignoreCase = true) -> Icons.Default.Folder
+        type.equals("note", ignoreCase = true) -> Icons.Default.Description
+        type.equals("record", ignoreCase = true) -> Icons.AutoMirrored.Filled.InsertDriveFile
         else -> Icons.Default.Search
+
     }
 
 private fun iconTintForType(type: String): Color =
-    when (type.lowercase()) {
-        "task" -> TajsOSTheme.AccentRed
-        "project" -> TajsOSTheme.Primary
-        "note" -> TajsOSTheme.AccentBlue
-        "record" -> TajsOSTheme.AccentCyan
+    when {
+        type.equals("task", ignoreCase = true) -> TajsOSTheme.AccentRed
+        type.equals("project", ignoreCase = true) -> TajsOSTheme.Primary
+        type.equals("note", ignoreCase = true) -> TajsOSTheme.AccentBlue
+        type.equals("record", ignoreCase = true) -> TajsOSTheme.AccentCyan
         else -> TajsOSTheme.Primary
+
     }
 
 private fun formatRelativeTime(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksScreenCommon.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksScreenCommon.kt
@@ -59,7 +59,7 @@ internal fun StatusPill(state: TaskState) {
                 .padding(horizontal = 8.dp, vertical = 4.dp),
     ) {
         Text(
-            state.storageKey.replace("_", " ").uppercase(),
+            state.displayName,
             style = MaterialTheme.typography.labelSmall,
             color = color,
         )

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectModels.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectModels.kt
@@ -32,6 +32,8 @@ enum class ItemKind(
     AREA("area"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into an [ItemKind].
@@ -59,6 +61,8 @@ enum class TaskState(
     ARCHIVED("archived"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into a [TaskState].
@@ -80,6 +84,8 @@ enum class ProjectState(
     COMPLETED("completed"), // NON-NLS
     ARCHIVED("archived"), // NON-NLS
     ;
+
+    val displayName: String = storageKey.replace("_", " ").uppercase()
 
     companion object {
         /**
@@ -108,6 +114,8 @@ enum class NoteKind(
     EVERGREEN("evergreen"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into a [NoteKind].
@@ -129,6 +137,8 @@ enum class NoteState(
     DISTILLED("distilled"), // NON-NLS
     TAKEAWAY("takeaway"), // NON-NLS
     ;
+
+    val displayName: String = storageKey.replace("_", " ").uppercase()
 
     companion object {
         /**
@@ -155,6 +165,8 @@ enum class RecordKind(
     SYMPTOM_LOG("symptom_log"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into a [RecordKind].
@@ -177,6 +189,8 @@ enum class AreaHealthStatus(
     ON_FIRE("on_fire"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into an [AreaHealthStatus].
@@ -198,6 +212,8 @@ enum class ScheduleEntryKind(
     EVENT("event"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into a [ScheduleEntryKind].
@@ -217,6 +233,8 @@ enum class RichContentFormat(
     PLAIN_TEXT("plain_text"), // NON-NLS
     BLOCKS_JSON("blocks_json"), // NON-NLS
     ;
+
+    val displayName: String = storageKey.replace("_", " ").uppercase()
 
     companion object {
         /**
@@ -246,6 +264,8 @@ enum class RelationKind(
     PAPER_REFERENCE("PAPER_REFERENCE"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into a [RelationKind].
@@ -273,6 +293,8 @@ enum class SavedViewLens(
     REVIEW("review"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into a [SavedViewLens].
@@ -297,6 +319,8 @@ enum class SavedViewLayout(
     /** Displays items in a multi-dimensional matrix, often used for cross-referencing metrics. */
     MATRIX("matrix"), // NON-NLS
     ;
+
+    val displayName: String = storageKey.replace("_", " ").uppercase()
 
     companion object {
         /**
@@ -341,6 +365,8 @@ enum class SavedViewFieldKey(
     PINNED("pinned"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into a [SavedViewFieldKey].
@@ -363,6 +389,8 @@ enum class SavedViewMeasure(
     /** The count of items that have reached a completed state. */
     COMPLETED_COUNT("completed_count"), // NON-NLS
     ;
+
+    val displayName: String = storageKey.replace("_", " ").uppercase()
 
     companion object {
         /**
@@ -401,6 +429,8 @@ enum class SavedViewFilterOperator(
     IS_NOT_NULL("is_not_null"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into a [SavedViewFilterOperator].
@@ -430,6 +460,8 @@ enum class SavedViewValueType(
     REFERENCE("reference"), // NON-NLS
     ;
 
+    val displayName: String = storageKey.replace("_", " ").uppercase()
+
     companion object {
         /**
          * Resolves a persisted storage key into a [SavedViewValueType].
@@ -450,6 +482,8 @@ enum class SavedViewSortDirection(
     /** Sorts from highest to lowest, or alphabetically Z to A. */
     DESCENDING("desc"), // NON-NLS
     ;
+
+    val displayName: String = storageKey.replace("_", " ").uppercase()
 
     companion object {
         /**


### PR DESCRIPTION
This PR addresses performance-focused polish in the Compose UI rendering layer.

To prevent unnecessary string allocations during rapid recomposition, dynamic text formatting (`.lowercase()`, `.replace()`, and `.replaceFirstChar(Char::titlecase)`) has been removed from several UI components.
- Added a pre-computed `displayName` property to core domain models in `LifeObjectModels.kt` (e.g., `TaskState`, `ProjectState`, `ItemKind`, etc.) and `NotesDomain`.
- Updated `NotesListRail.kt`, `NotesEditorPane.kt`, and `NotesContextPanel.kt` to use the cached `displayName`.
- Refactored `when (type.lowercase())` in `SearchDashboardBlocks.kt` to safely use `equals(..., ignoreCase = true)` to avoid string copies.

These changes make the UI slightly smoother, specifically while scrolling high-density lists, without changing product direction.

---
*PR created automatically by Jules for task [7233334347271983669](https://jules.google.com/task/7233334347271983669) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

