### PR TITLE
fix(ui): disable default 404 route to resolve collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,8 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      // Disable default 404 route because a custom src/pages/404.astro exists
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
This PR fixes an Astro build warning regarding a static route collision for `/404`. Since a custom `src/pages/404.astro` exists, the default Starlight 404 route needs to be disabled to prevent the conflict. I added `disable404Route: true` to the Starlight configuration in `astro.config.mjs` along with an inline explanatory comment. Build tests (`npm run build` and `npm run check`) pass successfully without the warning.

---
*PR created automatically by Jules for task [837938356299724143](https://jules.google.com/task/837938356299724143) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

