### PR TITLE
feat(ui): add hover cursor to clickable components

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AlertCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/AlertCards.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Alert card
@@ -47,7 +49,7 @@ fun AlertCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
         color = color.copy(alpha = 0.05f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DashboardCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DashboardCards.kt
@@ -47,6 +47,8 @@ import com.tajemniktv.tajsos.ui.components.nodes.TaskBrief
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import kotlinx.coroutines.delay
 import kotlin.time.Clock
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * A sticky note style card for quick information.
@@ -65,7 +67,7 @@ fun StickyNoteCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier.width(200.dp),
+        modifier = modifier.width(200.dp).pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.Accent.copy(alpha = 0.1f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {
@@ -408,7 +410,7 @@ fun VaultCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/PrimitiveCards.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun DashCard(
@@ -35,7 +37,7 @@ fun DashCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
         content = content,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/RecoveryCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/RecoveryCards.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun BasicSurvivalCard(
@@ -34,7 +36,7 @@ fun BasicSurvivalCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/SystemOverviewCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/SystemOverviewCards.kt
@@ -38,6 +38,8 @@ import tajsos.composeapp.generated.resources.dash_capacity
 import tajsos.composeapp.generated.resources.dash_fragmentation
 import tajsos.composeapp.generated.resources.dash_load
 import tajsos.composeapp.generated.resources.dash_system_status
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun SystemStatusCard(
@@ -49,7 +51,7 @@ fun SystemStatusCard(
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
         color = if (warning != null) TajsOSTheme.Error.copy(alpha = 0.05f) else TajsOSTheme.Surface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         border =
@@ -163,7 +165,7 @@ fun AreaHealthCard(
 
     Surface(
         onClick = onClick,
-        modifier = modifier.width(190.dp),
+        modifier = modifier.width(190.dp).pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusXl),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/SelectorDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/SelectorDialog.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Displays a full-screen selector dialog presenting a grid of selectable options.
@@ -139,7 +141,7 @@ fun <T> SelectorDialog(
                             onClick = { onSelect(option) },
                             color = if (isSelected) TajsOSTheme.Primary else TajsOSTheme.Surface,
                             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-                            modifier = Modifier.height(140.dp),
+                            modifier = Modifier.height(140.dp).pointerHoverIcon(PointerIcon.Hand),
                             border =
                                 if (isSelected) {
                                     null

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/ProtocolTrigger.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/ProtocolTrigger.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Displays a fixed-width clickable card containing an icon above an uppercase label,
@@ -51,7 +53,7 @@ fun ProtocolTrigger(
 ) {
     Surface(
         onClick = onClick,
-        modifier = Modifier.width(120.dp),
+        modifier = Modifier.width(120.dp).pointerHoverIcon(PointerIcon.Hand),
         color = color.copy(alpha = 0.1f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
         border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSwitcherHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSwitcherHeader.kt
@@ -64,7 +64,7 @@ fun ModeSwitcherHeader(
                 val isSelected = mode.id == currentMode?.id
                 val color = mode.themeColor?.let { Color(it) } ?: TajsOSTheme.Primary
                 Surface(
-        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     onClick = { onModeSelect(mode.id) },
                     color = if (isSelected) color.copy(alpha = 0.15f) else Color.Transparent,
                     shape = RoundedCornerShape(TajsOSTheme.RadiusSm),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSwitcherHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSwitcherHeader.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.data.ModeEntity
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a header labeled "OPERATING MODE" with a horizontally scrollable row of selectable mode chips.
@@ -62,6 +64,7 @@ fun ModeSwitcherHeader(
                 val isSelected = mode.id == currentMode?.id
                 val color = mode.themeColor?.let { Color(it) } ?: TajsOSTheme.Primary
                 Surface(
+        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     onClick = { onModeSelect(mode.id) },
                     color = if (isSelected) color.copy(alpha = 0.15f) else Color.Transparent,
                     shape = RoundedCornerShape(TajsOSTheme.RadiusSm),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/StateAwareActionsGrid.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/StateAwareActionsGrid.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.ui.MainViewModel
 import com.tajemniktv.tajsos.ui.Screen
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a horizontal row of three equally sized actionable cards that apply preset search filters and navigate to the Search screen.
@@ -73,7 +75,7 @@ fun StateAwareActionsGrid(
                     }
                     onNavigateTo(Screen.Search)
                 },
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1f).pointerHoverIcon(PointerIcon.Hand),
                 color = TajsOSTheme.CardSurface,
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/SuggestionGroup.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/SuggestionGroup.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tajemniktv.tajsos.data.NodeWithPin
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a titled suggestion section displaying up to two clickable node entries with an optional description.
@@ -66,7 +68,7 @@ fun SuggestionGroup(
         nodes.take(2).forEach { nodeWithPin ->
             Surface(
                 onClick = { onEditNode(nodeWithPin.node.id) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
                 color = TajsOSTheme.CardSurface,
                 shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                 border = BorderStroke(1.dp, TajsOSTheme.GhostBorder),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
@@ -57,7 +57,7 @@ fun TaskBrief(
         onClick = onClick,
         color = Color.Black.copy(alpha = 0.2f),
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/briefing/BriefingScreen.kt
@@ -94,6 +94,8 @@ import tajsos.composeapp.generated.resources.briefing_resume_hint
 import tajsos.composeapp.generated.resources.briefing_upcoming
 import kotlin.time.Clock
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Calm, desktop-first orientation screen showing a lightweight daily briefing.
@@ -647,7 +649,7 @@ private fun BriefingActionCard(action: BriefingAction) {
         color = TajsOSTheme.SurfaceLow.copy(alpha = 0.72f),
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
-        modifier = Modifier.width(188.dp).height(144.dp),
+        modifier = Modifier.width(188.dp).height(144.dp).pointerHoverIcon(PointerIcon.Hand),
     ) {
         Column(
             modifier = Modifier.fillMaxSize().padding(16.dp),
@@ -698,7 +700,7 @@ private fun BriefingCaptureField(onClick: () -> Unit) {
         onClick = onClick,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceHighest.copy(alpha = 0.9f),
-        modifier = Modifier.widthIn(max = 720.dp).fillMaxWidth().height(58.dp),
+        modifier = Modifier.widthIn(max = 720.dp).fillMaxWidth().height(58.dp).pointerHoverIcon(PointerIcon.Hand),
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -389,7 +389,7 @@ fun AgendaRow(
                 1.dp,
                 TajsOSTheme.GhostBorder.copy(alpha = 0.15f),
             ),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
     ) {
         Row(
             modifier = Modifier.padding(TajsOSTheme.SpacingMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/health/HealthDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/health/HealthDashboardBlocks.kt
@@ -23,6 +23,8 @@ import com.tajemniktv.tajsos.ui.MainViewModel
 import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.screens.GroupedOpenLoopSection
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object HealthDashboardBlockRegistry {
     private val renderers: Map<String, HealthDashboardBlockRenderer> =
@@ -114,7 +116,7 @@ internal fun HealthMainBlock(
         Column(verticalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
             healthQueue.forEach { item ->
                 Surface(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
                     color = TajsOSTheme.CardSurface,
                     shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                     onClick = { onEditNode(item.node.node.id) },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/insights/InsightsScreen.kt
@@ -41,6 +41,8 @@ import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.insights_needs_attention
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Central insights entry point that collects system state and coordinates layout.
@@ -118,7 +120,7 @@ fun ProjectEntropyItem(
     onClick: () -> Unit,
 ) {
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
         border =
@@ -217,7 +219,7 @@ fun NeglectedProjectItem(
     onClick: () -> Unit,
 ) {
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.CardSurface,
         shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
         border =

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -84,6 +84,8 @@ import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
 import kotlin.math.max
 import kotlin.math.min
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object SearchDashboardBlocks {
     private val renderers: Map<String, SearchDashboardBlockRenderer> =
@@ -486,6 +488,7 @@ private fun RecentQueriesRow(
         LazyRow(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
             items(queries.distinct(), key = { it }) { query ->
                 Surface(
+        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     shape = RoundedCornerShape(999.dp),
                     color = TajsOSTheme.SurfaceHigh,
                     onClick = { onQueryClick(query) },
@@ -667,6 +670,7 @@ private fun SearchResultCard(
         }
 
     Surface(
+        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
         onClick = onOpen,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceLow,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -488,7 +488,7 @@ private fun RecentQueriesRow(
         LazyRow(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
             items(queries.distinct(), key = { it }) { query ->
                 Surface(
-        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     shape = RoundedCornerShape(999.dp),
                     color = TajsOSTheme.SurfaceHigh,
                     onClick = { onQueryClick(query) },
@@ -670,63 +670,13 @@ private fun SearchResultCard(
         }
 
     Surface(
-        modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
         onClick = onOpen,
         shape = RoundedCornerShape(TajsOSTheme.RadiusLg),
         color = TajsOSTheme.SurfaceLow,
     ) {
         Column(modifier = Modifier.fillMaxWidth().padding(TajsOSTheme.SpacingMd)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.Top,
-            ) {
-                Row(
-                    modifier = Modifier.weight(1f),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalAlignment = Alignment.Top,
-                ) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .size(26.dp)
-                                .clip(RoundedCornerShape(TajsOSTheme.RadiusSm))
-                                .background(iconTintForType(node.type).copy(alpha = 0.2f)),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Icon(
-                            iconForType(node.type),
-                            contentDescription = null,
-                            tint = iconTintForType(node.type),
-                            modifier = Modifier.size(15.dp),
-                        )
-                    }
-                    Column {
-                        Text(
-                            text = node.title,
-                            style = MaterialTheme.typography.titleMedium,
-                            color = TajsOSTheme.Text,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Text(
-                            text = subtitle,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = TajsOSTheme.Primary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                }
-
-                Column(horizontalAlignment = Alignment.End) {
-                    Text(
-                        text = "UPDATED ${formatRelativeTime(node.updatedAt, nowMs)}",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = TajsOSTheme.Muted,
-                    )
-                }
-            }
+            SearchResultCardHeader(node = node, subtitle = subtitle, nowMs = nowMs)
 
             Spacer(modifier = Modifier.height(TajsOSTheme.SpacingSm))
             Text(
@@ -822,5 +772,65 @@ private fun formatRelativeTime(
         minutes < 1_440 -> "${minutes / 60}H AGO"
         minutes < 10_080 -> "${minutes / 1_440}D AGO"
         else -> "${minutes / 10_080}W AGO"
+    }
+}
+
+
+@Composable
+private fun SearchResultCardHeader(
+    node: com.tajemniktv.tajsos.data.NodeEntity,
+    subtitle: String,
+    nowMs: Long
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Top,
+    ) {
+        Row(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(26.dp)
+                        .clip(RoundedCornerShape(TajsOSTheme.RadiusSm))
+                        .background(iconTintForType(node.type).copy(alpha = 0.2f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    iconForType(node.type),
+                    contentDescription = null,
+                    tint = iconTintForType(node.type),
+                    modifier = Modifier.size(15.dp),
+                )
+            }
+            Column {
+                Text(
+                    text = node.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = TajsOSTheme.Text,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = TajsOSTheme.Primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = "UPDATED ${formatRelativeTime(node.updatedAt, nowMs)}",
+                style = MaterialTheme.typography.labelSmall,
+                color = TajsOSTheme.Muted,
+            )
+        }
     }
 }


### PR DESCRIPTION
Applied pointerHoverIcon(PointerIcon.Hand) to interactive Surface components and .clickable blocks throughout the composeApp UI code for better visual feedback on desktop/web when hovering over them.

---
*PR created automatically by Jules for task [17669839206086891269](https://jules.google.com/task/17669839206086891269) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

