### PR TITLE
perf: Optimize collection operations

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -44,6 +44,10 @@ import kotlin.time.Instant
  * @param projects A curated list of nodes strictly identified as "project" entities.
  * @return An analytical [InsightsData] snapshot summarizing the user's historical performance.
  */
+/**
+ * Calculates insights metrics.
+ * Optimized using .groupingBy {}.eachCount() instead of .groupBy {}.mapValues { it.value.size } to reduce intermediate collection allocations.
+ */
 fun calculateInsights(
     nodes: List<NodeWithPin>,
     sessions: List<FocusSessionEntity>,
@@ -128,13 +132,13 @@ fun calculateInsights(
     val completionsByArea =
         recentCompletions
             .mapNotNull { item -> item.node.areaId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .groupingBy { it.first }
+            .eachCount()
     val completionsByProject =
         recentCompletions
             .mapNotNull { item -> item.node.projectId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .groupingBy { it.first }
+            .eachCount()
 
     val inboxGrowth = recentNodes.count { it.node.inboxState }
     val archivedCount =
@@ -175,23 +179,23 @@ fun calculateInsights(
     // Correlating track entries with activity
     val dailyCompletions =
         recentCompletions
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.completedAt ?: 0)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyCaptures =
         recentNodes
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.createdAt)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyFocus =
         recentSessions
@@ -1709,6 +1713,10 @@ fun calculateVaultsSnapshot(nodes: List<NodeWithPin>): VaultsSnapshot {
  * @param inputs A bundled dataset providing current node volumes, maintenance debt, and open loops.
  * @return A [CapacitySnapshot] identifying execution pressure and potential burnout risks.
  */
+/**
+ * Calculates the capacity snapshot.
+ * Optimized using .distinctBy {}.size instead of .groupBy {}.size to avoid unnecessary intermediate map and list allocations.
+ */
 fun calculateCapacitySnapshot(
     nodes: List<NodeWithPin>,
     projects: List<NodeEntity>,
@@ -1736,9 +1744,9 @@ fun calculateCapacitySnapshot(
         ).coerceIn(0, 100)
     val fragmentationScore =
         (
-                activeTasks.groupBy { it.node.projectId }.size *
+                activeTasks.distinctBy { it.node.projectId }.size *
                         7 +
-                        activeTasks.groupBy { it.node.areaId }.size *
+                        activeTasks.distinctBy { it.node.areaId }.size *
                         4
         ).coerceIn(0, 100)
 
@@ -1762,7 +1770,7 @@ fun calculateCapacitySnapshot(
     val unrealisticWeekSignal =
         if (weeklyCreatedActive > weeklyDone * 2 + 5) "THIS WEEK IS UNREALISTIC // INTAKE OUTPACES EXECUTION" else null
     val tooManyActiveFrontsIndicator =
-        if (activeTasks.groupBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
+        if (activeTasks.distinctBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
     val attentionFragmentedIndicator =
         if (fragmentationScore >= 55) "ATTENTION IS TOO FRAGMENTED" else null
     val weeklyStructuralOverloadWarning =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -330,6 +330,10 @@ fun buildPlaybookSnapshot(
  * @param packs The registry of enabled and owned application packs.
  * @return A fully populated [DashboardUIState] reflecting the entire system's status filtered by the active mode.
  */
+/**
+ * Builds the dashboard UI state.
+ * Optimized using .distinctBy {}.size to performantly count unique items without generating intermediate maps.
+ */
 suspend fun buildDashboardUIState(
     repository: AppRepository,
     nodes: List<NodeWithPin>,
@@ -443,7 +447,7 @@ suspend fun buildDashboardUIState(
     val areaHealthMetrics = areaSnapshot.areas.associateBy { it.areaId }
 
     val loadScore = (activeTasks.size * 2) + (openLoops.size * 3) + (overdue.size * 5)
-    val fragmentation = activeTasks.groupBy { it.node.projectId }.size * 5
+    val fragmentation = activeTasks.distinctBy { it.node.projectId }.size * 5
     val capWarning =
         when
             {


### PR DESCRIPTION
Replaces `.groupBy {}.size` with `.distinctBy {}.size` and `.groupBy {}.mapValues { it.value.size }` with `.groupingBy {}.eachCount()` to avoid creating intermediate arrays and maps that negatively impact the efficiency.

---
*PR created automatically by Jules for task [751559875016746866](https://jules.google.com/task/751559875016746866) started by @tajemniktv*

## Summary by Sourcery

Optimize collection-based insight and capacity calculations for better performance and add brief documentation for the affected calculators and assemblers.

Enhancements:
- Replace groupBy/mapValues size computations with groupingBy/eachCount in insights calculators to reduce intermediate allocations.
- Replace groupBy-based uniqueness counting with distinctBy.size in capacity and dashboard state assemblers to more efficiently measure fragmentation and unique fronts.
- Add clarifying KDoc comments documenting the purpose of the optimized calculator and assembler functions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

