### PR TITLE
fix(website): resolve 404 route collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -21,6 +21,8 @@ export default defineConfig({
       title: "Docs",
       description: "TajsOS Documentation",
 
+      disable404Route: true,
+
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",
       },


### PR DESCRIPTION
This PR fixes a build warning where the `/404` route was defined in both the custom `src/pages/404.astro` file and the default Starlight configuration. Adding `disable404Route: true` to the Starlight config resolves this collision.

---
*PR created automatically by Jules for task [2709418725760383094](https://jules.google.com/task/2709418725760383094) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

