### PR TITLE
perf: Pre-compute domain display names to avoid redundant string allocations in UI

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -114,9 +114,7 @@ fun NotesContextPanel(
             item {
                 ContextSection(title = "Domain", icon = Icons.Default.Category) {
                     Text(
-                        selectedNote.domain.name
-                            .lowercase()
-                            .replaceFirstChar(Char::titlecase),
+                        selectedNote.domain.displayName,
                         color = TajsOSTheme.Text,
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -109,7 +109,7 @@ fun NotesEditorPane(
                 Column(modifier = Modifier.fillMaxWidth().widthIn(max = 880.dp)) {
                     Text(
                         text = "NOTES > ${
-                            note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                            note.domain.displayName
                         }",
                         style = MaterialTheme.typography.labelSmall,
                         color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -297,7 +297,7 @@ fun NotesListItem(
                 )
                 Text(
                     text = "${
-                        note.domain.name.lowercase().replaceFirstChar(Char::titlecase)
+                        note.domain.displayName
                     } • ${relativeDateLabel(note.updatedAt)}",
                     style = MaterialTheme.typography.labelSmall,
                     color = TajsOSTheme.Muted,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceModels.kt
@@ -11,12 +11,14 @@ import com.tajemniktv.tajsos.data.isTaskItem
 
 /**
  * Local domain grouping used by the Notes workspace left-rail filters.
+ *
+ * @property displayName The pre-formatted, user-facing display name of the domain.
  */
-enum class NotesDomain {
-    PERSONAL,
-    STUDY,
-    WORK,
-    HEALTH,
+enum class NotesDomain(val displayName: String) {
+    PERSONAL("Personal"),
+    STUDY("Study"),
+    WORK("Work"),
+    HEALTH("Health");
 }
 
 /**


### PR DESCRIPTION
This PR identifies a small but measurable performance bottleneck where string manipulations (`.lowercase().replaceFirstChar(Char::titlecase)`) were occurring directly inside Compose UI functions for rendering `NotesDomain` labels. 

To resolve this, the PR updates the `NotesDomain` enum to pre-compute and store its own user-facing display string (`displayName`). The Compose functions in `NotesListRail`, `NotesEditorPane`, and `NotesContextPanel` have been updated to reference this pre-computed property instead of performing string allocations on every recomposition.

Additionally, a KDoc has been added to the `displayName` property in the enum to document its intent and usage.

---
*PR created automatically by Jules for task [10758940434173026397](https://jules.google.com/task/10758940434173026397) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

