### PR TITLE
docs: Add missing KDocs to NodeDao queries

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -17,10 +17,21 @@ import kotlinx.coroutines.flow.Flow
  */
 @Dao
 interface NodeDao {
+    /**
+     * Retrieves all nodes along with their today-pin information, ordered by creation time descending.
+     *
+     * @return A Flow emitting lists of NodeWithPin for all nodes.
+     */
     @Transaction
     @Query("SELECT * FROM nodes ORDER BY createdAt DESC")
     fun getAllNodesWithPins(): Flow<List<NodeWithPin>>
 
+    /**
+     * Retrieves active nodes pinned for the given date, ordered by their pinned position.
+     *
+     * @param date The date string to filter pins by.
+     * @return A Flow emitting lists of active NodeEntity objects pinned for the specified date.
+     */
     @Query(
         """
         SELECT nodes.* FROM nodes 
@@ -97,6 +108,12 @@ interface NodeDao {
     @Query("SELECT * FROM nodes WHERE id = :id")
     suspend fun getNodeById(id: Long): NodeEntity?
 
+    /**
+     * Fetches nodes matching the given list of primary keys.
+     *
+     * @param ids A list of node primary keys.
+     * @return A list of matching NodeEntity objects.
+     */
     @Query("SELECT * FROM nodes WHERE id IN (:ids)")
     suspend fun getNodesByIds(ids: List<Long>): List<NodeEntity>
 
@@ -111,6 +128,9 @@ interface NodeDao {
 
     /**
      * Inserts multiple nodes, returning their generated or existing identifiers.
+     *
+     * @param nodes The list of [NodeEntity] to insert.
+     * @return A list of generated or existing primary key IDs of the inserted nodes.
      */
     @Upsert
     suspend fun insertNodes(nodes: List<NodeEntity>): List<Long>


### PR DESCRIPTION
This PR adds missing KDoc comments to several public functions in `NodeDao` interface (like `getAllNodesWithPins`, `getTodayNodes`, `getNodesByIds`, and `insertNodes`). This improves the documentation coverage for database query methods and aligns with the documentation goal of clarifying system behavior.

---
*PR created automatically by Jules for task [3487694855240765308](https://jules.google.com/task/3487694855240765308) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

