### PR TITLE
fix(website): disable default starlight 404 route

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,8 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      // Disabling Starlight's default 404 route because a custom src/pages/404.astro exists
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
This PR fixes a build warning in the Astro website project caused by a collision between the custom `src/pages/404.astro` page and Astro Starlight's default static 404 route.

It adds the `disable404Route: true` property to the Starlight configuration in `website/astro.config.mjs` and includes an explanatory comment so reviewers understand the reasoning.

**Testing done:**
* Ran `cd website && npm run build` successfully without the routing warning.
* Ran `cd website && npm run check` successfully.

---
*PR created automatically by Jules for task [3724718529629625596](https://jules.google.com/task/3724718529629625596) started by @tajemniktv*

## Summary by Sourcery

Build:
- Update Astro Starlight configuration to turn off the framework-provided 404 route in favor of the project's custom 404 page.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

