### PR TITLE
fix(reliability): replace generic catch-all with specific exception handlers

### DIFF
--- a/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/tajemniktv/tajsos/MainActivity.kt
@@ -423,7 +423,7 @@ class MainActivity : FragmentActivity() {
                             viewModel.setAuthenticated(true)
                         } catch (e: CancellationException) {
                             throw e
-                        } catch (e: Exception) {
+                        } catch (e: java.security.GeneralSecurityException) {
                             Log.e(TAG, "Biometric crypto operation failed: ${e.javaClass.simpleName}")
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -126,19 +126,25 @@ fun App(
 
     val accentColor =
         remember(accentColorHex) {
-            try {
+            run {
                 val hex = accentColorHex.removePrefix("#")
                 if (hex.length == 6) {
-                    androidx.compose.ui.graphics.Color(
-                        red = hex.substring(0, 2).toInt(16),
-                        green = hex.substring(2, 4).toInt(16),
-                        blue = hex.substring(4, 6).toInt(16),
-                    )
+                    val red = hex.substring(0, 2).toIntOrNull(16)
+                    val green = hex.substring(2, 4).toIntOrNull(16)
+                    val blue = hex.substring(4, 6).toIntOrNull(16)
+
+                    if (red != null && green != null && blue != null) {
+                        androidx.compose.ui.graphics.Color(
+                            red = red,
+                            green = green,
+                            blue = blue,
+                        )
+                    } else {
+                        TajsOSTheme.Primary
+                    }
                 } else {
                     TajsOSTheme.Primary
                 }
-            } catch (_: IllegalArgumentException) {
-                TajsOSTheme.Primary
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -941,10 +941,9 @@ private fun RenderTaskMetadataProperties(
                 TaskPropertyOption(TaskDuePreset.InSevenDays.name, "In 7 days"),
             ),
         onSelect = { value ->
-            try {
-                context.onDuePresetChange(TaskDuePreset.valueOf(value))
-            } catch (e: IllegalArgumentException) {
-                // Ignore invalid values to prevent crashes
+            val preset = TaskDuePreset.entries.find { it.name == value }
+            if (preset != null) {
+                context.onDuePresetChange(preset)
             }
         },
     )

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/routes/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/routes/SyncRoutes.kt
@@ -78,9 +78,18 @@ fun Route.syncRoutes() {
             } catch (e: CancellationException) {
                 // Rethrow cancellation to let coroutines cancel gracefully
                 throw e
-            } catch (e: Exception) {
+            } catch (e: io.ktor.server.plugins.BadRequestException) {
                 call.application.environment.log.error("Failed to process sync request", e)
                 // If it fails to deserialize or handle the request, return a 400 Bad Request
+                call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse(
+                        error = "Invalid sync request payload",
+                        details = "The request could not be processed due to a malformed payload",
+                    ),
+                )
+            } catch (e: kotlinx.serialization.SerializationException) {
+                call.application.environment.log.error("Failed to process sync request", e)
                 call.respond(
                     HttpStatusCode.BadRequest,
                     ErrorResponse(

--- a/server/src/main/kotlin/com/tajemniktv/tajsos/routes/SyncRoutes.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/routes/SyncRoutes.kt
@@ -20,85 +20,81 @@ import kotlinx.coroutines.CancellationException
 private val syncStore = LinkedHashMap<String, SyncItem>()
 private val syncStoreLock = Any()
 
+private suspend fun io.ktor.server.application.ApplicationCall.handleSyncError(e: Throwable) {
+    application.environment.log.error("Failed to process sync request", e)
+    respond(
+        HttpStatusCode.BadRequest,
+        ErrorResponse(
+            error = "Invalid sync request payload",
+            details = "The request could not be processed due to a malformed payload",
+        ),
+    )
+}
+
 fun Route.syncRoutes() {
     authenticate("sync-auth") {
         route("/sync") {
-        post {
-            try {
-                // Manually check content type but use match to handle charsets correctly
-                val contentType = call.request.contentType()
-                if (!contentType.match(ContentType.Application.Json)) {
-                    call.respond(
-                        HttpStatusCode.UnsupportedMediaType,
-                        ErrorResponse(
-                            error = "Unsupported Media Type",
-                            details = "Content-Type must be application/json",
-                        ),
-                    )
-                    return@post
-                }
-
-                val request = call.receive<SyncRequest>()
-
-                val conflicts = mutableListOf<String>()
-                val acknowledged = mutableListOf<String>()
-                val outgoingItems: List<SyncItem>
-
-                synchronized(syncStoreLock) {
-                    request.items.forEach { incoming ->
-                        val existing = syncStore[incoming.id]
-                        if (existing == null || incoming.updatedAt >= existing.updatedAt) {
-                            syncStore[incoming.id] = incoming
-                            acknowledged += incoming.id
-                        } else {
-                            conflicts += incoming.id
-                        }
+            post {
+                try {
+                    // Manually check content type but use match to handle charsets correctly
+                    val contentType = call.request.contentType()
+                    if (!contentType.match(ContentType.Application.Json)) {
+                        call.respond(
+                            HttpStatusCode.UnsupportedMediaType,
+                            ErrorResponse(
+                                error = "Unsupported Media Type",
+                                details = "Content-Type must be application/json",
+                            ),
+                        )
+                        return@post
                     }
 
-                    outgoingItems =
-                        syncStore.values
-                            .filter { it.updatedAt > request.lastSyncTime }
-                            .filterNot { serverItem ->
-                                request.items.any { local ->
-                                    local.id == serverItem.id && local.updatedAt == serverItem.updatedAt
-                                }
-                            }.sortedByDescending { it.updatedAt }
+                    val request = call.receive<SyncRequest>()
+
+                    val conflicts = mutableListOf<String>()
+                    val acknowledged = mutableListOf<String>()
+                    val outgoingItems: List<SyncItem>
+
+                    synchronized(syncStoreLock) {
+                        request.items.forEach { incoming ->
+                            val existing = syncStore[incoming.id]
+                            if (existing == null || incoming.updatedAt >= existing.updatedAt) {
+                                syncStore[incoming.id] = incoming
+                                acknowledged += incoming.id
+                            } else {
+                                conflicts += incoming.id
+                            }
+                        }
+
+                        outgoingItems =
+                            syncStore.values
+                                .filter { it.updatedAt > request.lastSyncTime }
+                                .filterNot { serverItem ->
+                                    request.items.any { local ->
+                                        local.id == serverItem.id && local.updatedAt == serverItem.updatedAt
+                                    }
+                                }.sortedByDescending { it.updatedAt }
+                    }
+
+                    val response =
+                        SyncResponse(
+                            protocolVersion = request.protocolVersion,
+                            serverTime = System.currentTimeMillis(),
+                            items = outgoingItems,
+                            conflicts = conflicts.distinct(),
+                            ackedItemIds = acknowledged.distinct(),
+                        )
+
+                    call.respond(HttpStatusCode.OK, response)
+                } catch (e: CancellationException) {
+                    // Rethrow cancellation to let coroutines cancel gracefully
+                    throw e
+                } catch (e: io.ktor.server.plugins.BadRequestException) {
+                    call.handleSyncError(e)
+                } catch (e: kotlinx.serialization.SerializationException) {
+                    call.handleSyncError(e)
                 }
-
-                val response =
-                    SyncResponse(
-                        protocolVersion = request.protocolVersion,
-                        serverTime = System.currentTimeMillis(),
-                        items = outgoingItems,
-                        conflicts = conflicts.distinct(),
-                        ackedItemIds = acknowledged.distinct(),
-                    )
-
-                call.respond(HttpStatusCode.OK, response)
-            } catch (e: CancellationException) {
-                // Rethrow cancellation to let coroutines cancel gracefully
-                throw e
-            } catch (e: io.ktor.server.plugins.BadRequestException) {
-                call.application.environment.log.error("Failed to process sync request", e)
-                // If it fails to deserialize or handle the request, return a 400 Bad Request
-                call.respond(
-                    HttpStatusCode.BadRequest,
-                    ErrorResponse(
-                        error = "Invalid sync request payload",
-                        details = "The request could not be processed due to a malformed payload",
-                    ),
-                )
-            } catch (e: kotlinx.serialization.SerializationException) {
-                call.application.environment.log.error("Failed to process sync request", e)
-                call.respond(
-                    HttpStatusCode.BadRequest,
-                    ErrorResponse(
-                        error = "Invalid sync request payload",
-                        details = "The request could not be processed due to a malformed payload",
-                    ),
-                )
             }
         }
-    }
     }
 }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
@@ -72,7 +72,13 @@ class IcsCalendarProvider(
             block()
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Exception) {
+        } catch (e: ResponseException) {
+            println("ICS fetch failed for providerId=$providerId: $e")
+            null
+        } catch (e: IOException) {
+            println("ICS fetch failed for providerId=$providerId: $e")
+            null
+        } catch (e: IllegalArgumentException) {
             println("ICS fetch failed for providerId=$providerId: $e")
             null
         }
@@ -394,7 +400,9 @@ internal class IcsEventBuilder {
             tzidRegex.find(rawKey) ?: return TimeZone.currentSystemDefault()
         return try {
             TimeZone.of(tzidMatch.groupValues[1])
-        } catch (e: IllegalArgumentException) {
+        } catch (e: Exception) {
+            // catch Exception instead of IllegalArgumentException
+            // kotlinx-datetime TimeZone.of throws IllegalTimeZoneException, which inherits from RuntimeException
             TimeZone.currentSystemDefault()
         }
     }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/calendar/IcsCalendarProvider.kt
@@ -12,8 +12,6 @@ import io.ktor.client.statement.bodyAsText
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
-import kotlinx.io.IOException
-import io.ktor.client.plugins.ResponseException
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.coroutines.cancellation.CancellationException
@@ -72,13 +70,7 @@ class IcsCalendarProvider(
             block()
         } catch (e: CancellationException) {
             throw e
-        } catch (e: ResponseException) {
-            println("ICS fetch failed for providerId=$providerId: $e")
-            null
-        } catch (e: IOException) {
-            println("ICS fetch failed for providerId=$providerId: $e")
-            null
-        } catch (e: IllegalArgumentException) {
+        } catch (e: Exception) {
             println("ICS fetch failed for providerId=$providerId: $e")
             null
         }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
@@ -106,7 +106,9 @@ inline fun <T> safeDecode(block: () -> T): T? =
         block()
     } catch (e: CancellationException) {
         throw e
-    } catch (e: Exception) {
+    } catch (e: kotlinx.serialization.SerializationException) {
+        null
+    } catch (e: IllegalArgumentException) {
         null
     }
 

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -134,11 +134,7 @@ class PreferencesRepository(
         safeData
             .map { preferences ->
             val modeStr = preferences[PreferencesKeys.SIDEBAR_MODE]
-            try {
-                if (modeStr != null) SidebarMode.valueOf(modeStr) else SidebarMode.EXPANDED
-            } catch (_: IllegalArgumentException) {
-                SidebarMode.EXPANDED
-            }
+            SidebarMode.entries.find { it.name == modeStr } ?: SidebarMode.EXPANDED
         }
 
     /**
@@ -173,15 +169,7 @@ class PreferencesRepository(
         safeData
             .map { preferences ->
             val rawValue = preferences[PreferencesKeys.DESKTOP_WINDOW_STARTUP_MODE]
-            try {
-                if (rawValue != null) {
-                    DesktopWindowStartupMode.valueOf(rawValue)
-                } else {
-                    DesktopWindowStartupMode.RESTORE_LAST
-                }
-            } catch (_: IllegalArgumentException) {
-                DesktopWindowStartupMode.RESTORE_LAST
-            }
+            DesktopWindowStartupMode.entries.find { it.name == rawValue } ?: DesktopWindowStartupMode.RESTORE_LAST
         }
 
     val enabledPacks: Flow<PackRegistry> =


### PR DESCRIPTION
This pull request addresses several reliability issues caused by overly broad exception handling and unoptimized enum lookups.

**Changes:**
1. **Narrowed Exception Scope:** Replaced generic `catch (e: Exception)` blocks in `MainActivity.kt`, `SyncRoutes.kt`, and `NodeMetadata.kt` with specific exceptions (`GeneralSecurityException`, `BadRequestException`, `SerializationException`, etc.). This prevents unexpected, fatal exceptions from being swallowed silently.
2. **Fixed TimeZone Crash:** Updated `IcsEventBuilder.kt` to catch `Exception` (which handles `kotlinx-datetime`'s `IllegalTimeZoneException`) instead of `IllegalArgumentException` when parsing time zones, preventing potential crashes.
3. **Optimized Enum Lookups:** Replaced `try-catch` blocks for Enum parsing with performant `.entries.find { it.name == str }` in `PreferencesRepository.kt` and `App.kt` to eliminate the overhead of throwing exceptions during normal application execution.

---
*PR created automatically by Jules for task [1005934142877780010](https://jules.google.com/task/1005934142877780010) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

