### PR TITLE
fix: resolve static route collision for 404 page in Starlight

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -18,6 +18,8 @@ export default defineConfig({
   base: "/TajsOS/",
   integrations: [
     starlight({
+      // Disable Starlight's default 404 route to resolve the static route collision with our custom src/pages/404.astro
+      disable404Route: true,
       title: "Docs",
       description: "TajsOS Documentation",
 


### PR DESCRIPTION
This PR fixes a build warning that occurs due to a static route collision for `/404`. Starlight tries to inject its default 404 page while we already have a custom one at `src/pages/404.astro`. Adding the `disable404Route: true` flag in the config resolves this issue. I also added a comment to explain the context to anyone reading the config.

---
*PR created automatically by Jules for task [13090689978802355636](https://jules.google.com/task/13090689978802355636) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

