### PR TITLE
feat(ui): add pointer hover icon to icon buttons

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
@@ -28,6 +28,8 @@ import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.cd_delete_option
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 @Composable
 fun OptionCard(
@@ -51,7 +53,7 @@ fun OptionCard(
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                 )
-                IconButton(onClick = { onDelete(option) }) {
+                IconButton(onClick = { onDelete(option) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(
                         Icons.Default.Delete,
                         contentDescription = stringResource(Res.string.cd_delete_option),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
@@ -63,6 +63,8 @@ import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
 import kotlin.time.Clock
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 @Composable
 fun NodeCard(
@@ -267,7 +269,7 @@ fun NodeCard(
                         }
                     }
                     if (isDone) {
-                        IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+                        IconButton(onClick = onArchive, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                             Icon(
                                 imageVector = Icons.Default.Delete,
                                 contentDescription = stringResource(Res.string.detail_archive),
@@ -275,7 +277,7 @@ fun NodeCard(
                             )
                         }
                     }
-                    IconButton(onClick = { onTogglePin(!isPinnedToToday) }) {
+                    IconButton(onClick = { onTogglePin(!isPinnedToToday) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                         Icon(
                             imageVector = Icons.Default.Star,
                             contentDescription = stringResource(Res.string.node_pin_today_desc),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
@@ -87,6 +87,8 @@ import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 /**
  * Renders a modal bottom sheet that collects capture text and related metadata, then submits it via the provided callback.
@@ -286,7 +288,7 @@ fun CaptureSheet(
                 )
 
                 if (onVoiceCaptureClick != null) {
-                    IconButton(onClick = onVoiceCaptureClick, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onVoiceCaptureClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                         Icon(
                             imageVector = Icons.Default.Mic,
                             contentDescription = stringResource(Res.string.capture_voice),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -69,6 +69,8 @@ import tajsos.composeapp.generated.resources.header_mode_label
 import tajsos.composeapp.generated.resources.header_notifications
 import tajsos.composeapp.generated.resources.header_notifications_title
 import tajsos.composeapp.generated.resources.header_search_placeholder
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 /**
  * Mode option model shown by the header mode switcher.
@@ -136,7 +138,7 @@ fun AppShellHeader(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (!isDesktop && onMenuClick != null) {
-                    IconButton(onClick = onMenuClick, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onMenuClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                         Icon(
                             imageVector = Icons.Default.Menu,
                             contentDescription = stringResource(Res.string.header_menu),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
@@ -119,7 +119,7 @@ fun DashHeader(
                 }
             }
             Spacer(Modifier.width(12.dp))
-            IconButton(onClick = onSettingsClick, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onSettingsClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(Icons.Default.Settings, contentDescription = null, tint = TajsOSTheme.Muted)
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -289,7 +289,7 @@ fun DecisionDetailContent(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             SectionTitle(stringResource(Res.string.decision_options_label))
-            IconButton(onClick = { showAddOptionDialog = true }, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = { showAddOptionDialog = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = stringResource(Res.string.cd_add_option),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
@@ -45,6 +45,8 @@ import tajsos.composeapp.generated.resources.dash_heavy
 import tajsos.composeapp.generated.resources.dash_unclear
 import tajsos.composeapp.generated.resources.detail_archive
 import tajsos.composeapp.generated.resources.task_row_unpin_desc
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 /**
  * Renders a single task row for the given node, showing its title, metadata and action controls.
@@ -187,7 +189,7 @@ fun TaskRow(
                     }
                 }
                 if (isDone) {
-                    IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onArchive, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                         Icon(
                             imageVector = Icons.Default.Delete,
                             contentDescription = stringResource(Res.string.detail_archive),
@@ -195,7 +197,7 @@ fun TaskRow(
                         )
                     }
                 }
-                IconButton(onClick = onUnpin, modifier = Modifier.size(48.dp)) {
+                IconButton(onClick = onUnpin, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                     Icon(
                         Icons.Default.Close,
                         contentDescription = stringResource(Res.string.task_row_unpin_desc),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -155,7 +155,7 @@ fun CalendarHeader(
                     color = TajsOSTheme.Primary,
                 )
             }
-            IconButton(onClick = onSyncClick, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onSyncClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.Refresh,
                     contentDescription = stringResource(Res.string.cal_sync),
@@ -163,13 +163,13 @@ fun CalendarHeader(
                     modifier = Modifier.size(20.dp),
                 )
             }
-            IconButton(onClick = onPreviousMonth, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onPreviousMonth, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.ChevronLeft,
                     contentDescription = stringResource(Res.string.cal_previous),
                 )
             }
-            IconButton(onClick = onNextMonth, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onNextMonth, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.ChevronRight,
                     contentDescription = stringResource(Res.string.cal_next),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsBlocks.kt
@@ -37,6 +37,8 @@ import tajsos.composeapp.generated.resources.archive_delete
 import tajsos.composeapp.generated.resources.cal_settings_add
 import tajsos.composeapp.generated.resources.cal_settings_empty
 import tajsos.composeapp.generated.resources.cal_settings_title
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 object CalendarSettingsBlockRegistry {
     private val renderers: Map<String, CalendarSettingsBlockRenderer> =
@@ -60,7 +62,7 @@ private fun renderCalendarSettingsHeader(context: CalendarSettingsContext) {
             style = MaterialTheme.typography.displaySmall,
             color = TajsOSTheme.Text,
         )
-        IconButton(onClick = context.onShowAddDialog, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = context.onShowAddDialog, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
             Icon(
                 Icons.Default.Add,
                 contentDescription = stringResource(Res.string.cal_settings_add),
@@ -125,7 +127,7 @@ private fun ProviderRow(
                     )
                 }
             }
-            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onDelete, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.Delete,
                     contentDescription = stringResource(Res.string.archive_delete),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/inbox/InboxDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/inbox/InboxDashboardBlocks.kt
@@ -43,6 +43,8 @@ import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 object InboxDashboardBlockRegistry {
     private val renderers: Map<String, InboxDashboardBlockRenderer> =
@@ -122,7 +124,7 @@ internal fun InboxMainBlock(
                             onArchive = { viewModel.archiveNode(nodeWithPin.node) },
                         )
 
-                        IconButton(onClick = { viewModel.markAsProcessed(nodeWithPin.node.id) }) {
+                        IconButton(onClick = { viewModel.markAsProcessed(nodeWithPin.node.id) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                             Icon(
                                 imageVector = Icons.Default.Check,
                                 contentDescription = stringResource(Res.string.inbox_process),
@@ -180,7 +182,7 @@ private fun InboxCaptureCard(
                     onClick = { viewModel.triageInboxEntry(entry.id, ItemKind.PROJECT) },
                     label = { Text(stringResource(Res.string.type_project).uppercase()) },
                 )
-                IconButton(onClick = { viewModel.dismissInboxEntry(entry) }) {
+                IconButton(onClick = { viewModel.dismissInboxEntry(entry) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = "Dismiss capture",

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -59,6 +59,8 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.math.max
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 /**
  * Primary note viewer/editor pane with metadata and action row.
@@ -196,24 +198,24 @@ fun NotesEditorHeaderActions(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Row {
-            IconButton(onClick = onToggleFavorite, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleFavorite, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     imageVector = if (favorite) Icons.Default.Star else Icons.Default.StarBorder,
                     contentDescription = null,
                     tint = if (favorite) TajsOSTheme.Primary else TajsOSTheme.Text,
                 )
             }
-            IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onArchive, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(Icons.Default.Archive, contentDescription = null, tint = TajsOSTheme.Text)
             }
-            IconButton(onClick = onToggleFocusMode, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleFocusMode, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.CenterFocusStrong,
                     contentDescription = null,
                     tint = if (focusMode) TajsOSTheme.Primary else TajsOSTheme.Text,
                 )
             }
-            IconButton(onClick = onToggleContextPanel, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleContextPanel, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.Info,
                     contentDescription = null,
@@ -222,7 +224,7 @@ fun NotesEditorHeaderActions(
             }
         }
         Box {
-            IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = { menuOpen = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(Icons.Default.MoreVert, contentDescription = null)
             }
             DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -53,6 +53,8 @@ import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.common_open
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 /**
  * Notes workspace left rail with creation, search, filtering, sorting, and note list navigation.
@@ -99,7 +101,7 @@ fun NotesListRail(
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
                 trailingIcon = {
                     if (searchQuery.isNotEmpty()) {
-                        IconButton(onClick = { onSearchChange("") }) {
+                        IconButton(onClick = { onSearchChange("") }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                             Icon(Icons.Default.Close, contentDescription = "Clear search")
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
@@ -42,6 +42,8 @@ import com.tajemniktv.tajsos.ui.components.screen.ScreenScaffold
 import com.tajemniktv.tajsos.ui.components.screen.ScreenScrollBehavior
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import kotlinx.coroutines.launch
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 /**
  * Responsive route for the notes workspace.
@@ -215,7 +217,7 @@ fun NotesRoute(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            IconButton(onClick = { mobileInDetail = false }, modifier = Modifier.size(48.dp)) {
+                            IconButton(onClick = { mobileInDetail = false }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -206,7 +206,7 @@ fun NotesWorkspaceDetail(
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconButton(onClick = onBack, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onBack, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                     }
                     Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailScreen.kt
@@ -114,6 +114,8 @@ import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 /**
  * Detailed view for a single node (Note, Idea, Task, etc.)
@@ -203,7 +205,7 @@ fun NoteDetailScreen(
         }
 
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = { viewModel.togglePermanentPin(node) }) {
+        IconButton(onClick = { viewModel.togglePermanentPin(node) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
             Icon(
                 if (node.isPinned) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
                 contentDescription = null,
@@ -244,7 +246,7 @@ fun NoteDetailScreen(
                 modifier = Modifier.size(18.dp),
             )
         }
-        IconButton(onClick = { showMoreDialog = true }, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = { showMoreDialog = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
             Icon(
                 Icons.Default.MoreVert,
                 contentDescription = null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
@@ -76,6 +76,8 @@ import tajsos.composeapp.generated.resources.profile_select_avatar
 import tajsos.composeapp.generated.resources.profile_time_zone
 import tajsos.composeapp.generated.resources.profile_unsaved
 import tajsos.composeapp.generated.resources.profile_website
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 private val profileBlockRenderers: Map<String, ProfileDashboardBlockRenderer> =
     mapOf(
@@ -390,7 +392,7 @@ private fun renderMedicationsModuleBlock(context: ProfileScreenContext) {
             verticalAlignment = Alignment.CenterVertically,
         ) {
             ModuleTitle(title = stringResource(Res.string.profile_medications))
-            IconButton(onClick = context.onOpenAddMedication, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = context.onOpenAddMedication, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = null,
@@ -589,7 +591,7 @@ private fun MedicationItem(
                     color = TajsOSTheme.Primary,
                 )
             }
-            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onDelete, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                 Icon(Icons.Default.Delete, contentDescription = "Delete", tint = TajsOSTheme.Error)
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailScreen.kt
@@ -68,6 +68,8 @@ import tajsos.composeapp.generated.resources.project_health_neglected
 import tajsos.composeapp.generated.resources.project_health_on_hold
 import tajsos.composeapp.generated.resources.project_set_status
 import tajsos.composeapp.generated.resources.screen_project
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 /**
  * Project mission-control detail route that collects state and coordinates interactions.
@@ -316,13 +318,13 @@ fun ProjectDetailScreen(
 ) {
     val project = context.project
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = { context.onStatusClick() }) {
+        IconButton(onClick = { context.onStatusClick() }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
             Icon(Icons.Default.Tune, contentDescription = null, modifier = Modifier.size(18.dp))
         }
-        IconButton(onClick = { context.onEditNode(project.id) }) {
+        IconButton(onClick = { context.onEditNode(project.id) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
             Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
         }
-        IconButton(onClick = { context.viewModel.updateNode(project.copy(isFrozen = !project.isFrozen)) }) {
+        IconButton(onClick = { context.viewModel.updateNode(project.copy(isFrozen = !project.isFrozen)) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
             Icon(
                 if (project.isFrozen) Icons.Default.WbSunny else Icons.Default.Schedule,
                 contentDescription = null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/review/ReviewDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/review/ReviewDashboardBlocks.kt
@@ -61,6 +61,8 @@ import tajsos.composeapp.generated.resources.review_step_plan
 import tajsos.composeapp.generated.resources.review_step_stats
 import tajsos.composeapp.generated.resources.review_step_wins
 import tajsos.composeapp.generated.resources.review_weekly
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 object ReviewDashboardBlocks {
     private val renderers: Map<String, ReviewDashboardBlockRenderer> =
@@ -199,7 +201,7 @@ private fun renderReviewFlow(context: ReviewDashboardContext) {
                                 ListItem(
                                     headlineContent = { Text(item.node.title) },
                                     trailingContent = {
-                                        IconButton(onClick = { viewModel.archiveNode(item.node) }) {
+                                        IconButton(onClick = { viewModel.archiveNode(item.node) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                                             Icon(
                                                 Icons.Default.Delete,
                                                 contentDescription = stringResource(Res.string.detail_archive),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -84,6 +84,8 @@ import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
 import kotlin.math.max
 import kotlin.math.min
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 object SearchDashboardBlocks {
     private val renderers: Map<String, SearchDashboardBlockRenderer> =
@@ -111,7 +113,7 @@ private fun renderSearchInput(context: SearchDashboardContext) {
             leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
             trailingIcon = {
                 if (context.searchQuery.isNotEmpty()) {
-                    IconButton(onClick = { viewModel.updateSearchQuery("") }) {
+                    IconButton(onClick = { viewModel.updateSearchQuery("") }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                         Icon(
                             Icons.Default.Clear,
                             contentDescription = stringResource(Res.string.search_clear),
@@ -125,7 +127,7 @@ private fun renderSearchInput(context: SearchDashboardContext) {
                     unfocusedContainerColor = TajsOSTheme.Surface,
                 ),
         )
-        IconButton(onClick = context.onToggleFilters, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = context.onToggleFilters, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
             Icon(
                 Icons.Default.FilterList,
                 contentDescription = "Toggle filters",

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksArchiveView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksArchiveView.kt
@@ -34,6 +34,8 @@ import tajsos.composeapp.generated.resources.tasks_archive_subtitle
 import tajsos.composeapp.generated.resources.tasks_archive_title
 import tajsos.composeapp.generated.resources.tasks_open_action
 import tajsos.composeapp.generated.resources.tasks_restore_action
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 @Composable
 internal fun TasksArchiveView(
@@ -96,7 +98,7 @@ internal fun TasksArchiveView(
                         Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
                             OutlinedButton(onClick = { onOpen(task.id) }) { Text(stringResource(Res.string.tasks_open_action)) }
                             OutlinedButton(onClick = { onRestore(task) }) { Text(stringResource(Res.string.tasks_restore_action)) }
-                            IconButton(onClick = { onDelete(task) }) {
+                            IconButton(onClick = { onDelete(task) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                                 Icon(
                                     Icons.Default.Delete,
                                     null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
@@ -68,6 +68,8 @@ import tajsos.composeapp.generated.resources.tasks_quick_capture_hint
 import tajsos.composeapp.generated.resources.tasks_quick_capture_title
 import tajsos.composeapp.generated.resources.tasks_start_focus_action
 import kotlin.time.Clock
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 @Composable
 internal fun TasksCommandView(
@@ -368,7 +370,7 @@ private fun QueueList(
                     Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
                         OutlinedButton(onClick = { onDoNow(task) }) { Text(stringResource(Res.string.tasks_start_focus_action)) }
                         OutlinedButton(onClick = { onOpen(task.id) }) { Text(stringResource(Res.string.tasks_open_action)) }
-                        IconButton(onClick = { onDone(task) }) { Icon(Icons.Default.Check, null) }
+                        IconButton(onClick = { onDone(task) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Icon(Icons.Default.Check, null) }
                     }
                 }
                 HorizontalDivider(color = TajsOSTheme.GhostBorder)

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksInboxView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksInboxView.kt
@@ -40,6 +40,8 @@ import tajsos.composeapp.generated.resources.tasks_inbox_tasks_title
 import tajsos.composeapp.generated.resources.tasks_inbox_title
 import tajsos.composeapp.generated.resources.tasks_inbox_triage_task
 import tajsos.composeapp.generated.resources.tasks_open_action
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 @Composable
 internal fun TasksInboxView(
@@ -115,7 +117,7 @@ internal fun TasksInboxView(
                                         stringResource(Res.string.tasks_inbox_triage_task),
                                     )
                                 }
-                                IconButton(onClick = { onDismiss(entry) }) {
+                                IconButton(onClick = { onDismiss(entry) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                                     Icon(
                                         Icons.Default.Delete,
                                         stringResource(Res.string.tasks_inbox_dismiss),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksTodayView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksTodayView.kt
@@ -40,6 +40,8 @@ import tajsos.composeapp.generated.resources.tasks_today_pinned
 import tajsos.composeapp.generated.resources.tasks_today_subtitle
 import tajsos.composeapp.generated.resources.tasks_today_title
 import kotlin.time.Clock
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 @Composable
 internal fun TasksTodayView(
@@ -195,7 +197,7 @@ private fun TodaySection(
                                     },
                                 )
                             }
-                            IconButton(onClick = { onDone(task) }) {
+                            IconButton(onClick = { onDone(task) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                                 Icon(
                                     Icons.Default.Check,
                                     null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -111,6 +111,8 @@ import tajsos.composeapp.generated.resources.task_detail_queued
 import tajsos.composeapp.generated.resources.task_detail_snooze
 import tajsos.composeapp.generated.resources.tasks_detail_updated
 import tajsos.composeapp.generated.resources.track_empty
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 private val detailPanelShape = RoundedCornerShape(TajsOSTheme.RadiusMd)
 private val detailPanelBorder = TajsOSTheme.GhostBorder.copy(alpha = 0.22f)
@@ -620,7 +622,7 @@ private fun SubtaskRow(
                 color = tint,
             )
             if (subtask.source == TaskSubtaskSource.InlineChecklist && onRemove != null) {
-                IconButton(onClick = onRemove, modifier = Modifier.size(48.dp)) {
+                IconButton(onClick = onRemove, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = null,
@@ -704,7 +706,7 @@ private fun AttachmentRow(
                 )
             }
         }
-        IconButton(onClick = onRemove, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = onRemove, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
             Icon(Icons.Default.Delete, contentDescription = null, tint = TajsOSTheme.Muted)
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesDashboardBlocks.kt
@@ -32,6 +32,8 @@ import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 object TemplatesDashboardBlocks {
     private val renderers: Map<String, TemplatesDashboardBlockRenderer> =
@@ -73,7 +75,7 @@ private fun renderTemplatesList(context: TemplatesDashboardContext) {
                         Text(typeLabel.uppercase())
                     },
                     trailingContent = {
-                        IconButton(onClick = { context.onDeleteTemplate(template) }) {
+                        IconButton(onClick = { context.onDeleteTemplate(template) }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                             Icon(
                                 Icons.Default.Delete,
                                 contentDescription = stringResource(Res.string.archive_delete),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesScreen.kt
@@ -48,6 +48,8 @@ import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.PointerIcon
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -70,7 +72,7 @@ fun TemplatesScreen(
         )
 
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = { showAddDialog = true }, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = { showAddDialog = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand).size(48.dp)) {
             Icon(
                 Icons.Default.Add,
                 contentDescription = stringResource(Res.string.templates_add_desc),


### PR DESCRIPTION
Adds `.pointerHoverIcon(PointerIcon.Hand)` modifier to `IconButton` usages across the application where missing. This is a common and highly effective UX polish for web and desktop environments on Compose Multiplatform that clarifies interactivity for users.

---
*PR created automatically by Jules for task [15027430354113045274](https://jules.google.com/task/15027430354113045274) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

