### PR TITLE
fix(website): resolve static route collision for custom 404 page

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -21,6 +21,7 @@ export default defineConfig({
       title: "Docs",
       description: "TajsOS Documentation",
 
+      disable404Route: true,
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",
       },


### PR DESCRIPTION
Resolved static route collision warning for '/404' when using the custom 404 page by adding 'disable404Route: true' to the Astro Starlight configuration. This fixes the warning printed during the build process, and allows Starlight to correctly use the custom 404 page defined at 'src/pages/404.astro'.

---
*PR created automatically by Jules for task [15823925228739109907](https://jules.google.com/task/15823925228739109907) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

