### PR TITLE
test: add edge cases for health signal matching with keywords

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesMatchesSignalTest.kt
@@ -190,4 +190,13 @@ class DomainLensQueriesMatchesSignalTest {
         val result = DomainLensQueries.healthActionItems(listOf(node1, node2))
         assertDomainQueryResult(listOf(1L, 2L), result)
     }
+
+    @Test
+    fun matchesHealthSignal_with_title_and_content_keywords() {
+        val titleMatch = createNode(1, "my health is good", type = "note", noteType = "other")
+        val contentMatch = createNode(2, "diary", "need mental_health check", type = "note", noteType = "other")
+        val result = DomainLensQueries.healthKnowledgeItems(listOf(titleMatch, contentMatch))
+        assertDomainQueryResult(listOf(1L, 2L), result)
+    }
+
 }


### PR DESCRIPTION
Added unit tests to `DomainLensQueriesMatchesSignalTest` to verify that `healthKnowledgeItems` properly extracts signals based on title and content keywords like 'health' and 'mental_health'.

---
*PR created automatically by Jules for task [17652823278604305052](https://jules.google.com/task/17652823278604305052) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

