### PR TITLE
fix(website): resolve 404 static route collision in build

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -21,6 +21,10 @@ export default defineConfig({
       title: "Docs",
       description: "TajsOS Documentation",
 
+
+      // Disable default 404 route to prevent collision with custom src/pages/404.astro
+      disable404Route: true,
+
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",
       },


### PR DESCRIPTION
This PR addresses a build warning in the Astro/Starlight `/website` project where the `/404` static route collided between the custom `src/pages/404.astro` and Starlight's internal routes.

Changes made:
- Added `disable404Route: true` to the Starlight configuration in `website/astro.config.mjs`.
- Added an inline comment to ensure the reasoning is clear for future developers and reviewers.

The changes have been verified locally using `npm run build && npm run check`, which confirmed the warning is now resolved.

---
*PR created automatically by Jules for task [2014921934697789277](https://jules.google.com/task/2014921934697789277) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

