### PR TITLE
fix(website): disable starlight default 404 route to resolve static route collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,8 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      // Disabling default 404 route because we have a custom src/pages/404.astro
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
This PR resolves the static route collision warning that happens when building the Astro website with `starlight` due to the conflict between Starlight's default `/404` route and the custom one provided in `src/pages/404.astro`. It simply adds `disable404Route: true` to the `starlight` Astro integration configuration block with a comment explaining the purpose.

---
*PR created automatically by Jules for task [14335049111882528971](https://jules.google.com/task/14335049111882528971) started by @tajemniktv*

## Summary by Sourcery

Build:
- Update Astro Starlight integration configuration to turn off the default /404 route in favor of the custom 404 page.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

