### PR TITLE
feat(ui): add hand pointer on hover to interactive components

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/DecisionCards.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.components.cards
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -51,7 +53,7 @@ fun OptionCard(
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                 )
-                IconButton(onClick = { onDelete(option) }) {
+                IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDelete(option) }) {
                     Icon(
                         Icons.Default.Delete,
                         contentDescription = stringResource(Res.string.cd_delete_option),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.components.cards
 
 import androidx.compose.animation.core.Spring
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.BorderStroke
@@ -267,7 +269,7 @@ fun NodeCard(
                         }
                     }
                     if (isDone) {
-                        IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+                        IconButton(onClick = onArchive, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                             Icon(
                                 imageVector = Icons.Default.Delete,
                                 contentDescription = stringResource(Res.string.detail_archive),
@@ -275,7 +277,7 @@ fun NodeCard(
                             )
                         }
                     }
-                    IconButton(onClick = { onTogglePin(!isPinnedToToday) }) {
+                    IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onTogglePin(!isPinnedToToday) }) {
                         Icon(
                             imageVector = Icons.Default.Star,
                             contentDescription = stringResource(Res.string.node_pin_today_desc),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.components.cards
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -310,13 +312,13 @@ fun ProgressControlCard(
             Text(title, style = MaterialTheme.typography.titleSmall)
             Text("$value%", style = MaterialTheme.typography.bodySmall, color = TajsOSTheme.Accent)
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                OutlinedButton(onClick = onDecrease) { Text("-10") }
-                OutlinedButton(onClick = onIncrease) { Text("+10") }
-                OutlinedButton(onClick = onOpen) { Text(stringResource(Res.string.common_open)) }
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDecrease) { Text("-10") }
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onIncrease) { Text("+10") }
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onOpen) { Text(stringResource(Res.string.common_open)) }
             }
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                OutlinedButton(onClick = onOpen) { Text(stringResource(Res.string.student_action_details)) }
-                OutlinedButton(onClick = {}) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onOpen) { Text(stringResource(Res.string.student_action_details)) }
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {}) {
                     Text(
                         stringResource(
                             Res.string.student_id_label,
@@ -355,7 +357,7 @@ fun StudentNodeCard(
         modifier = Modifier.fillMaxWidth().padding(bottom = TajsOSTheme.SpacingSm),
         horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
     ) {
-        OutlinedButton(onClick = {
+        OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
             viewModel.toggleFlashcardCandidate(
                 node.node,
                 enabled = true,
@@ -363,7 +365,7 @@ fun StudentNodeCard(
         }) {
             Text(stringResource(Res.string.common_flashcard))
         }
-        OutlinedButton(onClick = { viewModel.toggleRevisitBeforeExam(node.node, enabled = true) }) {
+        OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.toggleRevisitBeforeExam(node.node, enabled = true) }) {
             Text(stringResource(Res.string.common_revisit))
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.components.common
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -286,7 +288,7 @@ fun CaptureSheet(
                 )
 
                 if (onVoiceCaptureClick != null) {
-                    IconButton(onClick = onVoiceCaptureClick, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onVoiceCaptureClick, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                         Icon(
                             imageVector = Icons.Default.Mic,
                             contentDescription = stringResource(Res.string.capture_voice),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.components.layout
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.animation.core.LinearEasing
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -136,7 +138,7 @@ fun AppShellHeader(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (!isDesktop && onMenuClick != null) {
-                    IconButton(onClick = onMenuClick, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onMenuClick, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                         Icon(
                             imageVector = Icons.Default.Menu,
                             contentDescription = stringResource(Res.string.header_menu),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
@@ -119,7 +119,7 @@ fun DashHeader(
                 }
             }
             Spacer(Modifier.width(12.dp))
-            IconButton(onClick = onSettingsClick, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onSettingsClick, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.Settings, contentDescription = null, tint = TajsOSTheme.Muted)
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSuggestionBanner.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSuggestionBanner.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.components.modes
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -83,7 +85,7 @@ fun ModeSuggestionBanner(
                 }
             }
             Row {
-                TextButton(onClick = onDismiss) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) {
                     Text(
                         "IGNORE",
                         style = MaterialTheme.typography.labelSmall,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -226,7 +226,7 @@ fun DecisionDetailContent(
                 style = MaterialTheme.typography.bodySmall,
                 color = TajsOSTheme.Muted,
             )
-            TextButton(onClick = { showPeopleDialog = true }) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { showPeopleDialog = true }) {
                 Text(stringResource(Res.string.decision_action_link_person))
             }
         }
@@ -247,7 +247,7 @@ fun DecisionDetailContent(
                             style = MaterialTheme.typography.bodyMedium,
                             color = TajsOSTheme.Text,
                         )
-                        TextButton(onClick = {
+                        TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                             viewModel.unlinkDecisionFromPerson(
                                 node.id,
                                 person.node.id,
@@ -289,7 +289,7 @@ fun DecisionDetailContent(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             SectionTitle(stringResource(Res.string.decision_options_label))
-            IconButton(onClick = { showAddOptionDialog = true }, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = { showAddOptionDialog = true }, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = stringResource(Res.string.cd_add_option),
@@ -490,7 +490,7 @@ fun DecisionDetailContent(
                 }
             },
             confirmButton = {
-                TextButton(onClick = { showPeopleDialog = false }) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { showPeopleDialog = false }) {
                     Text(stringResource(Res.string.common_close))
                 }
             },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.components.nodes
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -187,7 +189,7 @@ fun TaskRow(
                     }
                 }
                 if (isDone) {
-                    IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onArchive, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                         Icon(
                             imageVector = Icons.Default.Delete,
                             contentDescription = stringResource(Res.string.detail_archive),
@@ -195,7 +197,7 @@ fun TaskRow(
                         )
                     }
                 }
-                IconButton(onClick = onUnpin, modifier = Modifier.size(48.dp)) {
+                IconButton(onClick = onUnpin, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(
                         Icons.Default.Close,
                         contentDescription = stringResource(Res.string.task_row_unpin_desc),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/archive/ArchiveDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/archive/ArchiveDashboardBlocks.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.archive
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -125,7 +127,7 @@ internal fun ArchiveMainBlock(
                                             tint = TajsOSTheme.Primary,
                                         )
                                     }
-                                    IconButton(onClick = {
+                                    IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                                         viewModel.deleteNodePermanently(
                                             nodeWithPin.node,
                                         )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.areas
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -123,7 +125,7 @@ internal fun AreasMainBlock(
                 color = TajsOSTheme.Text,
             )
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                OutlinedButton(onClick = { showAddDialog = true }) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { showAddDialog = true }) {
                     Text(stringResource(Res.string.areas_new))
                 }
             }
@@ -418,7 +420,7 @@ private fun AreaCard(
                     "${metrics?.neglectedDays ?: 0}d",
                 )
                 Spacer(modifier = Modifier.height(4.dp))
-                OutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
+                OutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand)) {
                     Text(stringResource(Res.string.areas_enter))
                 }
             }
@@ -475,7 +477,7 @@ fun AddAreaDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text(stringResource(Res.string.areas_dialog_cancel)) }
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) { Text(stringResource(Res.string.areas_dialog_cancel)) }
         },
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
@@ -155,9 +155,9 @@ private fun renderAreaHero(context: AreaDetailContext) {
                 trackColor = TajsOSTheme.SurfaceLow,
             )
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                FilledTonalButton(onClick = {}) { Text(stringResource(Res.string.area_detail_tab_work)) }
-                FilledTonalButton(onClick = {}) { Text(stringResource(Res.string.area_detail_tab_notes)) }
-                FilledTonalButton(onClick = {}) { Text(stringResource(Res.string.area_detail_tab_projects)) }
+                FilledTonalButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {}) { Text(stringResource(Res.string.area_detail_tab_work)) }
+                FilledTonalButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {}) { Text(stringResource(Res.string.area_detail_tab_notes)) }
+                FilledTonalButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {}) { Text(stringResource(Res.string.area_detail_tab_projects)) }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailScreen.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.areas.detail
 
 import androidx.compose.foundation.background
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -235,7 +237,7 @@ fun AreaDetailScreen(
 ) {
     val area = context.area
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = {
+        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
             context.viewModel.archiveNode(area)
             onBack()
         }) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -148,14 +148,14 @@ fun CalendarHeader(
             )
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            TextButton(onClick = onTodayClick) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onTodayClick) {
                 Text(
                     stringResource(Res.string.cal_today),
                     style = MaterialTheme.typography.labelSmall,
                     color = TajsOSTheme.Primary,
                 )
             }
-            IconButton(onClick = onSyncClick, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onSyncClick, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.Refresh,
                     contentDescription = stringResource(Res.string.cal_sync),
@@ -163,13 +163,13 @@ fun CalendarHeader(
                     modifier = Modifier.size(20.dp),
                 )
             }
-            IconButton(onClick = onPreviousMonth, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onPreviousMonth, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.ChevronLeft,
                     contentDescription = stringResource(Res.string.cal_previous),
                 )
             }
-            IconButton(onClick = onNextMonth, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onNextMonth, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.ChevronRight,
                     contentDescription = stringResource(Res.string.cal_next),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsBlocks.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.calendar
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Column
@@ -60,7 +62,7 @@ private fun renderCalendarSettingsHeader(context: CalendarSettingsContext) {
             style = MaterialTheme.typography.displaySmall,
             color = TajsOSTheme.Text,
         )
-        IconButton(onClick = context.onShowAddDialog, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = context.onShowAddDialog, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
             Icon(
                 Icons.Default.Add,
                 contentDescription = stringResource(Res.string.cal_settings_add),
@@ -125,7 +127,7 @@ private fun ProviderRow(
                     )
                 }
             }
-            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.Delete,
                     contentDescription = stringResource(Res.string.archive_delete),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsScreen.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.calendar
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.AlertDialog
@@ -146,7 +148,7 @@ private fun AddCalendarDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) {
                 Text(stringResource(Res.string.cal_settings_dialog_cancel))
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardCoreBlockRenderers.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardCoreBlockRenderers.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.screens.dashboard
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -219,7 +221,7 @@ internal fun renderOperationalBlock(context: DashboardBlockContext) {
                 letterSpacing = 2.sp,
             )
 
-            TextButton(onClick = { context.onNavigateTo(Screen.OpenLoops) }) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.onNavigateTo(Screen.OpenLoops) }) {
                 Text(
                     text = stringResource(Res.string.dashboard_open_loops_action),
                     style = MaterialTheme.typography.labelSmall,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardSpecialBlockRenderers.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardSpecialBlockRenderers.kt
@@ -5,6 +5,9 @@
 package com.tajemniktv.tajsos.ui.screens.dashboard
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.material.icons.filled.School
 import androidx.compose.material3.Text
@@ -98,7 +101,7 @@ internal fun renderStudyModuleBlock(
         nodes = studyNodes.take(5),
         onEditNode = context.onEditNode,
     )
-    TextButton(onClick = { context.onNavigateTo(Screen.Education) }) {
+    TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.onNavigateTo(Screen.Education) }) {
         Text(stringResource(Res.string.dash_action_open_study))
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/inbox/InboxDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/inbox/InboxDashboardBlocks.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.inbox
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -122,7 +124,7 @@ internal fun InboxMainBlock(
                             onArchive = { viewModel.archiveNode(nodeWithPin.node) },
                         )
 
-                        IconButton(onClick = { viewModel.markAsProcessed(nodeWithPin.node.id) }) {
+                        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.markAsProcessed(nodeWithPin.node.id) }) {
                             Icon(
                                 imageVector = Icons.Default.Check,
                                 contentDescription = stringResource(Res.string.inbox_process),
@@ -180,7 +182,7 @@ private fun InboxCaptureCard(
                     onClick = { viewModel.triageInboxEntry(entry.id, ItemKind.PROJECT) },
                     label = { Text(stringResource(Res.string.type_project).uppercase()) },
                 )
-                IconButton(onClick = { viewModel.dismissInboxEntry(entry) }) {
+                IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.dismissInboxEntry(entry) }) {
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = "Dismiss capture",

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.screens.notes
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -196,24 +198,24 @@ fun NotesEditorHeaderActions(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Row {
-            IconButton(onClick = onToggleFavorite, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleFavorite, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     imageVector = if (favorite) Icons.Default.Star else Icons.Default.StarBorder,
                     contentDescription = null,
                     tint = if (favorite) TajsOSTheme.Primary else TajsOSTheme.Text,
                 )
             }
-            IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onArchive, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.Archive, contentDescription = null, tint = TajsOSTheme.Text)
             }
-            IconButton(onClick = onToggleFocusMode, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleFocusMode, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.CenterFocusStrong,
                     contentDescription = null,
                     tint = if (focusMode) TajsOSTheme.Primary else TajsOSTheme.Text,
                 )
             }
-            IconButton(onClick = onToggleContextPanel, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleContextPanel, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.Info,
                     contentDescription = null,
@@ -222,7 +224,7 @@ fun NotesEditorHeaderActions(
             }
         }
         Box {
-            IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.MoreVert, contentDescription = null)
             }
             DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesListRail.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.screens.notes
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -99,7 +101,7 @@ fun NotesListRail(
                 leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
                 trailingIcon = {
                     if (searchQuery.isNotEmpty()) {
-                        IconButton(onClick = { onSearchChange("") }) {
+                        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onSearchChange("") }) {
                             Icon(Icons.Default.Close, contentDescription = "Clear search")
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.notes
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -215,7 +217,7 @@ fun NotesRoute(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            IconButton(onClick = { mobileInDetail = false }, modifier = Modifier.size(48.dp)) {
+                            IconButton(onClick = { mobileInDetail = false }, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -206,7 +206,7 @@ fun NotesWorkspaceDetail(
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconButton(onClick = onBack, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onBack, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                     }
                     Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailScreen.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.notes.detail
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
@@ -203,7 +205,7 @@ fun NoteDetailScreen(
         }
 
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = { viewModel.togglePermanentPin(node) }) {
+        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.togglePermanentPin(node) }) {
             Icon(
                 if (node.isPinned) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
                 contentDescription = null,
@@ -244,7 +246,7 @@ fun NoteDetailScreen(
                 modifier = Modifier.size(18.dp),
             )
         }
-        IconButton(onClick = { showMoreDialog = true }, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = { showMoreDialog = true }, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
             Icon(
                 Icons.Default.MoreVert,
                 contentDescription = null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.screens.profile
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -390,7 +392,7 @@ private fun renderMedicationsModuleBlock(context: ProfileScreenContext) {
             verticalAlignment = Alignment.CenterVertically,
         ) {
             ModuleTitle(title = stringResource(Res.string.profile_medications))
-            IconButton(onClick = context.onOpenAddMedication, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = context.onOpenAddMedication, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = null,
@@ -589,7 +591,7 @@ private fun MedicationItem(
                     color = TajsOSTheme.Primary,
                 )
             }
-            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.Delete, contentDescription = "Delete", tint = TajsOSTheme.Error)
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileRoute.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.screens.profile
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -255,7 +257,7 @@ private fun AddMedicationDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) {
                 Text(stringResource(Res.string.common_back))
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/ProjectsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/ProjectsScreen.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.projects
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -163,7 +165,7 @@ fun AddProjectDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) {
                 Text(stringResource(Res.string.projects_dialog_cancel))
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
@@ -214,12 +214,12 @@ private fun renderProjectHero(context: ProjectDetailContext) {
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                FilledTonalButton(onClick = context.onStatusClick) {
+                FilledTonalButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = context.onStatusClick) {
                     Icon(Icons.Default.Tune, null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.project_detail_set_status))
                 }
-                FilledTonalButton(onClick = {}) {
+                FilledTonalButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {}) {
                     Icon(Icons.Default.FolderOpen, null)
                     Spacer(Modifier.width(6.dp))
                     Text(context.areaName ?: stringResource(Res.string.detail_unassign))

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailScreen.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.projects.detail
 
 import androidx.compose.foundation.background
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -316,13 +318,13 @@ fun ProjectDetailScreen(
 ) {
     val project = context.project
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = { context.onStatusClick() }) {
+        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.onStatusClick() }) {
             Icon(Icons.Default.Tune, contentDescription = null, modifier = Modifier.size(18.dp))
         }
-        IconButton(onClick = { context.onEditNode(project.id) }) {
+        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.onEditNode(project.id) }) {
             Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
         }
-        IconButton(onClick = { context.viewModel.updateNode(project.copy(isFrozen = !project.isFrozen)) }) {
+        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.viewModel.updateNode(project.copy(isFrozen = !project.isFrozen)) }) {
             Icon(
                 if (project.isFrozen) Icons.Default.WbSunny else Icons.Default.Schedule,
                 contentDescription = null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/review/ReviewDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/review/ReviewDashboardBlocks.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.review
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -199,7 +201,7 @@ private fun renderReviewFlow(context: ReviewDashboardContext) {
                                 ListItem(
                                     headlineContent = { Text(item.node.title) },
                                     trailingContent = {
-                                        IconButton(onClick = { viewModel.archiveNode(item.node) }) {
+                                        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.archiveNode(item.node) }) {
                                             Icon(
                                                 Icons.Default.Delete,
                                                 contentDescription = stringResource(Res.string.detail_archive),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.search
 
 import androidx.compose.foundation.background
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -111,7 +113,7 @@ private fun renderSearchInput(context: SearchDashboardContext) {
             leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
             trailingIcon = {
                 if (context.searchQuery.isNotEmpty()) {
-                    IconButton(onClick = { viewModel.updateSearchQuery("") }) {
+                    IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.updateSearchQuery("") }) {
                         Icon(
                             Icons.Default.Clear,
                             contentDescription = stringResource(Res.string.search_clear),
@@ -125,7 +127,7 @@ private fun renderSearchInput(context: SearchDashboardContext) {
                     unfocusedContainerColor = TajsOSTheme.Surface,
                 ),
         )
-        IconButton(onClick = context.onToggleFilters, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = context.onToggleFilters, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
             Icon(
                 Icons.Default.FilterList,
                 contentDescription = "Toggle filters",
@@ -183,7 +185,7 @@ private fun renderSearchFilters(context: SearchDashboardContext) {
                 style = MaterialTheme.typography.labelSmall,
                 color = TajsOSTheme.Muted,
             )
-            TextButton(onClick = { viewModel.clearSearchFilters() }) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { viewModel.clearSearchFilters() }) {
                 Text(stringResource(Res.string.search_reset_filters))
             }
         }
@@ -531,13 +533,13 @@ private fun SearchResultsHeader(
             )
         }
         Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
-            TextButton(onClick = onToggleFilters) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onToggleFilters) {
                 Text(
                     "FILTER",
                     style = MaterialTheme.typography.labelSmall,
                 )
             }
-            TextButton(onClick = onToggleSort) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onToggleSort) {
                 Text(
                     if (sortMode == "relevance") "RELEVANCE" else "UPDATED",
                     style = MaterialTheme.typography.labelSmall,
@@ -759,25 +761,25 @@ private fun SearchResultCard(
 
             Spacer(modifier = Modifier.height(TajsOSTheme.SpacingSm))
             Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                TextButton(onClick = onOpen) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onOpen) {
                     Text(
                         "OPEN",
                         style = MaterialTheme.typography.labelSmall,
                     )
                 }
-                TextButton(onClick = { onToggleDone(if (node.status == "done") "active" else "done") }) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onToggleDone(if (node.status == "done") "active" else "done") }) {
                     Text(
                         if (node.status == "done") "ACTIVATE" else "DONE",
                         style = MaterialTheme.typography.labelSmall,
                     )
                 }
-                TextButton(onClick = { onTogglePin(!nodeWithPin.isPinnedToToday) }) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onTogglePin(!nodeWithPin.isPinnedToToday) }) {
                     Text(
                         if (nodeWithPin.isPinnedToToday) "REMOVE TODAY" else "ADD TODAY",
                         style = MaterialTheme.typography.labelSmall,
                     )
                 }
-                TextButton(onClick = onArchive) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onArchive) {
                     Text(
                         "ARCHIVE",
                         style = MaterialTheme.typography.labelSmall,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.screens.settings
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -721,7 +723,7 @@ private fun SettingsMedicationItem(
             color = TajsOSTheme.Muted,
         )
         Spacer(Modifier.height(TajsOSTheme.SpacingSm))
-        TextButton(onClick = onDelete) {
+        TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDelete) {
             Text(stringResource(Res.string.med_delete))
         }
     }
@@ -792,7 +794,7 @@ private fun SettingsAddMedicationDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onDismiss) {
                 Text(stringResource(Res.string.common_back))
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardBlocks.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.study
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -244,7 +246,7 @@ internal fun renderFlashcardCandidatesBlock(context: StudyDashboardContext) {
                         color = TajsOSTheme.Muted,
                     )
                 }
-                OutlinedButton(onClick = {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                     context.viewModel.toggleFlashcardCandidate(
                         item.node,
                         false,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksAllView.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.screens.tasks
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -433,19 +435,19 @@ private fun TaskDetails(
             horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
             modifier = Modifier.fillMaxWidth(),
         ) {
-            OutlinedButton(onClick = { onOpen(task.id) }, modifier = Modifier.weight(1f)) {
+            OutlinedButton(onClick = { onOpen(task.id) }, modifier = Modifier.weight(1f).pointerHoverIcon(PointerIcon.Hand)) {
                 Text(
                     stringResource(Res.string.tasks_open_action),
                 )
             }
             if (task.taskStateOrNull() == TaskState.DONE) {
-                OutlinedButton(onClick = { onRestore(task) }, modifier = Modifier.weight(1f)) {
+                OutlinedButton(onClick = { onRestore(task) }, modifier = Modifier.weight(1f).pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(Icons.Default.Refresh, null)
                     Spacer(Modifier.width(4.dp))
                     Text(stringResource(Res.string.tasks_restore_action))
                 }
             } else {
-                OutlinedButton(onClick = { onDone(task) }, modifier = Modifier.weight(1f)) {
+                OutlinedButton(onClick = { onDone(task) }, modifier = Modifier.weight(1f).pointerHoverIcon(PointerIcon.Hand)) {
                     Text(
                         stringResource(Res.string.tasks_done_action),
                     )
@@ -456,12 +458,12 @@ private fun TaskDetails(
             horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
             modifier = Modifier.fillMaxWidth(),
         ) {
-            OutlinedButton(onClick = { onArchive(task) }, modifier = Modifier.weight(1f)) {
+            OutlinedButton(onClick = { onArchive(task) }, modifier = Modifier.weight(1f).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.Archive, null)
                 Spacer(Modifier.width(4.dp))
                 Text(stringResource(Res.string.tasks_archive_action))
             }
-            OutlinedButton(onClick = { onDelete(task) }, modifier = Modifier.weight(1f)) {
+            OutlinedButton(onClick = { onDelete(task) }, modifier = Modifier.weight(1f).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.Delete, null, tint = TajsOSTheme.Error)
                 Spacer(Modifier.width(4.dp))
                 Text(stringResource(Res.string.tasks_delete_action), color = TajsOSTheme.Error)

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksArchiveView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksArchiveView.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.tasks
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -94,9 +96,9 @@ internal fun TasksArchiveView(
                             }
                         }
                         Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                            OutlinedButton(onClick = { onOpen(task.id) }) { Text(stringResource(Res.string.tasks_open_action)) }
-                            OutlinedButton(onClick = { onRestore(task) }) { Text(stringResource(Res.string.tasks_restore_action)) }
-                            IconButton(onClick = { onDelete(task) }) {
+                            OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onOpen(task.id) }) { Text(stringResource(Res.string.tasks_open_action)) }
+                            OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onRestore(task) }) { Text(stringResource(Res.string.tasks_restore_action)) }
+                            IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDelete(task) }) {
                                 Icon(
                                     Icons.Default.Delete,
                                     null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksCommandView.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.screens.tasks
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -294,7 +296,7 @@ private fun PriorityTaskCard(
                 horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Button(onClick = { onStartFocus(task) }, modifier = Modifier.weight(1f)) {
+                Button(onClick = { onStartFocus(task) }, modifier = Modifier.weight(1f).pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(Icons.Default.PlayArrow, null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.tasks_start_focus_action))
@@ -315,7 +317,7 @@ private fun PriorityTaskCard(
                         },
                     )
                 }
-                OutlinedButton(onClick = { onDone(task) }, modifier = Modifier.weight(1f)) {
+                OutlinedButton(onClick = { onDone(task) }, modifier = Modifier.weight(1f).pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(Icons.Default.Check, null)
                     Spacer(Modifier.width(4.dp))
                     Text(stringResource(Res.string.tasks_done_action))
@@ -366,9 +368,9 @@ private fun QueueList(
                         }
                     }
                     Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                        OutlinedButton(onClick = { onDoNow(task) }) { Text(stringResource(Res.string.tasks_start_focus_action)) }
-                        OutlinedButton(onClick = { onOpen(task.id) }) { Text(stringResource(Res.string.tasks_open_action)) }
-                        IconButton(onClick = { onDone(task) }) { Icon(Icons.Default.Check, null) }
+                        OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDoNow(task) }) { Text(stringResource(Res.string.tasks_start_focus_action)) }
+                        OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onOpen(task.id) }) { Text(stringResource(Res.string.tasks_open_action)) }
+                        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDone(task) }) { Icon(Icons.Default.Check, null) }
                     }
                 }
                 HorizontalDivider(color = TajsOSTheme.GhostBorder)
@@ -414,7 +416,7 @@ private fun CommandSidebar(
                 modifier = Modifier.fillMaxWidth(),
                 placeholder = { Text(stringResource(Res.string.tasks_quick_add_hint)) },
             )
-            Button(onClick = onQuickAdd, modifier = Modifier.fillMaxWidth()) {
+            Button(onClick = onQuickAdd, modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand)) {
                 Text(
                     stringResource(
                         Res.string.tasks_quick_add_action,
@@ -433,7 +435,7 @@ private fun CommandSidebar(
                 modifier = Modifier.fillMaxWidth(),
                 placeholder = { Text(stringResource(Res.string.tasks_quick_capture_hint)) },
             )
-            OutlinedButton(onClick = onCapture, modifier = Modifier.fillMaxWidth()) {
+            OutlinedButton(onClick = onCapture, modifier = Modifier.fillMaxWidth().pointerHoverIcon(PointerIcon.Hand)) {
                 Text(
                     stringResource(Res.string.tasks_quick_capture_action),
                 )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksInboxView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksInboxView.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.tasks
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -110,12 +112,12 @@ internal fun TasksInboxView(
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
                             ) {
-                                OutlinedButton(onClick = { onTriageTask(entry) }) {
+                                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onTriageTask(entry) }) {
                                     Text(
                                         stringResource(Res.string.tasks_inbox_triage_task),
                                     )
                                 }
-                                IconButton(onClick = { onDismiss(entry) }) {
+                                IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDismiss(entry) }) {
                                     Icon(
                                         Icons.Default.Delete,
                                         stringResource(Res.string.tasks_inbox_dismiss),
@@ -179,14 +181,14 @@ internal fun TasksInboxView(
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm),
                             ) {
-                                OutlinedButton(onClick = { onOpen(task.id) }) {
+                                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onOpen(task.id) }) {
                                     Text(
                                         stringResource(
                                             Res.string.tasks_open_action,
                                         ),
                                     )
                                 }
-                                OutlinedButton(onClick = { onMarkProcessed(task) }) {
+                                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onMarkProcessed(task) }) {
                                     Text(
                                         stringResource(Res.string.tasks_inbox_mark_processed),
                                     )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksTodayView.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/TasksTodayView.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.tasks
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -177,13 +179,13 @@ private fun TodaySection(
                             }
                         }
                         Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                            OutlinedButton(onClick = {
+                            OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                                 onStartFocus(task)
                             }) { Text(stringResource(Res.string.tasks_start_focus_action)) }
-                            OutlinedButton(onClick = {
+                            OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                                 onOpen(task.id)
                             }) { Text(stringResource(Res.string.tasks_open_action)) }
-                            OutlinedButton(onClick = {
+                            OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = {
                                 onSetTodayPayload(task, task.id !in todayTaskIds)
                             }) {
                                 Icon(Icons.Default.Star, null)
@@ -195,7 +197,7 @@ private fun TodaySection(
                                     },
                                 )
                             }
-                            IconButton(onClick = { onDone(task) }) {
+                            IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { onDone(task) }) {
                                 Icon(
                                     Icons.Default.Check,
                                     null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -6,6 +6,8 @@ package com.tajemniktv.tajsos.ui.screens.tasks.detail
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -327,7 +329,7 @@ private fun TaskActionBar(
     ) {
         if (isEditing) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = onCancel) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onCancel) {
                     Text(stringResource(Res.string.common_cancel))
                 }
                 Button(onClick = onSave) {
@@ -336,12 +338,12 @@ private fun TaskActionBar(
             }
         } else {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = onToggleEdit) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onToggleEdit) {
                     Icon(Icons.Default.Edit, contentDescription = null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.common_edit))
                 }
-                OutlinedButton(onClick = onSnooze) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = onSnooze) {
                     Icon(Icons.Default.AccessTime, contentDescription = null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.task_detail_snooze))
@@ -478,7 +480,7 @@ private fun renderTaskSubtasks(context: TaskDetailContext) {
                 }
             }
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = context.onSplitIntoSubtasks) {
+                OutlinedButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = context.onSplitIntoSubtasks) {
                     Text(stringResource(Res.string.detail_split_subtasks))
                 }
             }
@@ -620,7 +622,7 @@ private fun SubtaskRow(
                 color = tint,
             )
             if (subtask.source == TaskSubtaskSource.InlineChecklist && onRemove != null) {
-                IconButton(onClick = onRemove, modifier = Modifier.size(48.dp)) {
+                IconButton(onClick = onRemove, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = null,
@@ -704,7 +706,7 @@ private fun AttachmentRow(
                 )
             }
         }
-        IconButton(onClick = onRemove, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = onRemove, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
             Icon(Icons.Default.Delete, contentDescription = null, tint = TajsOSTheme.Muted)
         }
     }
@@ -1130,7 +1132,7 @@ private fun TaskEditablePropertyRow(
             )
         }
         Box {
-            TextButton(onClick = { expanded = true }) {
+            TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { expanded = true }) {
                 Text(selected)
             }
             DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesDashboardBlocks.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.templates
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -73,7 +75,7 @@ private fun renderTemplatesList(context: TemplatesDashboardContext) {
                         Text(typeLabel.uppercase())
                     },
                     trailingContent = {
-                        IconButton(onClick = { context.onDeleteTemplate(template) }) {
+                        IconButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { context.onDeleteTemplate(template) }) {
                             Icon(
                                 Icons.Default.Delete,
                                 contentDescription = stringResource(Res.string.archive_delete),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesScreen.kt
@@ -5,6 +5,8 @@
 package com.tajemniktv.tajsos.ui.screens.templates
 
 import androidx.compose.foundation.background
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Arrangement
@@ -70,7 +72,7 @@ fun TemplatesScreen(
         )
 
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = { showAddDialog = true }, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = { showAddDialog = true }, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
             Icon(
                 Icons.Default.Add,
                 contentDescription = stringResource(Res.string.templates_add_desc),
@@ -142,7 +144,7 @@ fun TemplatesScreen(
                 ) { Text(stringResource(Res.string.templates_dialog_create)) }
             },
             dismissButton = {
-                TextButton(onClick = { showAddDialog = false }) {
+                TextButton(modifier = Modifier.pointerHoverIcon(PointerIcon.Hand), onClick = { showAddDialog = false }) {
                     Text(
                         stringResource(
                             Res.string.templates_dialog_cancel,


### PR DESCRIPTION
This PR adds the `Modifier.pointerHoverIcon(PointerIcon.Hand)` to interactive components (such as `IconButton`, `TextButton`, `OutlinedButton`, `Button`, and `Modifier.clickable`) throughout the TajsOS composeApp UI. This UX enhancement provides immediate visual feedback when hovering over clickable elements, greatly improving consistency and clarity for desktop/web targets without affecting touch interfaces like Android.

---
*PR created automatically by Jules for task [14140060799539571401](https://jules.google.com/task/14140060799539571401) started by @tajemniktv*

## Summary by Sourcery

Enhancements:
- Apply pointer hover icon styling to buttons, icon buttons, text buttons, outlined buttons, filled tonal buttons, and various clickable actions throughout screens and shared components to improve discoverability of interactive elements.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

