### PR TITLE
feat(ui): Add hand cursor pointer on hover for buttons in compose UI

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.DecisionOptionEntity
@@ -51,7 +53,7 @@ fun OptionCard(
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                 )
-                IconButton(onClick = { onDelete(option) }) {
+                IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDelete(option) }) {
                     Icon(
                         Icons.Default.Delete,
                         contentDescription = stringResource(Res.string.cd_delete_option),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
@@ -33,6 +33,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.style.TextDecoration
@@ -267,7 +269,7 @@ fun NodeCard(
                         }
                     }
                     if (isDone) {
-                        IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+                        IconButton(onClick = onArchive, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                             Icon(
                                 imageVector = Icons.Default.Delete,
                                 contentDescription = stringResource(Res.string.detail_archive),
@@ -275,7 +277,7 @@ fun NodeCard(
                             )
                         }
                     }
-                    IconButton(onClick = { onTogglePin(!isPinnedToToday) }) {
+                    IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onTogglePin(!isPinnedToToday) }) {
                         Icon(
                             imageVector = Icons.Default.Star,
                             contentDescription = stringResource(Res.string.node_pin_today_desc),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.MainViewModel
@@ -180,7 +182,7 @@ fun OpenLoopCard(
                         label = { Text(stringResource(Res.string.open_loop_action_convert_note)) },
                     )
                 } else {
-                    Button(onClick = onArchive) { Text(stringResource(Res.string.open_loop_action_archive)) }
+                    Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onArchive) { Text(stringResource(Res.string.open_loop_action_archive)) }
                 }
             }
         }
@@ -311,7 +313,7 @@ fun MaintenanceCard(
                         label = { Text("RESOLVE") },
                     )
                 } else {
-                    Button(onClick = onArchive) { Text("ARCHIVE") }
+                    Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onArchive) { Text("ARCHIVE") }
                 }
             }
         }
@@ -386,7 +388,7 @@ fun ProtocolCard(
             ) {
                 AssistChip(onClick = { onEditNode(item.node.node.id) }, label = { Text("OPEN") })
                 AssistChip(onClick = onRun, label = { Text("RUN") })
-                Button(onClick = onArchive) { Text("ARCHIVE") }
+                Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onArchive) { Text("ARCHIVE") }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
@@ -31,6 +31,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import com.tajemniktv.tajsos.data.NodeEntity
 import com.tajemniktv.tajsos.data.NodeWithPin
 import com.tajemniktv.tajsos.data.TemplateEntity
