### PR TITLE
fix: remove non-null assertion in App.kt

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -119,10 +119,10 @@ fun App(
      *
      * @param it The route string to evaluate.
      */
-    fun isForwardNavigable(it: String?): Boolean =
-        !it.isNullOrBlank() &&
-            !it.contains('{') &&
-            it != Screen.Dashboard.route
+    fun isForwardNavigable(route: String): Boolean =
+        route.isNotBlank() &&
+            !route.contains('{') &&
+            route != Screen.Dashboard.route
 
     val accentColor =
         remember(accentColorHex) {
@@ -238,8 +238,8 @@ fun App(
                                 val currentRoute = currentDestination?.route
                                 val canPop = navController.previousBackStackEntry != null
                                 if (!canPop) return@mouseButtons
-                                if (isForwardNavigable(currentRoute)) {
-                                    mouseForwardRoutes.addLast(currentRoute!!)
+                                if (currentRoute != null && isForwardNavigable(currentRoute)) {
+                                    mouseForwardRoutes.addLast(currentRoute)
                                 }
                                 navController.popBackStack()
                             },


### PR DESCRIPTION
Replaces the non-null assertion operator (!!) with an explicit null check in the mouse backward navigation logic to prevent potential runtime crashes.

---
*PR created automatically by Jules for task [5727755583675148507](https://jules.google.com/task/5727755583675148507) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

