### PR TITLE
test: Add comprehensive IPv4 loopback and link-local boundary tests

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserEdgeTest.kt
@@ -56,4 +56,21 @@ class InetAddressParserEdgeTest {
         assertEquals(ipv6A, ipv6B)
         assertEquals(ipv6A!!.hashCode(), ipv6B!!.hashCode())
     }
+
+    @Test
+    fun testIpv4LoopbackEdges() {
+        assertTrue(parseIpAddress("127.0.0.0")!!.isLoopback())
+        assertTrue(parseIpAddress("127.255.255.255")!!.isLoopback())
+        assertTrue(parseIpAddress("127.1.2.3")!!.isLoopback())
+        assertFalse(parseIpAddress("126.255.255.255")!!.isLoopback())
+        assertFalse(parseIpAddress("128.0.0.0")!!.isLoopback())
+    }
+
+    @Test
+    fun testIpv4LinkLocalEdges() {
+        assertTrue(parseIpAddress("169.254.0.0")!!.isLinkLocal())
+        assertTrue(parseIpAddress("169.254.255.255")!!.isLinkLocal())
+        assertFalse(parseIpAddress("169.253.255.255")!!.isLinkLocal())
+        assertFalse(parseIpAddress("169.255.0.0")!!.isLinkLocal())
+    }
 }


### PR DESCRIPTION
Added explicit edge case tests for IPv4 loopback (127.0.0.0/8) and link-local (169.254.0.0/16) boundaries in `InetAddressParserEdgeTest.kt`.

---
*PR created automatically by Jules for task [8000307818410732486](https://jules.google.com/task/8000307818410732486) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

