### PR TITLE
docs: document fallbackToDestructiveMigration configuration

### DIFF
--- a/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
+++ b/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
@@ -7,6 +7,13 @@ package com.tajemniktv.tajsos.data
 import android.content.Context
 import androidx.room.Room
 
+/**
+ * Creates and configures the Room database instance.
+ *
+ * Note: The database is currently configured with `fallbackToDestructiveMigration(true)`
+ * as a pre-alpha safety posture. This permits rapid schema iteration without enforcing
+ * strict migrations, but will wipe local data if the schema version changes.
+ */
 fun createDatabase(context: Context): AppDatabase {
     val dbFile = context.getDatabasePath("tajsos.db")
     return Room

--- a/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
+++ b/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
@@ -9,6 +9,13 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import java.io.File
 import com.tajemniktv.tajsos.utils.AppDirs
 
+/**
+ * Creates and configures the Room database instance.
+ *
+ * Note: The database is currently configured with `fallbackToDestructiveMigration(true)`
+ * as a pre-alpha safety posture. This permits rapid schema iteration without enforcing
+ * strict migrations, but will wipe local data if the schema version changes.
+ */
 fun createDatabase(): AppDatabase {
     val dbFile = File(AppDirs.getAppDataDir(), "tajsos.db")
     return Room


### PR DESCRIPTION
Added KDoc documentation to the `createDatabase` functions in the `androidMain` and `jvmMain` source sets. This clarifies that the database is currently configured with `fallbackToDestructiveMigration(true)` as a pre-alpha safety posture, permitting rapid schema iteration without enforcing strict migrations at the cost of wiping local data on schema version changes. This satisfies the requirement to document intent, contracts, and non-obvious behavior.

---
*PR created automatically by Jules for task [8353593024961202130](https://jules.google.com/task/8353593024961202130) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

