### PR TITLE
fix(ui): improve hover state consistency for interactive elements

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/ActionButton.kt
@@ -4,6 +4,9 @@
 
 package com.tajemniktv.tajsos.ui.components
 
+
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -72,7 +75,7 @@ fun ActionButton(
         onClick = onClick,
         enabled = enabled,
         interactionSource = interactionSource,
-        modifier = finalModifier.graphicsLayer { scaleX = scale; scaleY = scale },
+        modifier = finalModifier.graphicsLayer { scaleX = scale; scaleY = scale }.pointerHoverIcon(if (enabled) PointerIcon.Hand else PointerIcon.Default),
         colors =
             resolveActionButtonColors(
                 isPrimary = isPrimary,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppSidebar.kt
@@ -4,6 +4,9 @@
 
 package com.tajemniktv.tajsos.ui.components.layout
 
+
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.fadeIn
@@ -744,7 +747,7 @@ fun NewEntryButton(
                     ).graphicsLayer {
                         scaleX = scale
                         scaleY = scale
-                    },
+                    }.pointerHoverIcon(PointerIcon.Hand),
             interactionSource = interactionSource,
             tonalElevation = 0.dp,
             shadowElevation = 0.dp,
@@ -797,7 +800,7 @@ fun UserProfileSidebarSection(
                 Modifier.fillMaxWidth().mouseButtons(
                     onSecondaryClick = onClick,
                     onMiddleClick = onClick,
-                ),
+                ).pointerHoverIcon(PointerIcon.Hand),
             shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
             color = TajsOSTheme.CardNestedSurface,
             tonalElevation = 0.dp,


### PR DESCRIPTION
This pull request addresses a UX polish issue in JetBrains Compose Multiplatform for desktop/web targets. By default, interactive components (like `ActionButton`, `NewEntryButton`, and `UserProfileSidebarSection`) do not always display a hand pointer on hover. This change explicitly appends `.pointerHoverIcon(PointerIcon.Hand)` (or conditionally `PointerIcon.Default` if disabled) to the modifiers of these components, significantly improving visual consistency and interactivity cues without altering product direction.

---
*PR created automatically by Jules for task [6587476814809202728](https://jules.google.com/task/6587476814809202728) started by @tajemniktv*

## Summary by Sourcery

Ensure interactive sidebar and action buttons consistently show a hand pointer on hover across desktop/web targets.

Bug Fixes:
- Add hover pointer icon to NewEntryButton and UserProfileSidebarSection for clearer interactivity cues.
- Apply conditional hover pointer icon to ActionButton based on enabled state to improve UX consistency.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

