### PR TITLE
docs: add missing KDocs to public classes and interfaces

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -36,6 +36,8 @@ enum class DesktopWindowStartupMode {
  *
  * All properties are exposed as [Flow] streams that emit the current value,
  * and automatically handle [IOException]s by emitting [emptyPreferences] as a fallback.
+ *
+ * @param dataStore The multiplatform data store managing preference persistence.
  */
 class PreferencesRepository(
     private val dataStore: DataStore<Preferences>,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/Repository.kt
@@ -258,6 +258,12 @@ private data class LifeObjectFacetSnapshot(
  * core LifeOS entities (`NodeEntity`) alongside their typed extension states (`TaskFacetEntity`,
  * `NoteFacetEntity`, etc.). This pattern avoids maintaining a single massive nullable row
  * and safely orchestrates creation, updates, and complex queries across related database tables.
+ *
+ * @param nodeDao Provides methods for accessing the core "Node" entities.
+ * @param focusSessionDao Provides methods for tracking focused work sessions against items.
+ * @param trackDao Provides methods for recording daily tracking entries (energy, mood, sleep).
+ * @param relationDao Provides methods for mapping bidirectional graph connections between nodes.
+ * @param tagDao Provides methods for applying and querying categorical tags on items.
  */
 class AppRepository(
     private val nodeDao: NodeDao,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/di/Modules.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/di/Modules.kt
@@ -17,7 +17,10 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
 /**
- * Simple manual DI module.
+ * Simple manual DI module to handle shared dependencies across multiplatform targets.
+ *
+ * @param database The instantiated SQLite application database.
+ * @param dataStore The instantiated multiplatform preferences data store.
  */
 class SharedModule(
     private val database: AppDatabase,

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/MainViewModel.kt
@@ -132,6 +132,12 @@ import kotlin.time.Clock
  * Handles shell-level state (including modes, sync status, application locking, and sidebar state).
  * It delegates feature-heavy orchestration to internal command handlers (e.g., [NodeCommands])
  * but acts as the root provider of core app state.
+ *
+ * @param repository The central data repository for reading and writing to the local SQLite database.
+ * @param preferencesRepository The data store manager for user configuration and app state preferences.
+ * @param calendarManager The orchestrator responsible for syncing and querying external calendar events.
+ * @param nextStepFallbackLabel Fallback string to use when a task has an empty next step.
+ * @param untitledFallbackLabel Fallback string to use when an item has an empty title.
  */
 @Stable
 class MainViewModel(


### PR DESCRIPTION
Adds missing KDoc documentation to core public classes to improve codebase readability and lower onboarding friction.
This PR adds class and parameter-level documentation to:
- `MainViewModel`
- `AppRepository`
- `PreferencesRepository`
- `SharedModule`

---
*PR created automatically by Jules for task [4632511190500698906](https://jules.google.com/task/4632511190500698906) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

