### PR TITLE
fix(docs): resolve Starlight 404 route collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "Docs",
+      disable404Route: true,
       description: "TajsOS Documentation",
 
       components: {


### PR DESCRIPTION
Added `disable404Route: true` to the Starlight integration config to resolve a static route collision warning between the default Starlight 404 route and our custom `src/pages/404.astro` page.

---
*PR created automatically by Jules for task [12940982792123297730](https://jules.google.com/task/12940982792123297730) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

