### PR TITLE
perf: pre-compute Enum display names to reduce UI string allocations

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -114,9 +114,7 @@ fun NotesContextPanel(
             item {
                 ContextSection(title = "Domain", icon = Icons.Default.Category) {
                     Text(
-                        selectedNote.domain.name
-                            .lowercase()
-                            .replaceFirstChar(Char::titlecase),
+                        selectedNote.domain.displayName,
                         color = TajsOSTheme.Text,
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -109,7 +109,7 @@ fun NotesEditorPane(
                 Column(modifier = Modifier.fillMaxWidth().widthIn(max = 880.dp)) {
                     Text(
                         text = "NOTES > ${
-                            note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                            note.domain.displayName
                         }",
                         style = MaterialTheme.typography.labelSmall,
                         color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -297,7 +297,7 @@ fun NotesListItem(
                 )
                 Text(
                     text = "${
-                        note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                        note.domain.displayName
                     } • ${relativeDateLabel(note.updatedAt)}",
                     style = MaterialTheme.typography.labelSmall,
                     color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
@@ -11,12 +11,13 @@ import com.tajemniktv.tajsos.data.isTaskItem
 
 /**
  * Local domain grouping used by the Notes workspace left-rail filters.
+ * @property displayName Pre-computed localized or display-ready label for UI performance.
  */
-enum class NotesDomain {
-    PERSONAL,
-    STUDY,
-    WORK,
-    HEALTH,
+enum class NotesDomain(val displayName: String) {
+    PERSONAL("Personal"),
+    STUDY("Study"),
+    WORK("Work"),
+    HEALTH("Health"),
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -189,7 +189,7 @@ private fun renderSettingsFeaturePacks(context: SettingsDashboardContext) {
                     Text(
                         text =
                             buildString {
-                                append(pack.key.replaceFirstChar { it.uppercase() })
+                                append(pack.displayName)
                                 append(if (pack.isFree) " (Free)" else " (Premium)")
                             },
                         style = MaterialTheme.typography.bodyLarge,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PackRegistry.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PackRegistry.kt
@@ -10,20 +10,22 @@ import androidx.compose.runtime.Immutable
  * Represents the available feature packs in TajsOS.
  *
  * @property key The unique identifier string for the pack.
+ * @property displayName Pre-computed localized or display-ready label for UI performance.
  * @property isFree Indicates whether the pack is available for free or requires purchase/subscription.
  * @property dependencies A set of pack keys that must be enabled for this pack to function. Defaults to an empty set.
  */
 enum class AppPack(
     val key: String,
+    val displayName: String,
     val isFree: Boolean,
     val dependencies: Set<String> = emptySet(),
 ) {
-    STUDENT("student", isFree = false),
-    CREATOR("creator", isFree = false),
-    FINANCE("finance", isFree = false, dependencies = setOf("maintenance")),
-    PEOPLE("people", isFree = false),
-    MAINTENANCE("maintenance", isFree = true),
-    PROTOCOLS("protocols", isFree = true),
+    STUDENT("student", "Student", isFree = false),
+    CREATOR("creator", "Creator", isFree = false),
+    FINANCE("finance", "Finance", isFree = false, dependencies = setOf("maintenance")),
+    PEOPLE("people", "People", isFree = false),
+    MAINTENANCE("maintenance", "Maintenance", isFree = true),
+    PROTOCOLS("protocols", "Protocols", isFree = true),
     ;
 
     companion object {


### PR DESCRIPTION
Replaces dynamic `.replaceFirstChar()` usage during Compose UI recomposition with static, pre-computed properties in `NotesDomain` and `AppPack`.

---
*PR created automatically by Jules for task [2692571343540930370](https://jules.google.com/task/2692571343540930370) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

