### PR TITLE
docs: Add missing KDocs to core data entities and repository methods

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Daos.kt
@@ -17,10 +17,19 @@ import kotlinx.coroutines.flow.Flow
  */
 @Dao
 interface NodeDao {
+    /**
+     * Returns a reactive flow of all nodes in the system, ordered from newest to oldest.
+     * It joins with the [TodayPinEntity] table to include the `isPinned` status.
+     */
     @Transaction
     @Query("SELECT * FROM nodes ORDER BY createdAt DESC")
     fun getAllNodesWithPins(): Flow<List<NodeWithPin>>
 
+    /**
+     * Returns nodes explicitly pinned to the specified date (e.g. "today").
+     *
+     * @param date The date string to filter by.
+     */
     @Query(
         """
         SELECT nodes.* FROM nodes 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Entities.kt
@@ -340,7 +340,9 @@ data class ModePreferenceEntity(
 )
 
 /**
- * ModeAreaFilterEntity filters which areas are visible in a mode.
+ * Represents an area filtering constraint attached to a Focus Mode.
+ *
+ * If a mode has area filters, only items belonging to the specified `areaId`s are visible.
  */
 @Entity(
     tableName = "mode_area_filters",
@@ -354,7 +356,9 @@ data class ModeAreaFilterEntity(
 )
 
 /**
- * ModeTypeFilterEntity filters which node types are visible in a mode.
+ * Represents a semantic type filtering constraint attached to a Focus Mode.
+ *
+ * If a mode has type filters, only items of the specified `itemType` (e.g., 'task', 'note') are visible.
  */
 @Entity(
     tableName = "mode_type_filters",
@@ -584,7 +588,9 @@ data class MedicationEntity(
 )
 
 /**
- * TrackMedicationJoinEntity tracks whether a specific medication was taken for a specific track entry.
+ * A many-to-many join entity associating a [TrackEntryEntity] with a [MedicationEntity].
+ *
+ * Represents the act of logging the intake of a specific medication during a specific health check-in.
  */
 @Entity(
     tableName = "track_medications",
@@ -643,7 +649,7 @@ data class TagEntity(
 )
 
 /**
- * ItemTagEntity is a join table for items and tags.
+ * A many-to-many join entity associating a node with a tag.
  */
 @Entity(
     tableName = "node_tags",
@@ -678,7 +684,9 @@ data class EventLogEntity(
 )
 
 /**
- * AttachmentEntity stores links or references to assets.
+ * Represents a file or external resource linked to a specific node.
+ *
+ * The `uri` or `path` specifies where the binary data lives, outside the database.
  */
 @Entity(
     tableName = "attachments",

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectEntities.kt
@@ -171,6 +171,10 @@ data class RichContentDocumentEntity(
 /**
  * Attach-able schedule layer for any item.
  *
+ * Provides the explicit database fields (e.g. `scheduledAt`, `isAllDay`, `recurrenceRule`)
+ * to define when a particular item happens without coupling the temporal data directly
+ * to the primary node schema.
+ *
  * Existing node time fields remain mirrored for legacy UI compatibility, but new code should
  * prefer this explicit table.
  */
@@ -194,7 +198,10 @@ data class ScheduleEntryEntity(
 )
 
 /**
- * Saved projection over shared life objects.
+ * Represents a configured projection ("view") over life objects in the database.
+ *
+ * Stores layout preferences (`lens`, `layout`), dimensional groupings, and metadata.
+ * It acts as the anchor table for a view's configurations (like filters, sorts).
  *
  * The view describes how to slice typed data without inventing a competing ontology.
  */
@@ -217,7 +224,7 @@ data class SavedViewEntity(
 )
 
 /**
- * Source object kinds targeted by a saved view.
+ * Join table defining which core object kinds (e.g., tasks, notes) are targeted by a [SavedViewEntity].
  */
 @Entity(
     tableName = "saved_view_source_kinds",
@@ -231,7 +238,10 @@ data class SavedViewSourceKindEntity(
 )
 
 /**
- * Persisted filters for a saved view.
+ * Represents a specific filter rule for a [SavedViewEntity].
+ *
+ * Defines logic (via `fieldKey`, `operatorKey`, `value`) to restrict items matching the view.
+ * Ordered sequentially by the `position` field.
  */
 @Entity(
     tableName = "saved_view_filters",
@@ -249,7 +259,9 @@ data class SavedViewFilterEntity(
 )
 
 /**
- * Persisted sort instructions for a saved view.
+ * Defines the sorting order rules for a [SavedViewEntity].
+ *
+ * Applies sorting by a specific `fieldKey` in either ascending or descending `direction`.
  */
 @Entity(
     tableName = "saved_view_sorts",
@@ -265,7 +277,7 @@ data class SavedViewSortEntity(
 )
 
 /**
- * Persisted visible-column configuration for a saved view.
+ * Declares which columns or fields are actively visible in a [SavedViewEntity] layout (like a table).
  */
 @Entity(
     tableName = "saved_view_visible_fields",

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -1223,6 +1223,9 @@ class AppRepository(
         }
     }
 
+    /**
+     * Returns a reactive flow of all health/habit track entries.
+     */
     fun getAllTrackEntries(): Flow<List<TrackEntryEntity>> = trackDao.getAllTrackEntries()
 
     suspend fun insertTrackEntry(entry: TrackEntryEntity): Long {
@@ -1233,8 +1236,14 @@ class AppRepository(
     }
 
     // Relations
+    /**
+     * Returns a reactive flow of all relations (edges) currently in the knowledge graph.
+     */
     fun getAllRelations() = relationDao.getAllRelations()
 
+    /**
+     * Retrieves all incoming and outgoing relations for a specific node.
+     */
     fun getRelationsForNode(nodeId: Long) = relationDao.getRelationsForNode(nodeId)
 
     suspend fun insertRelation(relation: RelationEntity) {
@@ -1299,6 +1308,10 @@ class AppRepository(
     suspend fun deleteAttachment(attachment: AttachmentEntity) = attachmentDao.deleteAttachment(attachment)
 
     // Domains
+    /**
+     * Reconstructs the domain assignments (areas/projects) for a given item by combining its facets.
+     * It returns a list of [DomainAssignment] containing the loaded entity models.
+     */
     fun getDomainsForItem(itemId: Long): Flow<List<DomainAssignment>> =
         itemDomainDao.getDomainsForItem(itemId).map { domains ->
             domains.mapNotNull { it.toModel() }
@@ -1327,6 +1340,10 @@ class AppRepository(
     ) = itemDomainDao.deleteDomain(itemId, domain.name)
 
     // Documents
+    /**
+     * Retrieves the [RichContentDocument] data model containing rich text blocks
+     * for a specific item, or null if the item has no document attached.
+     */
     fun getDocumentForItem(itemId: Long): Flow<RichContentDocument?> =
         richContentDocumentDao.observeDocumentForItem(itemId).map { document ->
             document?.toModel()
@@ -1370,6 +1387,10 @@ class AppRepository(
     suspend fun deleteDocumentForItem(itemId: Long) = richContentDocumentDao.deleteDocumentForItem(itemId)
 
     // Saved views
+    /**
+     * Builds and returns a reactive flow of all [SavedViewDefinition]s,
+     * which combine the core [SavedViewEntity] with its filters, sorts, and visible fields.
+     */
     fun getSavedViews(): Flow<List<SavedViewDefinition>> =
         combine(
             savedViewDao.getAllSavedViews(),
@@ -1501,6 +1522,9 @@ class AppRepository(
     suspend fun deleteTemplate(template: TemplateEntity) = templateDao.deleteTemplate(template)
 
     // Snapshots
+    /**
+     * Retrieves all historical [NodeSnapshotEntity] records for a specific node.
+     */
     fun getSnapshotsForNode(nodeId: Long) = nodeSnapshotDao.getSnapshotsForNode(nodeId)
 
     suspend fun insertSnapshot(snapshot: NodeSnapshotEntity) = nodeSnapshotDao.insertSnapshot(snapshot)
@@ -1554,6 +1578,11 @@ class AppRepository(
         timestamp: Long,
     ) = modeDao.deactivateLog(id, timestamp)
 
+    /**
+     * Constructs a [ModeQueryProfile] for a focus mode, which aggregates
+     * the mode's entity alongside its configured area and type filters.
+     * Useful for passing a fully loaded mode configuration into view models.
+     */
     fun getModeQueryProfile(modeId: Long): Flow<ModeQueryProfile?> =
         getPreferencesForMode(modeId).map { preference ->
             if (preference == null) return@map null
@@ -1715,6 +1744,9 @@ class AppRepository(
 
     suspend fun deleteDecisionOption(option: DecisionOptionEntity) = decisionDao.deleteDecisionOption(option)
 
+    /**
+     * Returns the singleton [UserEntity] representing the current app owner's profile.
+     */
     fun getUser(): Flow<UserEntity?> = userDao.getUser()
 
     suspend fun insertUser(user: UserEntity) = userDao.insertUser(user)
@@ -1737,6 +1769,9 @@ class AppRepository(
         userDao.insertUser(profile.toEntity(existing))
     }
 
+    /**
+     * Returns a reactive flow of all available [MedicationEntity] definitions.
+     */
     fun getAllMedications(): Flow<List<MedicationEntity>> = medicationDao.getAllMedications()
 
     suspend fun insertMedication(medication: MedicationEntity): Long {


### PR DESCRIPTION
This pull request adds missing KDocs to several core data entities, Data Access Objects (DAOs), and Repository methods across the project. 

Specifically, it addresses:
*   Adding explicit documentation to `NodeDao` queries indicating what is retrieved and joined.
*   Documenting the purpose of decoupled `LifeObject` tables such as `ScheduleEntryEntity` and the elements of `SavedViewEntity`.
*   Explaining graph capabilities and semantic linkage on `RelationEntity`, `AttachmentEntity`, and `NodeSnapshotEntity`.
*   Providing context for aggregation and reconstruction methods inside `Repository.kt`.

This PR reduces onboarding friction by making the intent and relationships within the local persistence model much clearer. No logic changes were made.

---
*PR created automatically by Jules for task [11012224054710697811](https://jules.google.com/task/11012224054710697811) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

