### PR TITLE
fix(docs): resolve 404 route collision in starlight config

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
Resolved a static route collision warning for `/404` in the Starlight configuration. The warning occurred because Starlight provides a default 404 route, but the project already implements a custom `404.astro` page in `src/pages`. Added `disable404Route: true` to the Starlight configuration in `astro.config.mjs` to disable the default route and correctly rely solely on the custom implementation.

---
*PR created automatically by Jules for task [3892850640345771478](https://jules.google.com/task/3892850640345771478) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

