### PR TITLE
fix(ui): resolve Astro 404 route collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -18,6 +18,8 @@ export default defineConfig({
   base: "/TajsOS/",
   integrations: [
     starlight({
+      // Disable default 404 route because a custom src/pages/404.astro exists
+      disable404Route: true,
       title: "Docs",
       description: "TajsOS Documentation",
 


### PR DESCRIPTION
This pull request resolves an Astro router warning regarding a static route collision for `/404`.

By adding `disable404Route: true` to the Starlight integration configuration in `website/astro.config.mjs`, we instruct Starlight to not generate its default 404 page, safely avoiding the conflict with the existing custom `src/pages/404.astro` page.

---
*PR created automatically by Jules for task [10634619399122120761](https://jules.google.com/task/10634619399122120761) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

