### PR TITLE
perf: Optimize list size calculations with distinctBy

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -1708,6 +1708,8 @@ fun calculateVaultsSnapshot(nodes: List<NodeWithPin>): VaultsSnapshot {
  *
  * @param inputs A bundled dataset providing current node volumes, maintenance debt, and open loops.
  * @return A [CapacitySnapshot] identifying execution pressure and potential burnout risks.
+ *
+ * Performance note: uses distinctBy instead of groupBy when only unique sizes are needed.
  */
 fun calculateCapacitySnapshot(
     nodes: List<NodeWithPin>,
@@ -1734,11 +1736,12 @@ fun calculateCapacitySnapshot(
                 (maintenance.overdue.size * 4) +
                 (overdueCount * 5)
         ).coerceIn(0, 100)
+    // Optimized from groupBy to distinctBy for performance
     val fragmentationScore =
         (
-                activeTasks.groupBy { it.node.projectId }.size *
+                activeTasks.distinctBy { it.node.projectId }.size *
                         7 +
-                        activeTasks.groupBy { it.node.areaId }.size *
+                        activeTasks.distinctBy { it.node.areaId }.size *
                         4
         ).coerceIn(0, 100)
 
@@ -1761,8 +1764,9 @@ fun calculateCapacitySnapshot(
         nodes.count { it.node.status == "done" && (it.node.completedAt ?: 0L) >= now - weekMs }
     val unrealisticWeekSignal =
         if (weeklyCreatedActive > weeklyDone * 2 + 5) "THIS WEEK IS UNREALISTIC // INTAKE OUTPACES EXECUTION" else null
+    // Optimized from groupBy to distinctBy for performance
     val tooManyActiveFrontsIndicator =
-        if (activeTasks.groupBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
+        if (activeTasks.distinctBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
     val attentionFragmentedIndicator =
         if (fragmentationScore >= 55) "ATTENTION IS TOO FRAGMENTED" else null
     val weeklyStructuralOverloadWarning =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -329,6 +329,8 @@ fun buildPlaybookSnapshot(
  * @param areasList The list of all system Area nodes.
  * @param packs The registry of enabled and owned application packs.
  * @return A fully populated [DashboardUIState] reflecting the entire system's status filtered by the active mode.
+ *
+ * Performance note: uses distinctBy instead of groupBy when only unique sizes are needed.
  */
 suspend fun buildDashboardUIState(
     repository: AppRepository,
@@ -443,7 +445,8 @@ suspend fun buildDashboardUIState(
     val areaHealthMetrics = areaSnapshot.areas.associateBy { it.areaId }
 
     val loadScore = (activeTasks.size * 2) + (openLoops.size * 3) + (overdue.size * 5)
-    val fragmentation = activeTasks.groupBy { it.node.projectId }.size * 5
+    // Optimized from groupBy to distinctBy for performance
+    val fragmentation = activeTasks.distinctBy { it.node.projectId }.size * 5
     val capWarning =
         when
             {


### PR DESCRIPTION
Identified a performance inefficiency in dashboard state calculation where `groupBy { ... }.size` was used instead of `distinctBy { ... }.size`. Replaced it in `MainSnapshotCalculators.kt` and `MainStateAssemblers.kt` to avoid unnecessary allocations of lists and `LinkedHashMap`s. Documented the change using KDocs. Tests were successfully executed and all passed.

---
*PR created automatically by Jules for task [1010961817009754531](https://jules.google.com/task/1010961817009754531) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

