### PR TITLE
test: add empty state tests for calculateInsights

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsInsightsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculatorsInsightsTest.kt
@@ -1,0 +1,14 @@
+package com.tajemniktv.tajsos.ui.main.calculators
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MainSnapshotCalculatorsInsightsTest {
+    @Test
+    fun testEmptyData() {
+        val insights = calculateInsights(emptyList(), emptyList(), emptyList(), emptyList())
+        assertEquals(0, insights.avgSessionMinutes)
+        assertEquals(0, insights.bestFocusHour)
+        assertEquals(0, insights.mostProductiveHour)
+    }
+}


### PR DESCRIPTION
Adds unit tests to cover empty input collections for the `calculateInsights` function to ensure robust default behavior and improve regression protection.

---
*PR created automatically by Jules for task [11185254313061271982](https://jules.google.com/task/11185254313061271982) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

