### PR TITLE
test: add DomainLensQueriesFinanceDeadlineTest for financeDeadlineItems

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesFinanceDeadlineTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesFinanceDeadlineTest.kt
@@ -1,0 +1,68 @@
+package com.tajemniktv.tajsos.domain.lens
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.data.TagEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DomainLensQueriesFinanceDeadlineTest {
+    private fun createNode(
+        id: Long,
+        title: String,
+        content: String = "",
+        type: String = "task",
+        status: String = "active",
+        tags: List<String> = emptyList(),
+        maintenanceType: String? = null,
+        noteType: String? = null,
+        dueAt: Long? = null,
+        updatedAt: Long = 0L,
+    ): NodeWithPin {
+        return NodeWithPin(
+            node = NodeEntity(
+                id = id,
+                title = title,
+                content = content,
+                type = type,
+                status = status,
+                maintenanceType = maintenanceType,
+                noteType = noteType,
+                dueAt = dueAt,
+                updatedAt = updatedAt,
+            ),
+            pin = null,
+            tags = tags.mapIndexed { index, tag -> TagEntity(id = index.toLong(), name = tag, normalizedName = tag.lowercase()) },
+        )
+    }
+
+    @Test
+    fun financeDeadlineItems_filters_by_active_status_and_due_date() {
+        val activeWithDate = createNode(id = 1, title = "Tax return", status = "active", dueAt = 1000L, tags = listOf("finance"))
+        val activeNoDate = createNode(id = 2, title = "Tax return", status = "active", dueAt = null, tags = listOf("finance"))
+        val inactiveWithDate = createNode(id = 3, title = "Tax return", status = "archived", dueAt = 1000L, tags = listOf("finance"))
+
+        val allNodes = listOf(activeWithDate, activeNoDate, inactiveWithDate)
+
+        val result = DomainLensQueries.financeDeadlineItems(allNodes)
+
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().node.id)
+    }
+
+    @Test
+    fun financeDeadlineItems_sorts_by_due_date_ascending() {
+        val farDeadline = createNode(id = 1, title = "Tax return", status = "active", dueAt = 3000L, tags = listOf("finance"))
+        val nearDeadline = createNode(id = 2, title = "Tax return", status = "active", dueAt = 1000L, tags = listOf("finance"))
+        val mediumDeadline = createNode(id = 3, title = "Tax return", status = "active", dueAt = 2000L, tags = listOf("finance"))
+
+        val allNodes = listOf(farDeadline, nearDeadline, mediumDeadline)
+
+        val result = DomainLensQueries.financeDeadlineItems(allNodes)
+
+        assertEquals(3, result.size)
+        assertEquals(2L, result[0].node.id)
+        assertEquals(3L, result[1].node.id)
+        assertEquals(1L, result[2].node.id)
+    }
+}


### PR DESCRIPTION
Adds a test for `financeDeadlineItems` in `DomainLensQueries`.
It verifies that it correctly filters by active status and non-null `dueAt` date, and that it correctly sorts the output list by the due date in ascending order.

---
*PR created automatically by Jules for task [6354605895436787293](https://jules.google.com/task/6354605895436787293) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

