### PR TITLE
perf: optimize NotesDomain enum formatting to avoid runtime allocations

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -114,9 +114,7 @@ fun NotesContextPanel(
             item {
                 ContextSection(title = "Domain", icon = Icons.Default.Category) {
                     Text(
-                        selectedNote.domain.name
-                            .lowercase()
-                            .replaceFirstChar(Char::titlecase),
+                        selectedNote.domain.displayName,
                         color = TajsOSTheme.Text,
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -108,9 +108,7 @@ fun NotesEditorPane(
             Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 Column(modifier = Modifier.fillMaxWidth().widthIn(max = 880.dp)) {
                     Text(
-                        text = "NOTES > ${
-                            note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
-                        }",
+                        text = "NOTES > ${note.domain.displayName}",
                         style = MaterialTheme.typography.labelSmall,
                         color = TajsOSTheme.Muted,
                     )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -296,9 +296,7 @@ fun NotesListItem(
                     overflow = TextOverflow.Ellipsis,
                 )
                 Text(
-                    text = "${
-                        note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
-                    } • ${relativeDateLabel(note.updatedAt)}",
+                    text = "${note.domain.displayName} • ${relativeDateLabel(note.updatedAt)}",
                     style = MaterialTheme.typography.labelSmall,
                     color = TajsOSTheme.Muted,
                     maxLines = 1,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
@@ -16,7 +16,14 @@ enum class NotesDomain {
     PERSONAL,
     STUDY,
     WORK,
-    HEALTH,
+    HEALTH;
+
+    /**
+     * Pre-computed display name to prevent repetitive string allocations during UI recomposition.
+     * Formats the enum constant name (e.g., "PERSONAL" -> "Personal").
+     */
+    val displayName: String =
+        name.lowercase().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
 }
 
 /**


### PR DESCRIPTION
Extracts the dynamic `replaceFirstChar` formatting logic out of the Compose UI layer into a pre-computed `displayName` property directly on the `NotesDomain` enum. This avoids unnecessary runtime string allocations and transformations during Jetpack Compose recompositions across the Notes workspace (e.g. `NotesContextPanel`, `NotesListRail`, `NotesEditorPane`).

---
*PR created automatically by Jules for task [15284240913499058417](https://jules.google.com/task/15284240913499058417) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

