### PR TITLE
fix: avoid unpredictable NaN propagation in average calculations

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -210,14 +210,14 @@ fun calculateInsights(
                     .filter { (dailyCompletions[it.date] ?: 0) >= 3 }
                     .mapNotNull { it.moodScore }
                     .takeIf { it.isNotEmpty() }
-                    ?.average() ?: Double.NaN
+                    ?.average()
             val moodOnSlowDays =
                 recentTracks
                     .filter { (dailyCompletions[it.date] ?: 0) == 0 }
                     .mapNotNull { it.moodScore }
                     .takeIf { it.isNotEmpty() }
-                    ?.average() ?: Double.NaN
-            if (!moodOnBusyDays.isNaN() && !moodOnSlowDays.isNaN()) moodOnBusyDays - moodOnSlowDays else 0.0
+                    ?.average()
+            if (moodOnBusyDays != null && moodOnSlowDays != null) moodOnBusyDays - moodOnSlowDays else 0.0
         } else {
             0.0
         }
@@ -230,15 +230,13 @@ fun calculateInsights(
                     .map { dailyFocus[it.date] ?: 0.0 }
                     .takeIf { it.isNotEmpty() }
                     ?.average()
-                    ?: Double.NaN
             val focusOnBadSleep =
                 recentTracks
                     .filter { (it.sleepScore ?: 0f) < 7f }
                     .map { dailyFocus[it.date] ?: 0.0 }
                     .takeIf { it.isNotEmpty() }
                     ?.average()
-                    ?: Double.NaN
-            if (!focusOnGoodSleep.isNaN() && !focusOnBadSleep.isNaN()) focusOnGoodSleep - focusOnBadSleep else 0.0
+            if (focusOnGoodSleep != null && focusOnBadSleep != null) focusOnGoodSleep - focusOnBadSleep else 0.0
         } else {
             0.0
         }
@@ -251,15 +249,13 @@ fun calculateInsights(
                     .map { dailyCaptures[it.date] ?: 0 }
                     .takeIf { it.isNotEmpty() }
                     ?.average()
-                    ?: Double.NaN
             val capturesOnLowEnergy =
                 recentTracks
                     .filter { (it.energyScore ?: 0) <= 2 }
                     .map { dailyCaptures[it.date] ?: 0 }
                     .takeIf { it.isNotEmpty() }
                     ?.average()
-                    ?: Double.NaN
-            if (!capturesOnHighEnergy.isNaN() && !capturesOnLowEnergy.isNaN()) capturesOnHighEnergy - capturesOnLowEnergy else 0.0
+            if (capturesOnHighEnergy != null && capturesOnLowEnergy != null) capturesOnHighEnergy - capturesOnLowEnergy else 0.0
         } else {
             0.0
         }
@@ -292,14 +288,14 @@ fun calculateInsights(
                     .filter { it.tookMeds }
                     .mapNotNull { it.focusScore }
                     .takeIf { it.isNotEmpty() }
-                    ?.average() ?: Double.NaN
+                    ?.average()
             val focusWithoutMeds =
                 recentTracks
                     .filter { !it.tookMeds }
                     .mapNotNull { it.focusScore }
                     .takeIf { it.isNotEmpty() }
-                    ?.average() ?: Double.NaN
-            if (!focusWithMeds.isNaN() && !focusWithoutMeds.isNaN()) focusWithMeds - focusWithoutMeds else 0.0
+                    ?.average()
+            if (focusWithMeds != null && focusWithoutMeds != null) focusWithMeds - focusWithoutMeds else 0.0
         } else {
             0.0
         }


### PR DESCRIPTION
This pull request addresses potential issues with predictable NaN propagation when calculating averages on empty collections in `MainSnapshotCalculators.kt`.

Previously, when `.average()` was called on potentially empty collections, it fell back to `Double.NaN`, and the subsequent logic used `.isNaN()` for checks. However, comparing NaN values can introduce subtle bugs (e.g., `NaN == NaN` is false).

The code has been updated to use Kotlin's idiomatic null-safety approach, returning `Double?` (`null` when the collection is empty) and utilizing standard `!= null` checks to ensure reliability and predictability. Tests have been executed and confirm this change preserves existing functionality.

---
*PR created automatically by Jules for task [18313156720404104031](https://jules.google.com/task/18313156720404104031) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

