### PR TITLE
fix(website): resolve 404 route collision in starlight config

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
         src: "./src/assets/logo.png",
         alt: "TajsOS Logo",
       },
+      disable404Route: true,
       plugins: [
         starlightBlog(),
         starlightLinksValidator(),


### PR DESCRIPTION
Resolves Starlight 404 route collision by adding `disable404Route: true` to the Starlight config in `astro.config.mjs`.

---
*PR created automatically by Jules for task [17865894362623042788](https://jules.google.com/task/17865894362623042788) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

