### PR TITLE
test: improve FilterHelper test coverage

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperQueryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperQueryTest.kt
@@ -11,37 +11,24 @@ import kotlin.test.assertTrue
 
 class FilterHelperQueryTest {
 
-    private fun createTestNode(
-        id: Long,
-        title: String,
-        content: String = "",
-        type: String = "task",
-        status: String = "active",
-    ): NodeWithPin {
-        val nodeEntity = NodeEntity(
-            id = id,
-            title = title,
-            content = content,
-            type = type,
-            status = status,
-            createdAt = 0L,
-            updatedAt = 0L
-        )
+
+    private fun createTestNode(id: Long, title: String): NodeWithPin {
         return NodeWithPin(
-            node = nodeEntity,
+            node = NodeEntity(id = id, title = title, content = "", type = "task", status = "active", createdAt = 0L, updatedAt = 0L),
             pin = null,
             tags = emptyList(),
         )
     }
 
+
     @Test
     fun testRelevanceScoreOrdering() {
         val helper = FilterHelper
-        val node1 = createTestNode(id = 1, title = "Exact Title Match", status = "inactive")
-        val node2 = createTestNode(id = 2, title = "Exact Title Not Match", content = "Exact Title Match", status = "active")
-        val node3 = createTestNode(id = 3, title = "Exact Prefix", content = "Something", status = "inactive")
-        val node4 = createTestNode(id = 4, title = "Something", content = "Something", status = "inactive")
-        val node5 = createTestNode(id = 5, title = "Another one", content = "Something", status = "inactive")
+        val node1 = createTestNode(id = 1, title = "Exact Title Match").let { it.copy(node = it.node.copy(status = "inactive")) }
+        val node2 = createTestNode(id = 2, title = "Exact Title Not Match").let { it.copy(node = it.node.copy(content = "Exact Title Match", status = "active")) }
+        val node3 = createTestNode(id = 3, title = "Exact Prefix").let { it.copy(node = it.node.copy(content = "Something", status = "inactive")) }
+        val node4 = createTestNode(id = 4, title = "Something").let { it.copy(node = it.node.copy(content = "Something", status = "inactive")) }
+        val node5 = createTestNode(id = 5, title = "Another one").let { it.copy(node = it.node.copy(content = "Something", status = "inactive")) }
 
         val nodeWithPin1 = node1.copy(pin = TodayPinEntity(1, 1, "2024-01-01", 0)) // score + 8
         val nodeWithPin2 = node2 // score + 5 (active)
@@ -60,7 +47,7 @@ class FilterHelperQueryTest {
     @Test
     fun testMatchesQueryAndRelevanceScore() {
         val helper = FilterHelper
-        val node1 = createTestNode(id = 1, title = "Apple", content = "Banana")
+        val node1 = createTestNode(id = 1, title = "Apple").let { it.copy(node = it.node.copy(content = "Banana")) }
         val nodeWithPin1 = node1.copy(tags = listOf(TagEntity(1, "fruit", "fruit")))
 
         assertTrue(helper.matchesQuery(nodeWithPin1, "Apple"))
@@ -75,8 +62,8 @@ class FilterHelperQueryTest {
         assertFalse(helper.matchesQuery(nodeWithPin1, "#"))
         assertFalse(helper.matchesQuery(nodeWithPin1, "#   "))
 
-        val node2 = createTestNode(id = 2, title = "PrefixApple", content = "something")
-        val node3 = createTestNode(id = 3, title = "Not exactly", content = "Apple")
+        val node2 = createTestNode(id = 2, title = "PrefixApple").let { it.copy(node = it.node.copy(content = "something")) }
+        val node3 = createTestNode(id = 3, title = "Not exactly").let { it.copy(node = it.node.copy(content = "Apple")) }
         val nodes = listOf(node3, node2, node1)
 
         val sorted = helper.filterAndSortNodes(nodes = nodes, query = "Apple", type = null, status = null, projectId = null, areaId = null, linkedToId = null, maxMins = null, energy = null, friction = null, locationContext = null, energyContext = null, deviceContext = null, socialContext = null, timeWindowContext = null, timeHorizon = null, relations = emptyList(), sortMode = "relevance")

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperQueryTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperQueryTest.kt
@@ -1,0 +1,89 @@
+package com.tajemniktv.tajsos.ui
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.data.TagEntity
+import com.tajemniktv.tajsos.data.TodayPinEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FilterHelperQueryTest {
+
+    private fun createTestNode(
+        id: Long,
+        title: String,
+        content: String = "",
+        type: String = "task",
+        status: String = "active",
+    ): NodeWithPin {
+        val nodeEntity = NodeEntity(
+            id = id,
+            title = title,
+            content = content,
+            type = type,
+            status = status,
+            createdAt = 0L,
+            updatedAt = 0L
+        )
+        return NodeWithPin(
+            node = nodeEntity,
+            pin = null,
+            tags = emptyList(),
+        )
+    }
+
+    @Test
+    fun testRelevanceScoreOrdering() {
+        val helper = FilterHelper
+        val node1 = createTestNode(id = 1, title = "Exact Title Match", status = "inactive")
+        val node2 = createTestNode(id = 2, title = "Exact Title Not Match", content = "Exact Title Match", status = "active")
+        val node3 = createTestNode(id = 3, title = "Exact Prefix", content = "Something", status = "inactive")
+        val node4 = createTestNode(id = 4, title = "Something", content = "Something", status = "inactive")
+        val node5 = createTestNode(id = 5, title = "Another one", content = "Something", status = "inactive")
+
+        val nodeWithPin1 = node1.copy(pin = TodayPinEntity(1, 1, "2024-01-01", 0)) // score + 8
+        val nodeWithPin2 = node2 // score + 5 (active)
+        val nodeWithPin3 = node3.copy(tags = listOf(TagEntity(id = 1, name = "Exact Title Match", normalizedName = "exact title match"))) // score + 20
+        val nodeWithPin4 = node4.copy(tags = listOf(TagEntity(id = 2, name = "Title Match", normalizedName = "title match"))) // score + 10
+
+        val nodes = listOf(nodeWithPin2, nodeWithPin1, nodeWithPin3, nodeWithPin4, node5)
+        val sorted = helper.filterAndSortNodes(nodes = nodes, query = "Exact Title Match", type = null, status = null, projectId = null, areaId = null, linkedToId = null, maxMins = null, energy = null, friction = null, locationContext = null, energyContext = null, deviceContext = null, socialContext = null, timeWindowContext = null, timeHorizon = null, relations = emptyList(), sortMode = "relevance")
+
+        assertEquals(1L, sorted[0].node.id)
+
+        val sortedPrefix = helper.filterAndSortNodes(nodes = nodes, query = "Exact P", type = null, status = null, projectId = null, areaId = null, linkedToId = null, maxMins = null, energy = null, friction = null, locationContext = null, energyContext = null, deviceContext = null, socialContext = null, timeWindowContext = null, timeHorizon = null, relations = emptyList(), sortMode = "relevance")
+        assertEquals(3L, sortedPrefix[0].node.id)
+    }
+
+    @Test
+    fun testMatchesQueryAndRelevanceScore() {
+        val helper = FilterHelper
+        val node1 = createTestNode(id = 1, title = "Apple", content = "Banana")
+        val nodeWithPin1 = node1.copy(tags = listOf(TagEntity(1, "fruit", "fruit")))
+
+        assertTrue(helper.matchesQuery(nodeWithPin1, "Apple"))
+        assertTrue(helper.matchesQuery(nodeWithPin1, "Banana"))
+        assertTrue(helper.matchesQuery(nodeWithPin1, "fruit"))
+        assertTrue(helper.matchesQuery(nodeWithPin1, "#fruit"))
+
+        assertFalse(helper.matchesQuery(nodeWithPin1, "Orange"))
+        assertFalse(helper.matchesQuery(nodeWithPin1, "#Orange"))
+        assertFalse(helper.matchesQuery(nodeWithPin1, ""))
+        assertFalse(helper.matchesQuery(nodeWithPin1, "   "))
+        assertFalse(helper.matchesQuery(nodeWithPin1, "#"))
+        assertFalse(helper.matchesQuery(nodeWithPin1, "#   "))
+
+        val node2 = createTestNode(id = 2, title = "PrefixApple", content = "something")
+        val node3 = createTestNode(id = 3, title = "Not exactly", content = "Apple")
+        val nodes = listOf(node3, node2, node1)
+
+        val sorted = helper.filterAndSortNodes(nodes = nodes, query = "Apple", type = null, status = null, projectId = null, areaId = null, linkedToId = null, maxMins = null, energy = null, friction = null, locationContext = null, energyContext = null, deviceContext = null, socialContext = null, timeWindowContext = null, timeHorizon = null, relations = emptyList(), sortMode = "relevance")
+
+        assertEquals(3, sorted.size)
+        assertEquals(1L, sorted[0].node.id)
+        assertEquals(2L, sorted[1].node.id)
+        assertEquals(3L, sorted[2].node.id)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperTest.kt
@@ -16,6 +16,71 @@ import kotlin.test.assertTrue
 
 class FilterHelperTest {
 
+
+
+
+    @Test
+    fun testRelevanceScoreOrdering() {
+        val helper = FilterHelper
+        val node1 = createTestNode(id = 1, title = "Exact Title Match", status = "inactive")
+        val node2 = createTestNode(id = 2, title = "Exact Title Not Match", content = "Exact Title Match", status = "active")
+        val node3 = createTestNode(id = 3, title = "Exact Prefix", content = "Something", status = "inactive")
+        val node4 = createTestNode(id = 4, title = "Something", content = "Something", status = "inactive")
+        val node5 = createTestNode(id = 5, title = "Another one", content = "Something", status = "inactive")
+
+        val nodeWithPin1 = node1.copy(pin = TodayPinEntity(1, 1, "2024-01-01", 0)) // score + 8
+        val nodeWithPin2 = node2 // score + 5 (active)
+        val nodeWithPin3 = node3.copy(tags = listOf(TagEntity(id = 1, name = "Exact Title Match", normalizedName = "exact title match"))) // score + 20
+        val nodeWithPin4 = node4.copy(tags = listOf(TagEntity(id = 2, name = "Title Match", normalizedName = "title match"))) // score + 10
+
+        // Exact Title Match (100) + Pinned (8) = 108
+        // Title contains Exact (30) + Content contains Exact Title Match (15) + active (5) = 50
+
+        val nodes = listOf(nodeWithPin2, nodeWithPin1, nodeWithPin3, nodeWithPin4, node5)
+        val sorted = filter(nodes) { query = "Exact Title Match"; sortMode = "relevance" }
+
+        // Exact Title Match
+        assertEquals(1L, sorted[0].node.id)
+
+        // Prefix test
+        val sortedPrefix = filter(nodes) { query = "Exact P"; sortMode = "relevance" }
+        assertEquals(3L, sortedPrefix[0].node.id) // Exact Prefix
+    }
+
+    @Test
+    fun testMatchesQueryAndRelevanceScore() {
+        val helper = FilterHelper
+        val node1 = createTestNode(id = 1, title = "Apple", content = "Banana")
+        val nodeWithPin1 = node1.copy(tags = listOf(TagEntity(1, "fruit", "fruit")))
+
+        // matchesQuery
+        assertTrue(helper.matchesQuery(nodeWithPin1, "Apple"))
+        assertTrue(helper.matchesQuery(nodeWithPin1, "Banana"))
+        assertTrue(helper.matchesQuery(nodeWithPin1, "fruit"))
+        assertTrue(helper.matchesQuery(nodeWithPin1, "#fruit"))
+
+        assertFalse(helper.matchesQuery(nodeWithPin1, "Orange"))
+        assertFalse(helper.matchesQuery(nodeWithPin1, "#Orange"))
+        assertFalse(helper.matchesQuery(nodeWithPin1, ""))
+        assertFalse(helper.matchesQuery(nodeWithPin1, "   "))
+        assertFalse(helper.matchesQuery(nodeWithPin1, "#"))
+        assertFalse(helper.matchesQuery(nodeWithPin1, "#   "))
+
+        // relevanceScore via reflection or test sorting
+        val node2 = createTestNode(id = 2, title = "PrefixApple", content = "something")
+        val node3 = createTestNode(id = 3, title = "Not exactly", content = "Apple")
+        val nodes = listOf(node3, node2, node1)
+
+        // Exact title match (Apple) > Title contains (PrefixApple) > Content contains (Apple)
+        val sorted = helper.filterAndSortNodes(nodes = nodes, query = "Apple", type = null, status = null, projectId = null, areaId = null, linkedToId = null, maxMins = null, energy = null, friction = null, locationContext = null, energyContext = null, deviceContext = null, socialContext = null, timeWindowContext = null, timeHorizon = null, relations = emptyList(), sortMode = "relevance")
+
+        assertEquals(3, sorted.size)
+        assertEquals(1L, sorted[0].node.id) // Exact match (Apple)
+        assertEquals(2L, sorted[1].node.id) // Title contains
+        assertEquals(3L, sorted[2].node.id) // Content contains
+    }
+
+
     class FilterConfig(val nodes: List<NodeWithPin>) {
         var query: String = ""
         var type: String? = null

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperTest.kt
@@ -19,66 +19,6 @@ class FilterHelperTest {
 
 
 
-    @Test
-    fun testRelevanceScoreOrdering() {
-        val helper = FilterHelper
-        val node1 = createTestNode(id = 1, title = "Exact Title Match", status = "inactive")
-        val node2 = createTestNode(id = 2, title = "Exact Title Not Match", content = "Exact Title Match", status = "active")
-        val node3 = createTestNode(id = 3, title = "Exact Prefix", content = "Something", status = "inactive")
-        val node4 = createTestNode(id = 4, title = "Something", content = "Something", status = "inactive")
-        val node5 = createTestNode(id = 5, title = "Another one", content = "Something", status = "inactive")
-
-        val nodeWithPin1 = node1.copy(pin = TodayPinEntity(1, 1, "2024-01-01", 0)) // score + 8
-        val nodeWithPin2 = node2 // score + 5 (active)
-        val nodeWithPin3 = node3.copy(tags = listOf(TagEntity(id = 1, name = "Exact Title Match", normalizedName = "exact title match"))) // score + 20
-        val nodeWithPin4 = node4.copy(tags = listOf(TagEntity(id = 2, name = "Title Match", normalizedName = "title match"))) // score + 10
-
-        // Exact Title Match (100) + Pinned (8) = 108
-        // Title contains Exact (30) + Content contains Exact Title Match (15) + active (5) = 50
-
-        val nodes = listOf(nodeWithPin2, nodeWithPin1, nodeWithPin3, nodeWithPin4, node5)
-        val sorted = filter(nodes) { query = "Exact Title Match"; sortMode = "relevance" }
-
-        // Exact Title Match
-        assertEquals(1L, sorted[0].node.id)
-
-        // Prefix test
-        val sortedPrefix = filter(nodes) { query = "Exact P"; sortMode = "relevance" }
-        assertEquals(3L, sortedPrefix[0].node.id) // Exact Prefix
-    }
-
-    @Test
-    fun testMatchesQueryAndRelevanceScore() {
-        val helper = FilterHelper
-        val node1 = createTestNode(id = 1, title = "Apple", content = "Banana")
-        val nodeWithPin1 = node1.copy(tags = listOf(TagEntity(1, "fruit", "fruit")))
-
-        // matchesQuery
-        assertTrue(helper.matchesQuery(nodeWithPin1, "Apple"))
-        assertTrue(helper.matchesQuery(nodeWithPin1, "Banana"))
-        assertTrue(helper.matchesQuery(nodeWithPin1, "fruit"))
-        assertTrue(helper.matchesQuery(nodeWithPin1, "#fruit"))
-
-        assertFalse(helper.matchesQuery(nodeWithPin1, "Orange"))
-        assertFalse(helper.matchesQuery(nodeWithPin1, "#Orange"))
-        assertFalse(helper.matchesQuery(nodeWithPin1, ""))
-        assertFalse(helper.matchesQuery(nodeWithPin1, "   "))
-        assertFalse(helper.matchesQuery(nodeWithPin1, "#"))
-        assertFalse(helper.matchesQuery(nodeWithPin1, "#   "))
-
-        // relevanceScore via reflection or test sorting
-        val node2 = createTestNode(id = 2, title = "PrefixApple", content = "something")
-        val node3 = createTestNode(id = 3, title = "Not exactly", content = "Apple")
-        val nodes = listOf(node3, node2, node1)
-
-        // Exact title match (Apple) > Title contains (PrefixApple) > Content contains (Apple)
-        val sorted = helper.filterAndSortNodes(nodes = nodes, query = "Apple", type = null, status = null, projectId = null, areaId = null, linkedToId = null, maxMins = null, energy = null, friction = null, locationContext = null, energyContext = null, deviceContext = null, socialContext = null, timeWindowContext = null, timeHorizon = null, relations = emptyList(), sortMode = "relevance")
-
-        assertEquals(3, sorted.size)
-        assertEquals(1L, sorted[0].node.id) // Exact match (Apple)
-        assertEquals(2L, sorted[1].node.id) // Title contains
-        assertEquals(3L, sorted[2].node.id) // Content contains
-    }
 
 
     class FilterConfig(val nodes: List<NodeWithPin>) {


### PR DESCRIPTION
Adds robust edge-case testing for `FilterHelper.matchesQuery` and relevance scoring in `FilterHelper.filterAndSortNodes`. Covers empty, blank, boundary, and hashtag queries, as well as exact match, partial match, and tags matching to improve regression protection.

---
*PR created automatically by Jules for task [14529732342510845296](https://jules.google.com/task/14529732342510845296) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

