### PR TITLE
fix: resolve 404 static route collision in website

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
This PR resolves a static route collision warning during the build process of the Astro website. 

The warning `[WARN] [router] The route "/404" is defined in both "src/pages/404.astro" and "node_modules/@astrojs/starlight/routes/static/404.astro"` occurred because Starlight provides a default 404 page, but the project has its own custom 404 page (`src/pages/404.astro`).

This is fixed by explicitly disabling the Starlight 404 route (`disable404Route: true`) in `astro.config.mjs`, ensuring the custom 404 page is used without conflicts.

---
*PR created automatically by Jules for task [13799791828927661370](https://jules.google.com/task/13799791828927661370) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

