### PR TITLE
fix(config): disable Starlight 404 route to avoid collisions

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -21,6 +21,8 @@ export default defineConfig({
       title: "Docs",
       description: "TajsOS Documentation",
 
+      disable404Route: true,
+
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",
       },


### PR DESCRIPTION
This commit fixes a build warning in the Astro project (`The route "/404" is defined in both "src/pages/404.astro" and "node_modules/@astrojs/starlight/routes/static/404.astro"`) by explicitly disabling the Starlight 404 route via `disable404Route: true` in `astro.config.mjs`, allowing our custom `404.astro` to take precedence without collisions.

---
*PR created automatically by Jules for task [5239198413011447590](https://jules.google.com/task/5239198413011447590) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

