### PR TITLE
fix: Replace unsafe .first() and !! calls with safe alternatives

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -239,7 +239,7 @@ fun App(
                                 val canPop = navController.previousBackStackEntry != null
                                 if (!canPop) return@mouseButtons
                                 if (isForwardNavigable(currentRoute)) {
-                                    mouseForwardRoutes.addLast(currentRoute!!)
+                                    mouseForwardRoutes.addLast(currentRoute ?: return@mouseButtons)
                                 }
                                 navController.popBackStack()
                             },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/Screen.kt
@@ -709,7 +709,7 @@ sealed class Screen(
 
             // Try base route match, ensuring we don't accidentally match sub-screens that share a base
             // unless they are explicitly the root screen.
-            return rootScreens.find { it.route.split("/").first() == currentRouteBase }
+            return rootScreens.find { it.route.split("/").firstOrNull() == currentRouteBase }
         }
 
         /**

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectModels.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectModels.kt
@@ -961,7 +961,7 @@ fun parseCapturedText(rawText: String): ParsedCaptureText {
         return ParsedCaptureText(title = "", content = "")
     }
 
-    val title = lines.first()
+    val title = lines.firstOrNull() ?: ""
     val content = lines.drop(1).joinToString("\n").trim()
     return ParsedCaptureText(title = title, content = content)
 }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
@@ -324,7 +324,7 @@ class NodeCommands(
                     if (lines.isNotEmpty()) {
                         val firstLine =
                             lines
-                                .first()
+                                .firstOrNull().orEmpty()
                                 .trim()
                                 .removePrefix("-")
                                 .removePrefix("*")
@@ -486,7 +486,7 @@ class NodeCommands(
                         val lines = section.lines()
                         val title =
                             lines
-                                .first()
+                                .firstOrNull().orEmpty()
                                 .removePrefix("# ")
                                 .trim()
                                 .ifBlank { defaultUntitledLabel() }


### PR DESCRIPTION
This PR addresses several instances of unsafe collection operations across the repository to improve application reliability and prevent runtime crashes.

- Replaced `mouseForwardRoutes.addLast(currentRoute!!)` with a safe Elvis return in `App.kt`.
- Replaced `route.split("/").first()` with `firstOrNull()` in `Screen.kt` to handle potentially empty arrays.
- Handled empty `lines` securely in `LifeObjectModels.kt` by using `.firstOrNull() ?: ""`.
- Secured `lines.first()` following a filter in `NodeCommands.kt` using `firstOrNull().orEmpty()`.

These changes ensure the application remains robust against unexpected nulls or empty collections, eliminating potential `NoSuchElementException` and `NullPointerException` sources. Tests have verified that core functionality remains fully intact.

---
*PR created automatically by Jules for task [12296964446074337726](https://jules.google.com/task/12296964446074337726) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

