### PR TITLE
docs: improve KDoc for core shared components

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/CalendarManager.kt
@@ -24,6 +24,7 @@ import kotlin.time.Duration.Companion.days
  *
  * @param repository The central data repository providing database operations for calendar objects.
  * @param httpClient The configured HTTP client to perform external API queries.
+ * @property providers A list of supported provider integration handlers (defaults to [IcsCalendarProvider]).
  */
 class CalendarManager(
     private val repository: AppRepository,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -36,6 +36,8 @@ enum class DesktopWindowStartupMode {
  *
  * All properties are exposed as [Flow] streams that emit the current value,
  * and automatically handle [IOException]s by emitting [emptyPreferences] as a fallback.
+ *
+ * @property dataStore The Jetpack DataStore instance managing preferences.
  */
 class PreferencesRepository(
     private val dataStore: DataStore<Preferences>,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -258,6 +258,27 @@ private data class LifeObjectFacetSnapshot(
  * core LifeOS entities (`NodeEntity`) alongside their typed extension states (`TaskFacetEntity`,
  * `NoteFacetEntity`, etc.). This pattern avoids maintaining a single massive nullable row
  * and safely orchestrates creation, updates, and complex queries across related database tables.
+ *
+ * @property nodeDao Data access object for the primary 'nodes' table.
+ * @property focusSessionDao Data access object for study/focus sessions.
+ * @property trackDao Data access object for time-tracking entries.
+ * @property relationDao Data access object for bidirectional inter-node relationships.
+ * @property tagDao Data access object for plain-text string tags.
+ * @property eventLogDao Data access object for system event tracking.
+ * @property attachmentDao Data access object for file attachments linked to nodes.
+ * @property templateDao Data access object for reusable node templates.
+ * @property nodeSnapshotDao Data access object for historical node revisions.
+ * @property reviewDao Data access object for recurring review schedules.
+ * @property calendarProviderDao Data access object for external calendar configuration.
+ * @property calendarEventDao Data access object for cached external events.
+ * @property modeDao Data access object for application mode definitions.
+ * @property protocolDao Data access object for workflow protocols.
+ * @property decisionDao Data access object for discrete choices linked to decisions.
+ * @property userDao Data access object for core user identity.
+ * @property medicationDao Data access object for health logs and prescriptions.
+ * @property inboxEntryDao Data access object for external quick-capture items.
+ * @property taskFacetDao Data access object for task-specific metadata (deadlines, states).
+ * @property noteFacetDao Data access object for standard note metadata.
  */
 class AppRepository(
     private val nodeDao: NodeDao,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/di/Modules.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/di/Modules.kt
@@ -17,7 +17,14 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
 /**
- * Simple manual DI module.
+ * Core manual Dependency Injection (DI) module for shared multiplatform dependencies.
+ *
+ * It manages the lifecycle and initialization of core infrastructure components such as
+ * the database instance, Ktor HTTP client, and various repositories. It provides these
+ * singletons to platform-specific application entry points.
+ *
+ * @property database The cross-platform SQLite database implementation.
+ * @property dataStore The multiplatform Jetpack DataStore instance for user preferences.
  */
 class SharedModule(
     private val database: AppDatabase,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -127,11 +127,19 @@ import kotlinx.serialization.json.Json
 import kotlin.time.Clock
 
 /**
- * Global orchestrator for the application shell.
+ * The primary ViewModel acting as the state-holder and orchestrator for the entire application UI.
  *
  * Handles shell-level state (including modes, sync status, application locking, and sidebar state).
- * It delegates feature-heavy orchestration to internal command handlers (e.g., [NodeCommands])
- * but acts as the root provider of core app state.
+ * This class bridges the gap between the underlying data layer ([AppRepository], [PreferencesRepository])
+ * and the presentation layer, exposing a reactive stream of application state (e.g., nodes, tags, domains).
+ * It dynamically filters data based on active modes or user contexts, and delegates complex state mutations
+ * to specialized command classes (e.g., [NodeCommands], [ProtocolCommands]).
+ *
+ * @property repository Central source of truth for all database operations.
+ * @property preferencesRepository Source of truth for application configuration and environment state.
+ * @property calendarManager Unified interface for handling platform-specific calendar integrations.
+ * @property nextStepFallbackLabel Fallback label used when a next step description is empty.
+ * @property untitledFallbackLabel Fallback label used when a node's title is empty.
  */
 @Stable
 class MainViewModel(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/bootstrap/AppBootstrapper.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/bootstrap/AppBootstrapper.kt
@@ -27,6 +27,9 @@ import kotlinx.coroutines.flow.first
  *
  * It generates default entities such as focus modes, academic templates, logistical systems,
  * and base user data if the local storage is detected as entirely empty.
+ *
+ * @property repository The main application repository for database interactions.
+ * @property preferencesRepository The repository for managing user preferences and system settings.
  */
 class AppBootstrapper(
     /** The main application repository for database interactions. */


### PR DESCRIPTION
This pull request adds detailed KDoc annotations to several core shared layer classes including `MainViewModel`, `CalendarManager`, `SharedModule`, `AppBootstrapper`, `PreferencesRepository`, and `AppRepository`. It documents intent, architectural role, and explicitly annotates properties to reduce onboarding friction and clarify assumptions.

---
*PR created automatically by Jules for task [3911945408225316837](https://jules.google.com/task/3911945408225316837) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

