### PR TITLE
test: add missing tests for domain lens queries and sync dtos

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesDeadlineItemsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesDeadlineItemsTest.kt
@@ -1,0 +1,41 @@
+package com.tajemniktv.tajsos.domain.lens
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DomainLensQueriesDeadlineItemsTest {
+
+    @Test
+    fun financeDeadlineItems_excludes_items_without_deadline() {
+        val nodeWithDeadline = createTestNode(id = 1, title = "Pay tax", status = "active", dueAt = 1000L, tags = listOf("finance"))
+        val nodeWithoutDeadline = createTestNode(id = 2, title = "Review budget", status = "active", dueAt = null, tags = listOf("finance"))
+
+        val result = DomainLensQueries.financeDeadlineItems(listOf(nodeWithDeadline, nodeWithoutDeadline))
+
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.id)
+    }
+
+    @Test
+    fun financeDeadlineItems_excludes_inactive_items() {
+        val activeNode = createTestNode(id = 1, title = "Pay tax", status = "active", dueAt = 1000L, tags = listOf("finance"))
+        val doneNode = createTestNode(id = 2, title = "Paid tax", status = "done", dueAt = 1000L, tags = listOf("finance"))
+
+        val result = DomainLensQueries.financeDeadlineItems(listOf(activeNode, doneNode))
+
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.id)
+    }
+
+    @Test
+    fun financeDeadlineItems_includes_both_tasks_and_notes() {
+        val taskNode = createTestNode(id = 1, title = "Pay tax", status = "active", dueAt = 1000L, type = "task", tags = listOf("finance"))
+        val noteNode = createTestNode(id = 2, title = "Tax deadline", status = "active", dueAt = 2000L, type = "note", tags = listOf("finance"))
+        val unrelatedTask = createTestNode(id = 3, title = "Normal task", status = "active", dueAt = 3000L, type = "task", tags = emptyList())
+
+        val result = DomainLensQueries.financeDeadlineItems(listOf(taskNode, noteNode, unrelatedTask))
+
+        assertEquals(2, result.size)
+        assertEquals(setOf(1L, 2L), result.map { it.node.id }.toSet())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesKnowledgeItemsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesKnowledgeItemsTest.kt
@@ -1,0 +1,51 @@
+package com.tajemniktv.tajsos.domain.lens
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DomainLensQueriesKnowledgeItemsTest {
+
+    @Test
+    fun financeKnowledgeItems_excludes_inactive_items() {
+        val activeFinanceNote = createTestNode(id = 1, title = "Tax reference", type = "note", noteType = "reference", status = "active", tags = listOf("finance"))
+        val archivedFinanceNote = createTestNode(id = 2, title = "Old budget", type = "note", noteType = "reference", status = "archived", tags = listOf("finance"))
+        val activeNonFinanceNote = createTestNode(id = 3, title = "Random thoughts", type = "note", status = "active")
+
+        val result = DomainLensQueries.financeKnowledgeItems(listOf(activeFinanceNote, archivedFinanceNote, activeNonFinanceNote))
+
+        assertEquals(setOf(1L), result.map { it.node.id }.toSet())
+    }
+
+    @Test
+    fun financeKnowledgeItems_excludes_non_knowledge_items() {
+        val financeNote = createTestNode(id = 1, title = "Tax reference", type = "note", noteType = "reference", tags = listOf("finance"))
+        val financeRecord = createTestNode(id = 2, title = "Paid tax", type = "record", tags = listOf("finance"))
+        val financeTask = createTestNode(id = 3, title = "Pay tax", type = "task", tags = listOf("finance"))
+
+        val result = DomainLensQueries.financeKnowledgeItems(listOf(financeNote, financeRecord, financeTask))
+
+        assertEquals(setOf(1L, 2L), result.map { it.node.id }.toSet())
+    }
+
+    @Test
+    fun healthKnowledgeItems_excludes_inactive_items() {
+        val activeHealthNote = createTestNode(id = 1, title = "Medical history", type = "note", status = "active", tags = listOf("health"))
+        val archivedHealthNote = createTestNode(id = 2, title = "Old symptoms", type = "note", status = "archived", tags = listOf("health"))
+        val activeNonHealthNote = createTestNode(id = 3, title = "Meeting notes", type = "note", status = "active")
+
+        val result = DomainLensQueries.healthKnowledgeItems(listOf(activeHealthNote, archivedHealthNote, activeNonHealthNote))
+
+        assertEquals(setOf(1L), result.map { it.node.id }.toSet())
+    }
+
+    @Test
+    fun healthKnowledgeItems_excludes_non_knowledge_items() {
+        val healthNote = createTestNode(id = 1, title = "Medical history", type = "note", tags = listOf("health"))
+        val healthRecord = createTestNode(id = 2, title = "Symptom log", type = "record", tags = listOf("health"))
+        val healthTask = createTestNode(id = 3, title = "See doctor", type = "task", tags = listOf("health"))
+
+        val result = DomainLensQueries.healthKnowledgeItems(listOf(healthNote, healthRecord, healthTask))
+
+        assertEquals(setOf(1L, 2L), result.map { it.node.id }.toSet())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMaintenanceItemsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMaintenanceItemsTest.kt
@@ -1,0 +1,67 @@
+package com.tajemniktv.tajsos.domain.lens
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.data.TagEntity
+import com.tajemniktv.tajsos.ui.MaintenanceSnapshot
+import com.tajemniktv.tajsos.ui.MaintenanceStatusItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DomainLensQueriesMaintenanceItemsTest {
+
+    private fun createMaintenanceItem(
+        id: Long,
+        maintenanceType: String?,
+        title: String = "Test Item",
+        tags: List<String> = emptyList()
+    ): MaintenanceStatusItem {
+        return MaintenanceStatusItem(
+            node = NodeWithPin(
+                node = NodeEntity(
+                    id = id,
+                    title = title,
+                    type = "maintenance",
+                    maintenanceType = maintenanceType,
+                    status = "active"
+                ),
+                pin = null,
+                tags = tags.mapIndexed { index, tag -> TagEntity(id = index.toLong(), name = tag, normalizedName = tag.lowercase()) }
+            ),
+            urgency = "high",
+            isRecurring = true
+        )
+    }
+
+    @Test
+    fun financeMaintenanceItems_filters_by_maintenance_type() {
+        val financeBill = createMaintenanceItem(1, "bill", tags = listOf("finance"))
+        val healthAppointment = createMaintenanceItem(2, "appointment", tags = listOf("health"))
+
+        val snapshot = MaintenanceSnapshot(
+            active = listOf(financeBill, healthAppointment),
+            recurring = emptyList(),
+            overdue = emptyList()
+        )
+
+        val result = DomainLensQueries.financeMaintenanceItems(snapshot)
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.node.id)
+    }
+
+    @Test
+    fun healthMaintenanceItems_filters_by_maintenance_type() {
+        val financeBill = createMaintenanceItem(1, "bill", tags = listOf("finance"))
+        val healthAppointment = createMaintenanceItem(2, "appointment", tags = listOf("health"))
+
+        val snapshot = MaintenanceSnapshot(
+            active = listOf(financeBill, healthAppointment),
+            recurring = emptyList(),
+            overdue = emptyList()
+        )
+
+        val result = DomainLensQueries.healthMaintenanceItems(snapshot)
+        assertEquals(1, result.size)
+        assertEquals(2L, result.first().node.node.id)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/dto/SyncDtosTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/dto/SyncDtosTest.kt
@@ -1,0 +1,80 @@
+package com.tajemniktv.tajsos.dto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class SyncDtosTest {
+    @Test
+    fun testSyncRequestDefaults() {
+        val request = SyncRequest(
+            lastSyncTime = 12345L,
+            items = emptyList()
+        )
+        assertEquals(1, request.protocolVersion)
+        assertNull(request.clientId)
+        assertEquals(12345L, request.lastSyncTime)
+        assertTrue(request.items.isEmpty())
+        assertTrue(request.enabledPacks.isEmpty())
+    }
+
+    @Test
+    fun testSyncItemDefaults() {
+        val item = SyncItem(
+            id = "item-1",
+            entityType = "NodeEntity",
+            payload = "{}",
+            updatedAt = 1000L
+        )
+        assertEquals("item-1", item.id)
+        assertEquals("NodeEntity", item.entityType)
+        assertEquals("{}", item.payload)
+        assertEquals(1000L, item.updatedAt)
+        assertFalse(item.isDeleted)
+        assertEquals("upsert", item.operation)
+        assertEquals(1, item.payloadVersion)
+    }
+
+    @Test
+    fun testSyncResponseDefaults() {
+        val response = SyncResponse(
+            serverTime = 54321L,
+            items = emptyList()
+        )
+        assertEquals(1, response.protocolVersion)
+        assertEquals(54321L, response.serverTime)
+        assertTrue(response.items.isEmpty())
+        assertTrue(response.conflicts.isEmpty())
+        assertTrue(response.ackedItemIds.isEmpty())
+    }
+
+    @Test
+    fun testHealthResponse() {
+        val health = HealthResponse(
+            status = "ok",
+            version = "1.0.0",
+            uptime = 9999L
+        )
+        assertEquals("ok", health.status)
+        assertEquals("1.0.0", health.version)
+        assertEquals(9999L, health.uptime)
+    }
+
+    @Test
+    fun testErrorResponse() {
+        val error = ErrorResponse(
+            error = "Not Found",
+            details = "Item not found"
+        )
+        assertEquals("Not Found", error.error)
+        assertEquals("Item not found", error.details)
+
+        val errorNoDetails = ErrorResponse(
+            error = "Bad Request"
+        )
+        assertEquals("Bad Request", errorNoDetails.error)
+        assertNull(errorNoDetails.details)
+    }
+}


### PR DESCRIPTION
Adds comprehensive test coverage for synchronization DTOs and previously untested DomainLensQueries methods (deadline items, maintenance items, and knowledge items). This improves test robustness against regressions.

---
*PR created automatically by Jules for task [6091333675330590675](https://jules.google.com/task/6091333675330590675) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

