### PR TITLE
build(website): disable Starlight 404 route to fix collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,8 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      // Disable Starlight's default 404 route because a custom src/pages/404.astro exists
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
Disables the default Starlight 404 route in astro.config.mjs to resolve a routing collision with the custom src/pages/404.astro file, fixing build warnings.

---
*PR created automatically by Jules for task [6611369741884342780](https://jules.google.com/task/6611369741884342780) started by @tajemniktv*

## Summary by Sourcery

Enhancements:
- Configure the Starlight integration to use the existing custom 404 page instead of its default 404 route.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

