### PR TITLE
test: add tests for FilterHelper friction and status filters

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperTest.kt
@@ -807,4 +807,29 @@ class FilterHelperTest {
         val result3 = filter(listOf(node1)) { linkedToId = 100L; this.relations = relations }
         assertEquals(1, result3.size)
     }
+
+    @Test
+    fun testFrictionFilter() {
+        val node1 = createTestNode(1, "Low Friction", friction = "low")
+        val node2 = createTestNode(2, "High Friction", friction = "high")
+
+        val filtered = filter(listOf(node1, node2)) { friction = "low" }
+
+        assertEquals(1, filtered.size)
+        assertEquals(1L, filtered[0].node.id)
+    }
+
+    @Test
+    fun testStatusFilterCommaSeparated() {
+        val node1 = createTestNode(1, "Node 1", status = "active")
+        val node2 = createTestNode(2, "Node 2", status = "on_hold")
+        val node3 = createTestNode(3, "Node 3", status = "completed")
+
+        val filtered = filter(listOf(node1, node2, node3)) { status = "active, on_hold" }
+
+        assertEquals(2, filtered.size)
+        val sortedIds = filtered.map { it.node.id }.sorted()
+        assertEquals(listOf(1L, 2L), sortedIds)
+    }
+
 }


### PR DESCRIPTION
Added tests to `FilterHelperTest.kt` to cover `friction` filtering and the comma-separated `status` filtering logic. This strengthens the test suite for existing parsing and filtering functionality in `FilterHelper`.

---
*PR created automatically by Jules for task [14050717935875710995](https://jules.google.com/task/14050717935875710995) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

