### PR TITLE
docs: improve KDocs for DomainLensQueries and UserDao

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -911,6 +911,9 @@ interface DecisionDao {
 
 /**
  * Provides database access for retrieving the primary application [UserEntity] identity profile.
+ *
+ * The application currently operates on a single-user model, so queries generally
+ * target a unified profile singleton (e.g., `id = 1`).
  */
 @Dao
 interface UserDao {

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -100,17 +100,12 @@ private val healthTitleKeywords =
     )
 
 /**
- * Provides static heuristic queries to categorize active nodes into broader LifeOS domains.
+ * Provides heuristic-based query functions to categorize un-typed [NodeWithPin] and [MaintenanceStatusItem]
+ * entities into specific top-level domains (e.g., Finance, Health) for the UI.
  *
- * This singleton relies heavily on zero-configuration implicit matching—such as tags,
- * keywords within title and content, maintenance types, and specific note types—rather than explicit database
- * entity associations. This design significantly lowers the friction of capturing new items,
- * ensuring they surface in relevant domains (like Finances or Health) automatically.
- *
- * This object evaluates the system's shared nodes (tasks, notes, records) and determines
- * if they implicitly belong to a specific LifeOS domain (like Finance or Health) based on
- * explicit markers such as tags, titles, content keywords, maintenance types, or specific
- * note types (e.g., reflections vs references).
+ * This object implements the zero-configuration domain strategy described in [com.tajemniktv.tajsos.domain.DomainKind].
+ * Instead of querying explicit database relations (like ItemDomainEntity), it filters lists in-memory
+ * by examining node metadata: tags, keywords, maintenance types, and note types.
  *
  * This zero-configuration design intentionally bypasses strict associative models
  * (like `ItemDomainEntity`) so users are not forced to explicitly classify every


### PR DESCRIPTION
This PR improves the KDoc for the `DomainLensQueries` object by explaining its heuristic-based zero-configuration logic. It also adds a missing KDoc for the `UserDao` class, documenting the unstated assumption that the application uses a single-user architecture targeting `id = 1`.

---
*PR created automatically by Jules for task [15502479014966180648](https://jules.google.com/task/15502479014966180648) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

