### PR TITLE
fix(config): disable starlight 404 route to prevent collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
This PR resolves a static route collision warning that occurs during the build process of the Astro website. 

The Starlight documentation integration injects its own default `404` route, which conflicts with the custom `src/pages/404.astro` page designed for the main website. By setting `disable404Route: true` in the Starlight configuration, we instruct Starlight not to inject its 404 route, allowing the root `404.astro` page to correctly handle all "Not Found" errors across the site without build warnings.

---
*PR created automatically by Jules for task [4184714627279471927](https://jules.google.com/task/4184714627279471927) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

