### PR TITLE
docs: add missing KDocs in PreferencesRepository

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -274,6 +274,9 @@ class PreferencesRepository(
         }
     }
 
+    /**
+     * Persists the dark theme preference.
+     */
     suspend fun updateDarkThemeEnabled(enabled: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.DARK_THEME_ENABLED] = enabled
@@ -309,6 +312,11 @@ class PreferencesRepository(
         }
     }
 
+    /**
+     * Enables or disables a specific pack in the user's preferences.
+     *
+     * Note: A pack can only be enabled if it is currently owned by the user.
+     */
     suspend fun setPackEnabled(
         pack: AppPack,
         enabled: Boolean,
@@ -326,6 +334,11 @@ class PreferencesRepository(
         }
     }
 
+    /**
+     * Updates the ownership status of a specific pack.
+     *
+     * If ownership is revoked for a non-free pack, it is also automatically disabled.
+     */
     suspend fun setPackOwned(
         pack: AppPack,
         owned: Boolean,
@@ -351,6 +364,11 @@ class PreferencesRepository(
         }
     }
 
+    /**
+     * Verifies that the user has ownership and enabled status for all default free packs.
+     *
+     * If any default free packs are missing from the user's preferences, they will be automatically added.
+     */
     suspend fun ensureDefaultPackAccess() {
         dataStore.edit { preferences ->
             val owned = (preferences[PreferencesKeys.OWNED_PACKS] ?: emptySet()).toMutableSet()


### PR DESCRIPTION
Added missing KDocs to `PreferencesRepository` functions (`updateDarkThemeEnabled`, `setPackEnabled`, `setPackOwned`, `ensureDefaultPackAccess`) to explicitly document their behavior, business rules, and contracts, improving code readability and reducing onboarding friction.

---
*PR created automatically by Jules for task [14952564586156795352](https://jules.google.com/task/14952564586156795352) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

