### PR TITLE
docs: Add KDocs for NodeCommands public API

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
@@ -589,6 +589,13 @@ class NodeCommands(
         }
     }
 
+    /**
+     * Creates a new project node in the system.
+     *
+     * @param name The primary title of the new project.
+     * @param description An optional detailed description or initial content for the project.
+     * @param areaId The optional unique ID of a parent area to which this project belongs.
+     */
     fun addProject(
         name: String,
         description: String = "",
@@ -598,10 +605,24 @@ class NodeCommands(
         addNode(title = name, content = description, type = "project", areaId = areaId) // NON-NLS
         }
 
+    /**
+     * Creates a new top-level area node in the system.
+     *
+     * @param name The primary title of the new area.
+     */
     fun addArea(name: String) {
         addNode(title = name, type = "area") // NON-NLS
     }
 
+    /**
+     * Updates the specific open loop subtype (e.g., "idea", "maybe") of an existing open loop node.
+     * Also resets its staleness timer.
+     *
+     * This method silently fails if the target node is not of type "open_loop".
+     *
+     * @param node The [NodeEntity] representing the open loop to update.
+     * @param openLoopType The new specific type classification to apply.
+     */
     fun updateOpenLoopType(
         node: NodeEntity,
         openLoopType: String,
@@ -629,10 +650,20 @@ class NodeCommands(
         convertOpenLoop(nodeId, "task") // NON-NLS
     }
 
+    /**
+     * Morphs an unstructured "open loop" node into a formal "decision" node.
+     *
+     * @param nodeId The unique numeric ID of the open loop node to convert.
+     */
     fun convertOpenLoopToDecision(nodeId: Long) {
         convertOpenLoop(nodeId, "decision") // NON-NLS
     }
 
+    /**
+     * Morphs an unstructured "open loop" node into a static "note" node.
+     *
+     * @param nodeId The unique numeric ID of the open loop node to convert.
+     */
     fun convertOpenLoopToNote(nodeId: Long) {
         convertOpenLoop(nodeId, "note") // NON-NLS
     }


### PR DESCRIPTION
Added KDocs for public functions in NodeCommands.kt to improve maintainability and onboarding, specifically detailing `addProject`, `addArea`, `updateOpenLoopType`, `convertOpenLoopToDecision`, and `convertOpenLoopToNote`.

---
*PR created automatically by Jules for task [8896107973331253676](https://jules.google.com/task/8896107973331253676) started by @tajemniktv*

## Summary by Sourcery

Document public node command APIs for projects, areas, and open-loop conversions to clarify their usage and intent.

Documentation:
- Add KDoc descriptions for project creation, area creation, and open-loop subtype updates.
- Add KDoc descriptions for converting open loops into tasks, decisions, and notes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