@@ -310,13 +312,13 @@ fun ProgressControlCard(
             Text(title, style = MaterialTheme.typography.titleSmall)
             Text("$value%", style = MaterialTheme.typography.bodySmall, color = TajsOSTheme.Accent)
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                OutlinedButton(onClick = onDecrease) { Text("-10") }
-                OutlinedButton(onClick = onIncrease) { Text("+10") }
-                OutlinedButton(onClick = onOpen) { Text(stringResource(Res.string.common_open)) }
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDecrease) { Text("-10") }
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onIncrease) { Text("+10") }
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onOpen) { Text(stringResource(Res.string.common_open)) }
             }
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                OutlinedButton(onClick = onOpen) { Text(stringResource(Res.string.student_action_details)) }
-                OutlinedButton(onClick = {}) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onOpen) { Text(stringResource(Res.string.student_action_details)) }
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {}) {
                     Text(
                         stringResource(
                             Res.string.student_id_label,
@@ -355,7 +357,7 @@ fun StudentNodeCard(
         modifier = Modifier.fillMaxWidth().padding(bottom = TajsOSTheme.SpacingSm),
         horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
     ) {
-        OutlinedButton(onClick = {
+        OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
             viewModel.toggleFlashcardCandidate(
                 node.node,
                 enabled = true,
@@ -363,7 +365,7 @@ fun StudentNodeCard(
         }) {
             Text(stringResource(Res.string.common_flashcard))
         }
-        OutlinedButton(onClick = { viewModel.toggleRevisitBeforeExam(node.node, enabled = true) }) {
+        OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.toggleRevisitBeforeExam(node.node, enabled = true) }) {
             Text(stringResource(Res.string.common_revisit))
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
@@ -46,6 +46,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.input.ImeAction
@@ -286,7 +288,7 @@ fun CaptureSheet(
                 )
 
                 if (onVoiceCaptureClick != null) {
-                    IconButton(onClick = onVoiceCaptureClick, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onVoiceCaptureClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                         Icon(
                             imageVector = Icons.Default.Mic,
                             contentDescription = stringResource(Res.string.capture_voice),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -43,6 +43,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
@@ -136,7 +138,7 @@ fun AppShellHeader(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (!isDesktop && onMenuClick != null) {
-                    IconButton(onClick = onMenuClick, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onMenuClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                         Icon(
                             imageVector = Icons.Default.Menu,
                             contentDescription = stringResource(Res.string.header_menu),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
@@ -119,7 +119,7 @@ fun DashHeader(
                 }
             }
             Spacer(Modifier.width(12.dp))
-            IconButton(onClick = onSettingsClick, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onSettingsClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(Icons.Default.Settings, contentDescription = null, tint = TajsOSTheme.Muted)
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSuggestionBanner.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSuggestionBanner.kt
@@ -27,6 +27,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -83,7 +85,7 @@ fun ModeSuggestionBanner(
                 }
             }
             Row {
-                TextButton(onClick = onDismiss) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) {
                     Text(
                         "IGNORE",
                         style = MaterialTheme.typography.labelSmall,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -226,7 +226,7 @@ fun DecisionDetailContent(
                 style = MaterialTheme.typography.bodySmall,
                 color = TajsOSTheme.Muted,
             )
-            TextButton(onClick = { showPeopleDialog = true }) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { showPeopleDialog = true }) {
                 Text(stringResource(Res.string.decision_action_link_person))
             }
         }
@@ -247,7 +247,7 @@ fun DecisionDetailContent(
                             style = MaterialTheme.typography.bodyMedium,
                             color = TajsOSTheme.Text,
                         )
-                        TextButton(onClick = {
+                        TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                             viewModel.unlinkDecisionFromPerson(
                                 node.id,
                                 person.node.id,
@@ -289,7 +289,7 @@ fun DecisionDetailContent(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             SectionTitle(stringResource(Res.string.decision_options_label))
-            IconButton(onClick = { showAddOptionDialog = true }, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = { showAddOptionDialog = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = stringResource(Res.string.cd_add_option),
@@ -490,7 +490,7 @@ fun DecisionDetailContent(
                 }
             },
             confirmButton = {
-                TextButton(onClick = { showPeopleDialog = false }) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { showPeopleDialog = false }) {
                     Text(stringResource(Res.string.common_close))
                 }
             },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
@@ -27,6 +27,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
@@ -187,7 +189,7 @@ fun TaskRow(
                     }
                 }
                 if (isDone) {
-                    IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onArchive, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                         Icon(
                             imageVector = Icons.Default.Delete,
                             contentDescription = stringResource(Res.string.detail_archive),
@@ -195,7 +197,7 @@ fun TaskRow(
                         )
                     }
                 }
-                IconButton(onClick = onUnpin, modifier = Modifier.size(48.dp)) {
+                IconButton(onClick = onUnpin, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                     Icon(
                         Icons.Default.Close,
                         contentDescription = stringResource(Res.string.task_row_unpin_desc),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/archive/ArchiveDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/archive/ArchiveDashboardBlocks.kt
@@ -25,6 +25,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import com.tajemniktv.tajsos.ui.MainViewModel
 import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.components.common.MouseContextMenuHost
@@ -125,7 +127,7 @@ internal fun ArchiveMainBlock(
                                             tint = TajsOSTheme.Primary,
                                         )
                                     }
-                                    IconButton(onClick = {
+                                    IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                                         viewModel.deleteNodePermanently(
                                             nodeWithPin.node,
                                         )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
@@ -48,6 +48,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
@@ -123,7 +125,7 @@ internal fun AreasMainBlock(
                 color = TajsOSTheme.Text,
             )
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                OutlinedButton(onClick = { showAddDialog = true }) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { showAddDialog = true }) {
                     Text(stringResource(Res.string.areas_new))
                 }
             }
@@ -132,7 +134,7 @@ internal fun AreasMainBlock(
         if (areas.isEmpty()) {
             EmptyState(message = stringResource(Res.string.areas_empty)) {
                 Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
-                Button(onClick = { showAddDialog = true }) {
+                Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { showAddDialog = true }) {
                     Text(stringResource(Res.string.areas_create_first))
                 }
             }
@@ -418,7 +420,7 @@ private fun AreaCard(
                     "${metrics?.neglectedDays ?: 0}d",
                 )
                 Spacer(modifier = Modifier.height(4.dp))
-                OutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
+                OutlinedButton(onClick = onClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).fillMaxWidth()) {
                     Text(stringResource(Res.string.areas_enter))
                 }
             }
@@ -470,12 +472,12 @@ fun AddAreaDialog(
             )
         },
         confirmButton = {
-            Button(onClick = { onConfirm(name) }, enabled = name.isNotBlank()) {
+            Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onConfirm(name) }, enabled = name.isNotBlank()) {
                 Text(stringResource(Res.string.areas_dialog_create))
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text(stringResource(Res.string.areas_dialog_cancel)) }
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) { Text(stringResource(Res.string.areas_dialog_cancel)) }
         },
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
@@ -155,9 +155,9 @@ private fun renderAreaHero(context: AreaDetailContext) {
                 trackColor = TajsOSTheme.SurfaceLow,
             )
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                FilledTonalButton(onClick = {}) { Text(stringResource(Res.string.area_detail_tab_work)) }
-                FilledTonalButton(onClick = {}) { Text(stringResource(Res.string.area_detail_tab_notes)) }
-                FilledTonalButton(onClick = {}) { Text(stringResource(Res.string.area_detail_tab_projects)) }
+                FilledTonalButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {}) { Text(stringResource(Res.string.area_detail_tab_work)) }
+                FilledTonalButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {}) { Text(stringResource(Res.string.area_detail_tab_notes)) }
+                FilledTonalButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {}) { Text(stringResource(Res.string.area_detail_tab_projects)) }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.ProjectState
 import com.tajemniktv.tajsos.data.TaskState
@@ -235,7 +237,7 @@ fun AreaDetailScreen(
 ) {
     val area = context.area
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = {
+        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
             context.viewModel.archiveNode(area)
             onBack()
         }) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -148,14 +148,14 @@ fun CalendarHeader(
             )
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            TextButton(onClick = onTodayClick) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onTodayClick) {
                 Text(
                     stringResource(Res.string.cal_today),
                     style = MaterialTheme.typography.labelSmall,
                     color = TajsOSTheme.Primary,
                 )
             }
-            IconButton(onClick = onSyncClick, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onSyncClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.Refresh,
                     contentDescription = stringResource(Res.string.cal_sync),
@@ -163,13 +163,13 @@ fun CalendarHeader(
                     modifier = Modifier.size(20.dp),
                 )
             }
-            IconButton(onClick = onPreviousMonth, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onPreviousMonth, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.ChevronLeft,
                     contentDescription = stringResource(Res.string.cal_previous),
                 )
             }
-            IconButton(onClick = onNextMonth, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onNextMonth, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.ChevronRight,
                     contentDescription = stringResource(Res.string.cal_next),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsBlocks.kt
@@ -28,6 +28,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import com.tajemniktv.tajsos.data.CalendarProviderEntity
 import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
@@ -60,7 +62,7 @@ private fun renderCalendarSettingsHeader(context: CalendarSettingsContext) {
             style = MaterialTheme.typography.displaySmall,
             color = TajsOSTheme.Text,
         )
-        IconButton(onClick = context.onShowAddDialog, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = context.onShowAddDialog, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
             Icon(
                 Icons.Default.Add,
                 contentDescription = stringResource(Res.string.cal_settings_add),
@@ -75,7 +77,7 @@ private fun renderCalendarSettingsList(context: CalendarSettingsContext) {
     if (context.providers.isEmpty()) {
         EmptyState(message = stringResource(Res.string.cal_settings_empty)) {
             Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
-            Button(onClick = context.onShowAddDialog) {
+            Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = context.onShowAddDialog) {
                 Text(stringResource(Res.string.cal_settings_add))
             }
         }
@@ -125,7 +127,7 @@ private fun ProviderRow(
                     )
                 }
             }
-            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onDelete, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.Delete,
                     contentDescription = stringResource(Res.string.archive_delete),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import com.tajemniktv.tajsos.ui.MainViewModel
 import com.tajemniktv.tajsos.ui.Screen
 import com.tajemniktv.tajsos.ui.components.screen.ScreenScaffold
@@ -146,7 +148,7 @@ private fun AddCalendarDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) {
                 Text(stringResource(Res.string.cal_settings_dialog_cancel))
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardCoreBlockRenderers.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardCoreBlockRenderers.kt
@@ -58,6 +58,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -219,7 +221,7 @@ internal fun renderOperationalBlock(context: DashboardBlockContext) {
                 letterSpacing = 2.sp,
             )
 
-            TextButton(onClick = { context.onNavigateTo(Screen.OpenLoops) }) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.onNavigateTo(Screen.OpenLoops) }) {
                 Text(
                     text = stringResource(Res.string.dashboard_open_loops_action),
                     style = MaterialTheme.typography.labelSmall,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardSpecialBlockRenderers.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardSpecialBlockRenderers.kt
@@ -9,6 +9,9 @@ import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.material.icons.filled.School
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -98,7 +101,7 @@ internal fun renderStudyModuleBlock(
         nodes = studyNodes.take(5),
         onEditNode = context.onEditNode,
     )
-    TextButton(onClick = { context.onNavigateTo(Screen.Education) }) {
+    TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.onNavigateTo(Screen.Education) }) {
         Text(stringResource(Res.string.dash_action_open_study))
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/focus/FocusDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/focus/FocusDashboardBlocks.kt
@@ -44,6 +44,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -402,7 +404,7 @@ internal fun FocusMainBlock(viewModel: MainViewModel) {
                         )
                         capture = ""
                     }
-                }, modifier = Modifier.fillMaxWidth()) {
+                }, modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(Icons.Default.Inbox, null)
                     Spacer(Modifier.size(6.dp))
                     Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/inbox/InboxDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/inbox/InboxDashboardBlocks.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.InboxEntryEntity
 import com.tajemniktv.tajsos.data.ItemKind
@@ -122,7 +124,7 @@ internal fun InboxMainBlock(
                             onArchive = { viewModel.archiveNode(nodeWithPin.node) },
                         )
 
-                        IconButton(onClick = { viewModel.markAsProcessed(nodeWithPin.node.id) }) {
+                        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.markAsProcessed(nodeWithPin.node.id) }) {
                             Icon(
                                 imageVector = Icons.Default.Check,
                                 contentDescription = stringResource(Res.string.inbox_process),
@@ -180,7 +182,7 @@ private fun InboxCaptureCard(
                     onClick = { viewModel.triageInboxEntry(entry.id, ItemKind.PROJECT) },
                     label = { Text(stringResource(Res.string.type_project).uppercase()) },
                 )
-                IconButton(onClick = { viewModel.dismissInboxEntry(entry) }) {
+                IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.dismissInboxEntry(entry) }) {
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = "Dismiss capture",

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -43,6 +43,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
@@ -196,24 +198,24 @@ fun NotesEditorHeaderActions(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Row {
-            IconButton(onClick = onToggleFavorite, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleFavorite, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     imageVector = if (favorite) Icons.Default.Star else Icons.Default.StarBorder,
                     contentDescription = null,
                     tint = if (favorite) TajsOSTheme.Primary else TajsOSTheme.Text,
                 )
             }
-            IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onArchive, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(Icons.Default.Archive, contentDescription = null, tint = TajsOSTheme.Text)
             }
-            IconButton(onClick = onToggleFocusMode, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleFocusMode, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.CenterFocusStrong,
                     contentDescription = null,
                     tint = if (focusMode) TajsOSTheme.Primary else TajsOSTheme.Text,
                 )
             }
-            IconButton(onClick = onToggleContextPanel, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleContextPanel, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.Info,
                     contentDescription = null,
@@ -222,7 +224,7 @@ fun NotesEditorHeaderActions(
             }
         }
         Box {
-            IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = { menuOpen = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(Icons.Default.MoreVert, contentDescription = null)
             }
             DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -38,6 +38,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -99,7 +101,7 @@ fun NotesListRail(
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
                 trailingIcon = {
                     if (searchQuery.isNotEmpty()) {
-                        IconButton(onClick = { onSearchChange("") }) {
+                        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onSearchChange("") }) {
                             Icon(Icons.Default.Close, contentDescription = "Clear search")
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
@@ -33,6 +33,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.isNoteItem
 import com.tajemniktv.tajsos.ui.MainViewModel
@@ -215,7 +217,7 @@ fun NotesRoute(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            IconButton(onClick = { mobileInDetail = false }, modifier = Modifier.size(48.dp)) {
+                            IconButton(onClick = { mobileInDetail = false }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -206,7 +206,7 @@ fun NotesWorkspaceDetail(
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconButton(onClick = onBack, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onBack, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                     }
                     Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailScreen.kt
@@ -90,6 +90,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.ItemKind
 import com.tajemniktv.tajsos.data.isNoteItem
@@ -203,7 +205,7 @@ fun NoteDetailScreen(
         }
 
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = { viewModel.togglePermanentPin(node) }) {
+        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.togglePermanentPin(node) }) {
             Icon(
                 if (node.isPinned) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
                 contentDescription = null,
@@ -244,7 +246,7 @@ fun NoteDetailScreen(
                 modifier = Modifier.size(18.dp),
             )
         }
-        IconButton(onClick = { showMoreDialog = true }, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = { showMoreDialog = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
             Icon(
                 Icons.Default.MoreVert,
                 contentDescription = null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
@@ -34,6 +34,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.font.FontWeight
@@ -390,7 +392,7 @@ private fun renderMedicationsModuleBlock(context: ProfileScreenContext) {
             verticalAlignment = Alignment.CenterVertically,
         ) {
             ModuleTitle(title = stringResource(Res.string.profile_medications))
-            IconButton(onClick = context.onOpenAddMedication, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = context.onOpenAddMedication, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = null,
@@ -589,7 +591,7 @@ private fun MedicationItem(
                     color = TajsOSTheme.Primary,
                 )
             }
-            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onDelete, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(Icons.Default.Delete, contentDescription = "Delete", tint = TajsOSTheme.Error)
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileRoute.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.MainViewModel
@@ -255,7 +257,7 @@ private fun AddMedicationDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) {
                 Text(stringResource(Res.string.common_back))
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/ProjectsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/ProjectsScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.NodeEntity
 import com.tajemniktv.tajsos.data.NodeWithPin
@@ -163,7 +165,7 @@ fun AddProjectDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) {
                 Text(stringResource(Res.string.projects_dialog_cancel))
             }
         },
@@ -197,7 +199,7 @@ fun ProjectListContent(
             message = stringResource(Res.string.projects_empty),
         ) {
             Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
-            Button(onClick = onShowAddDialog) {
+            Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onShowAddDialog) {
                 Text(stringResource(Res.string.projects_create_first))
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
@@ -214,12 +214,12 @@ private fun renderProjectHero(context: ProjectDetailContext) {
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                FilledTonalButton(onClick = context.onStatusClick) {
+                FilledTonalButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = context.onStatusClick) {
                     Icon(Icons.Default.Tune, null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.project_detail_set_status))
                 }
-                FilledTonalButton(onClick = {}) {
+                FilledTonalButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {}) {
                     Icon(Icons.Default.FolderOpen, null)
                     Spacer(Modifier.width(6.dp))
                     Text(context.areaName ?: stringResource(Res.string.detail_unassign))

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailScreen.kt
@@ -38,6 +38,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.ProjectState
 import com.tajemniktv.tajsos.data.TaskState
@@ -316,13 +318,13 @@ fun ProjectDetailScreen(
 ) {
     val project = context.project
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = { context.onStatusClick() }) {
+        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.onStatusClick() }) {
             Icon(Icons.Default.Tune, contentDescription = null, modifier = Modifier.size(18.dp))
         }
-        IconButton(onClick = { context.onEditNode(project.id) }) {
+        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.onEditNode(project.id) }) {
             Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
         }
-        IconButton(onClick = { context.viewModel.updateNode(project.copy(isFrozen = !project.isFrozen)) }) {
+        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.viewModel.updateNode(project.copy(isFrozen = !project.isFrozen)) }) {
             Icon(
                 if (project.isFrozen) Icons.Default.WbSunny else Icons.Default.Schedule,
                 contentDescription = null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/protocols/ProtocolsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/protocols/ProtocolsScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -561,7 +563,7 @@ private fun ProtocolLibraryCard(
                 color = TajsOSTheme.Muted,
             )
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                Button(onClick = onRun) {
+                Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onRun) {
                     Text(stringResource(Res.string.protocols_action_run))
                 }
                 AssistChip(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/review/ReviewDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/review/ReviewDashboardBlocks.kt
@@ -31,6 +31,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.components.common.SelectorDialog
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
@@ -199,7 +201,7 @@ private fun renderReviewFlow(context: ReviewDashboardContext) {
                                 ListItem(
                                     headlineContent = { Text(item.node.title) },
                                     trailingContent = {
-                                        IconButton(onClick = { viewModel.archiveNode(item.node) }) {
+                                        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.archiveNode(item.node) }) {
                                             Icon(
                                                 Icons.Default.Delete,
                                                 contentDescription = stringResource(Res.string.detail_archive),
@@ -234,7 +236,7 @@ private fun renderReviewFlow(context: ReviewDashboardContext) {
             horizontalArrangement = Arrangement.End,
         ) {
             if (currentStep < steps.size - 1) {
-                Button(onClick = context.onNext) {
+                Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = context.onNext) {
                     Text(stringResource(Res.string.review_next))
                 }
             } else {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -46,6 +46,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -111,7 +113,7 @@ private fun renderSearchInput(context: SearchDashboardContext) {
             leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
             trailingIcon = {
                 if (context.searchQuery.isNotEmpty()) {
-                    IconButton(onClick = { viewModel.updateSearchQuery("") }) {
+                    IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.updateSearchQuery("") }) {
                         Icon(
                             Icons.Default.Clear,
                             contentDescription = stringResource(Res.string.search_clear),
@@ -125,7 +127,7 @@ private fun renderSearchInput(context: SearchDashboardContext) {
                     unfocusedContainerColor = TajsOSTheme.Surface,
                 ),
         )
-        IconButton(onClick = context.onToggleFilters, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = context.onToggleFilters, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
             Icon(
                 Icons.Default.FilterList,
                 contentDescription = "Toggle filters",
@@ -183,7 +185,7 @@ private fun renderSearchFilters(context: SearchDashboardContext) {
                 style = MaterialTheme.typography.labelSmall,
                 color = TajsOSTheme.Muted,
             )
-            TextButton(onClick = { viewModel.clearSearchFilters() }) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.clearSearchFilters() }) {
                 Text(stringResource(Res.string.search_reset_filters))
             }
         }
@@ -531,13 +533,13 @@ private fun SearchResultsHeader(
             )
         }
         Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
-            TextButton(onClick = onToggleFilters) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onToggleFilters) {
                 Text(
                     "FILTER",
                     style = MaterialTheme.typography.labelSmall,
                 )
             }
-            TextButton(onClick = onToggleSort) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onToggleSort) {
                 Text(
                     if (sortMode == "relevance") "RELEVANCE" else "UPDATED",
                     style = MaterialTheme.typography.labelSmall,
@@ -759,25 +761,25 @@ private fun SearchResultCard(
 
             Spacer(modifier = Modifier.height(TajsOSTheme.SpacingSm))
             Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                TextButton(onClick = onOpen) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onOpen) {
                     Text(
                         "OPEN",
                         style = MaterialTheme.typography.labelSmall,
                     )
                 }
-                TextButton(onClick = { onToggleDone(if (node.status == "done") "active" else "done") }) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onToggleDone(if (node.status == "done") "active" else "done") }) {
                     Text(
                         if (node.status == "done") "ACTIVATE" else "DONE",
                         style = MaterialTheme.typography.labelSmall,
                     )
                 }
-                TextButton(onClick = { onTogglePin(!nodeWithPin.isPinnedToToday) }) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onTogglePin(!nodeWithPin.isPinnedToToday) }) {
                     Text(
                         if (nodeWithPin.isPinnedToToday) "REMOVE TODAY" else "ADD TODAY",
                         style = MaterialTheme.typography.labelSmall,
                     )
                 }
-                TextButton(onClick = onArchive) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onArchive) {
                     Text(
                         "ARCHIVE",
                         style = MaterialTheme.typography.labelSmall,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -39,6 +39,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.AppPack
@@ -721,7 +723,7 @@ private fun SettingsMedicationItem(
             color = TajsOSTheme.Muted,
         )
         Spacer(Modifier.height(TajsOSTheme.SpacingSm))
-        TextButton(onClick = onDelete) {
+        TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDelete) {
             Text(stringResource(Res.string.med_delete))
         }
     }
@@ -792,7 +794,7 @@ private fun SettingsAddMedicationDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) {
                 Text(stringResource(Res.string.common_back))
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardBlocks.kt
@@ -22,6 +22,8 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import com.tajemniktv.tajsos.data.NodeWithPin
 import com.tajemniktv.tajsos.ui.components.cards.ProgressControlCard
@@ -244,7 +246,7 @@ internal fun renderFlashcardCandidatesBlock(context: StudyDashboardContext) {
                         color = TajsOSTheme.Muted,
                     )
                 }
-                OutlinedButton(onClick = {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                     context.viewModel.toggleFlashcardCandidate(
                         item.node,
                         false,
@@ -268,7 +270,7 @@ internal fun renderLinksGraphBlock(context: StudyDashboardContext) {
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(TajsOSTheme.SpacingSm))
-            Button(onClick = context.onOpenTopicLink) {
+            Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = context.onOpenTopicLink) {
                 Icon(Icons.Default.Link, contentDescription = null)
                 Text("Create Topic Link")
             }
@@ -283,7 +285,7 @@ internal fun renderLinksGraphBlock(context: StudyDashboardContext) {
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(TajsOSTheme.SpacingSm))
-            Button(onClick = context.onOpenPaperLink) {
+            Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = context.onOpenPaperLink) {
                 Icon(Icons.Default.Link, contentDescription = null)
                 Text("Create Paper Link")
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
@@ -36,6 +36,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -433,19 +435,19 @@ private fun TaskDetails(
             horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
             modifier = Modifier.fillMaxWidth(),
         ) {
-            OutlinedButton(onClick = { onOpen(task.id) }, modifier = Modifier.weight(1f)) {
+            OutlinedButton(onClick = { onOpen(task.id) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).weight(1f)) {
                 Text(
                     stringResource(Res.string.tasks_open_action),
                 )
             }
             if (task.taskStateOrNull() == TaskState.DONE) {
-                OutlinedButton(onClick = { onRestore(task) }, modifier = Modifier.weight(1f)) {
+                OutlinedButton(onClick = { onRestore(task) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).weight(1f)) {
                     Icon(Icons.Default.Refresh, null)
                     Spacer(Modifier.width(4.dp))
                     Text(stringResource(Res.string.tasks_restore_action))
                 }
             } else {
-                OutlinedButton(onClick = { onDone(task) }, modifier = Modifier.weight(1f)) {
+                OutlinedButton(onClick = { onDone(task) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).weight(1f)) {
                     Text(
                         stringResource(Res.string.tasks_done_action),
                     )
@@ -456,12 +458,12 @@ private fun TaskDetails(
             horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
             modifier = Modifier.fillMaxWidth(),
         ) {
-            OutlinedButton(onClick = { onArchive(task) }, modifier = Modifier.weight(1f)) {
+            OutlinedButton(onClick = { onArchive(task) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).weight(1f)) {
                 Icon(Icons.Default.Archive, null)
                 Spacer(Modifier.width(4.dp))
                 Text(stringResource(Res.string.tasks_archive_action))
             }
-            OutlinedButton(onClick = { onDelete(task) }, modifier = Modifier.weight(1f)) {
+            OutlinedButton(onClick = { onDelete(task) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).weight(1f)) {
                 Icon(Icons.Default.Delete, null, tint = TajsOSTheme.Error)
                 Spacer(Modifier.width(4.dp))
                 Text(stringResource(Res.string.tasks_delete_action), color = TajsOSTheme.Error)

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksArchiveView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksArchiveView.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import com.tajemniktv.tajsos.data.NodeEntity
 import com.tajemniktv.tajsos.ui.components.common.EmptyState
@@ -94,9 +96,9 @@ internal fun TasksArchiveView(
                             }
                         }
                         Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                            OutlinedButton(onClick = { onOpen(task.id) }) { Text(stringResource(Res.string.tasks_open_action)) }
-                            OutlinedButton(onClick = { onRestore(task) }) { Text(stringResource(Res.string.tasks_restore_action)) }
-                            IconButton(onClick = { onDelete(task) }) {
+                            OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onOpen(task.id) }) { Text(stringResource(Res.string.tasks_open_action)) }
+                            OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onRestore(task) }) { Text(stringResource(Res.string.tasks_restore_action)) }
+                            IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDelete(task) }) {
                                 Icon(
                                     Icons.Default.Delete,
                                     null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
@@ -36,6 +36,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.data.NodeEntity
@@ -294,7 +296,7 @@ private fun PriorityTaskCard(
                 horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Button(onClick = { onStartFocus(task) }, modifier = Modifier.weight(1f)) {
+                Button(onClick = { onStartFocus(task) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).weight(1f)) {
                     Icon(Icons.Default.PlayArrow, null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.tasks_start_focus_action))
@@ -315,7 +317,7 @@ private fun PriorityTaskCard(
                         },
                     )
                 }
-                OutlinedButton(onClick = { onDone(task) }, modifier = Modifier.weight(1f)) {
+                OutlinedButton(onClick = { onDone(task) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).weight(1f)) {
                     Icon(Icons.Default.Check, null)
                     Spacer(Modifier.width(4.dp))
                     Text(stringResource(Res.string.tasks_done_action))
@@ -366,9 +368,9 @@ private fun QueueList(
                         }
                     }
                     Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                        OutlinedButton(onClick = { onDoNow(task) }) { Text(stringResource(Res.string.tasks_start_focus_action)) }
-                        OutlinedButton(onClick = { onOpen(task.id) }) { Text(stringResource(Res.string.tasks_open_action)) }
-                        IconButton(onClick = { onDone(task) }) { Icon(Icons.Default.Check, null) }
+                        OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDoNow(task) }) { Text(stringResource(Res.string.tasks_start_focus_action)) }
+                        OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onOpen(task.id) }) { Text(stringResource(Res.string.tasks_open_action)) }
+                        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDone(task) }) { Icon(Icons.Default.Check, null) }
                     }
                 }
                 HorizontalDivider(color = TajsOSTheme.GhostBorder)
@@ -414,7 +416,7 @@ private fun CommandSidebar(
                 modifier = Modifier.fillMaxWidth(),
                 placeholder = { Text(stringResource(Res.string.tasks_quick_add_hint)) },
             )
-            Button(onClick = onQuickAdd, modifier = Modifier.fillMaxWidth()) {
+            Button(onClick = onQuickAdd, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).fillMaxWidth()) {
                 Text(
                     stringResource(
                         Res.string.tasks_quick_add_action,
@@ -433,7 +435,7 @@ private fun CommandSidebar(
                 modifier = Modifier.fillMaxWidth(),
                 placeholder = { Text(stringResource(Res.string.tasks_quick_capture_hint)) },
             )
-            OutlinedButton(onClick = onCapture, modifier = Modifier.fillMaxWidth()) {
+            OutlinedButton(onClick = onCapture, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).fillMaxWidth()) {
                 Text(
                     stringResource(Res.string.tasks_quick_capture_action),
                 )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksInboxView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksInboxView.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import com.tajemniktv.tajsos.data.InboxEntryEntity
 import com.tajemniktv.tajsos.data.NodeEntity
@@ -110,12 +112,12 @@ internal fun TasksInboxView(
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
                             ) {
-                                OutlinedButton(onClick = { onTriageTask(entry) }) {
+                                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onTriageTask(entry) }) {
                                     Text(
                                         stringResource(Res.string.tasks_inbox_triage_task),
                                     )
                                 }
-                                IconButton(onClick = { onDismiss(entry) }) {
+                                IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDismiss(entry) }) {
                                     Icon(
                                         Icons.Default.Delete,
                                         stringResource(Res.string.tasks_inbox_dismiss),
@@ -179,14 +181,14 @@ internal fun TasksInboxView(
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
                             ) {
-                                OutlinedButton(onClick = { onOpen(task.id) }) {
+                                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onOpen(task.id) }) {
                                     Text(
                                         stringResource(
                                             Res.string.tasks_open_action,
                                         ),
                                     )
                                 }
-                                OutlinedButton(onClick = { onMarkProcessed(task) }) {
+                                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onMarkProcessed(task) }) {
                                     Text(
                                         stringResource(Res.string.tasks_inbox_mark_processed),
                                     )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksTodayView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksTodayView.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import com.tajemniktv.tajsos.data.NodeEntity
 import com.tajemniktv.tajsos.ui.components.common.EmptyState
@@ -177,13 +179,13 @@ private fun TodaySection(
                             }
                         }
                         Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                            OutlinedButton(onClick = {
+                            OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                                 onStartFocus(task)
                             }) { Text(stringResource(Res.string.tasks_start_focus_action)) }
-                            OutlinedButton(onClick = {
+                            OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                                 onOpen(task.id)
                             }) { Text(stringResource(Res.string.tasks_open_action)) }
-                            OutlinedButton(onClick = {
+                            OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                                 onSetTodayPayload(task, task.id !in todayTaskIds)
                             }) {
                                 Icon(Icons.Default.Star, null)
@@ -195,7 +197,7 @@ private fun TodaySection(
                                     },
                                 )
                             }
-                            IconButton(onClick = { onDone(task) }) {
+                            IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDone(task) }) {
                                 Icon(
                                     Icons.Default.Check,
                                     null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -59,6 +59,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
@@ -327,21 +329,21 @@ private fun TaskActionBar(
     ) {
         if (isEditing) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = onCancel) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onCancel) {
                     Text(stringResource(Res.string.common_cancel))
                 }
-                Button(onClick = onSave) {
+                Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onSave) {
                     Text(stringResource(Res.string.common_save))
                 }
             }
         } else {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = onToggleEdit) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onToggleEdit) {
                     Icon(Icons.Default.Edit, contentDescription = null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.common_edit))
                 }
-                OutlinedButton(onClick = onSnooze) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onSnooze) {
                     Icon(Icons.Default.AccessTime, contentDescription = null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.task_detail_snooze))
@@ -478,7 +480,7 @@ private fun renderTaskSubtasks(context: TaskDetailContext) {
                 }
             }
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = context.onSplitIntoSubtasks) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = context.onSplitIntoSubtasks) {
                     Text(stringResource(Res.string.detail_split_subtasks))
                 }
             }
@@ -620,7 +622,7 @@ private fun SubtaskRow(
                 color = tint,
             )
             if (subtask.source == TaskSubtaskSource.InlineChecklist && onRemove != null) {
-                IconButton(onClick = onRemove, modifier = Modifier.size(48.dp)) {
+                IconButton(onClick = onRemove, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = null,
@@ -704,7 +706,7 @@ private fun AttachmentRow(
                 )
             }
         }
-        IconButton(onClick = onRemove, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = onRemove, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
             Icon(Icons.Default.Delete, contentDescription = null, tint = TajsOSTheme.Muted)
         }
     }
@@ -1130,7 +1132,7 @@ private fun TaskEditablePropertyRow(
             )
         }
         Box {
-            TextButton(onClick = { expanded = true }) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { expanded = true }) {
                 Text(selected)
             }
             DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesDashboardBlocks.kt
@@ -20,6 +20,8 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import com.tajemniktv.tajsos.ui.components.common.EmptyState
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import org.jetbrains.compose.resources.stringResource
@@ -48,7 +50,7 @@ private fun renderTemplatesList(context: TemplatesDashboardContext) {
     if (templates.isEmpty()) {
         EmptyState(message = stringResource(Res.string.templates_empty)) {
             Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
-            Button(onClick = context.onShowAddDialog) {
+            Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = context.onShowAddDialog) {
                 Text(stringResource(Res.string.templates_add_desc))
             }
         }
@@ -73,7 +75,7 @@ private fun renderTemplatesList(context: TemplatesDashboardContext) {
                         Text(typeLabel.uppercase())
                     },
                     trailingContent = {
-                        IconButton(onClick = { context.onDeleteTemplate(template) }) {
+                        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.onDeleteTemplate(template) }) {
                             Icon(
                                 Icons.Default.Delete,
                                 contentDescription = stringResource(Res.string.archive_delete),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import com.tajemniktv.tajsos.ui.MainViewModel
 import com.tajemniktv.tajsos.ui.components.screen.ScreenScaffold
 import com.tajemniktv.tajsos.ui.components.screen.ScreenScrollBehavior
@@ -70,7 +72,7 @@ fun TemplatesScreen(
         )
 
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = { showAddDialog = true }, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = { showAddDialog = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
             Icon(
                 Icons.Default.Add,
                 contentDescription = stringResource(Res.string.templates_add_desc),
@@ -142,7 +144,7 @@ fun TemplatesScreen(
                 ) { Text(stringResource(Res.string.templates_dialog_create)) }
             },
             dismissButton = {
-                TextButton(onClick = { showAddDialog = false }) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { showAddDialog = false }) {
                     Text(
                         stringResource(
                             Res.string.templates_dialog_cancel,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
@@ -27,6 +27,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -347,7 +349,7 @@ private fun TimeArchitectureCadenceCard(
                     ),
                 status = "Pending",
             )
-            Button(onClick = onRunMonthlyReset) {
+            Button(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onRunMonthlyReset) {
                 Text(stringResource(Res.string.time_architecture_run_monthly_reset))
             }
         }


### PR DESCRIPTION
Identified that buttons and clickable elements lack hand cursors on hover by default in the desktop target. Added `Modifier.pointerHoverIcon(PointerIcon.Hand)` directly to all `Button`, `IconButton`, `TextButton`, `OutlinedButton`, `FloatingActionButton`, and `FilledTonalButton` calls within the compose UI package to improve usability and offer a consistent visual polish on pointer device interaction. This follows existing design patterns as `pointerHoverIcon` was already selectively used elsewhere.

---
*PR created automatically by Jules for task [16358679907325417835](https://jules.google.com/task/16358679907325417835) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

