### PR TITLE
docs: add missing KDoc to PreferencesRepository and DomainLensQueries

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -184,6 +184,10 @@ class PreferencesRepository(
             }
         }
 
+    /**
+     * The registry of all currently available packs, combining owned and actively enabled packs.
+     * Evaluated against [AppPack.defaultFreePackKeys] to ensure baseline pack availability.
+     */
     val enabledPacks: Flow<PackRegistry> =
         safeData
             .map { preferences ->
@@ -195,12 +199,18 @@ class PreferencesRepository(
             )
         }
 
+    /**
+     * A flow emitting the set of pack keys explicitly owned by the user, incorporating defaults.
+     */
     val ownedPacks: Flow<Set<String>> =
         safeData
             .map { preferences ->
             preferences[PreferencesKeys.OWNED_PACKS] ?: AppPack.defaultFreePackKeys
         }
 
+    /**
+     * Updates the biometric authentication requirement flag.
+     */
     suspend fun updateBiometricEnabled(enabled: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.BIOMETRIC_ENABLED] = enabled
@@ -274,6 +284,9 @@ class PreferencesRepository(
         }
     }
 
+    /**
+     * Persists the user's preference for dark theme mode.
+     */
     suspend fun updateDarkThemeEnabled(enabled: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.DARK_THEME_ENABLED] = enabled
@@ -309,6 +322,13 @@ class PreferencesRepository(
         }
     }
 
+    /**
+     * Toggles whether a specific pack is actively enabled in the app shell.
+     * Prevents enabling packs that are not currently owned by the user.
+     *
+     * @param pack The target application pack.
+     * @param enabled Whether to enable or disable the pack.
+     */
     suspend fun setPackEnabled(
         pack: AppPack,
         enabled: Boolean,
@@ -326,6 +346,13 @@ class PreferencesRepository(
         }
     }
 
+    /**
+     * Marks a pack as owned or unowned. Disabling ownership of non-free packs also removes
+     * them from the currently enabled set.
+     *
+     * @param pack The target application pack.
+     * @param owned Whether the pack is owned.
+     */
     suspend fun setPackOwned(
         pack: AppPack,
         owned: Boolean,
@@ -351,6 +378,10 @@ class PreferencesRepository(
         }
     }
 
+    /**
+     * Validates and ensures that the baseline default packs (defined in [AppPack.defaultFreePackKeys])
+     * are present in both the owned and enabled preference sets. Usually invoked during app initialization.
+     */
     suspend fun ensureDefaultPackAccess() {
         dataStore.edit { preferences ->
             val owned = (preferences[PreferencesKeys.OWNED_PACKS] ?: emptySet()).toMutableSet()

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -121,6 +121,10 @@ private val healthTitleKeywords =
  * do not yet have dedicated queries in this object. Adding support for them would require
  * establishing similar heuristic marker sets (e.g., `educationTagMarkers`, `educationTitleKeywords`,
  * `relationshipsMaintenanceTypes`) and implementing their respective projection queries.
+ *
+ * This object provides functions to filter and group `NodeWithPin` and `MaintenanceStatusItem`
+ * objects into specific domains based on implicit keyword, tag, and structural heuristics,
+ * bypassing the need for manual explicit domain assignments.
  */
 object DomainLensQueries {
     /**


### PR DESCRIPTION
This PR adds missing documentation to key areas of the codebase, reducing onboarding friction and clarifying intent.

Changes:
- Added KDoc for `DomainLensQueries` explaining its role as a stateless utility for projecting heuristic-based lenses over `NodeWithPin` models.
- Added KDoc to public properties and methods in `PreferencesRepository` (such as `enabledPacks`, `ownedPacks`, `setPackEnabled`, `setPackOwned`, `updateDarkThemeEnabled`, etc.) to explicitly describe their behaviors and constraints.

---
*PR created automatically by Jules for task [17661384831798768136](https://jules.google.com/task/17661384831798768136) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

