### PR TITLE
test: Improve coverage for SidebarMode and MainProtocolHelpers

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/SidebarModeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/SidebarModeTest.kt
@@ -1,0 +1,16 @@
+package com.tajemniktv.tajsos.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SidebarModeTest {
+
+    @Test
+    fun testSidebarModeValues() {
+        val modes = SidebarMode.entries
+        assertEquals(3, modes.size)
+        assertEquals(SidebarMode.EXPANDED, modes[0])
+        assertEquals(SidebarMode.COLLAPSED, modes[1])
+        assertEquals(SidebarMode.HOVER_EXPAND, modes[2])
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpersTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainProtocolHelpersTest.kt
@@ -19,7 +19,8 @@ class MainProtocolHelpersTest {
         assertEquals("hello world", normalizeProtocolLabel("  Hello... World  "))
         assertEquals("hello 123", normalizeProtocolLabel("Hello 123"))
         assertEquals("", normalizeProtocolLabel("   !!!   "))
-    }
+
+}
 
     @Test
     fun testBuildPlaybookRelationshipContext() {
@@ -233,6 +234,27 @@ class MainProtocolHelpersTest {
 
         val cantThinkMode = ModeEntity(id = 3, key = "CANT_THINK", name = "Cant Think")
         assertEquals("Bad day protocol", suggestPlaybookLabel(cantThinkMode, emptyList()))
+    }
+
+
+    @Test
+    fun testMatchesQuery() {
+        val nodeWithPin = com.tajemniktv.tajsos.data.NodeWithPin(
+            node = com.tajemniktv.tajsos.data.NodeEntity(id = 1, title = "title", content = "content", type = "task"),
+            pin = null,
+            tags = listOf(com.tajemniktv.tajsos.data.TagEntity(id = 1, name = "tag1", normalizedName = "tag1"))
+        )
+
+        // Exact matches
+        kotlin.test.assertTrue(matchesQuery(nodeWithPin, "title"))
+        kotlin.test.assertTrue(matchesQuery(nodeWithPin, "content"))
+        kotlin.test.assertTrue(matchesQuery(nodeWithPin, "tag1"))
+
+        // Negative match
+        kotlin.test.assertFalse(matchesQuery(nodeWithPin, "nothing"))
+
+        // Blank search delegates properly
+        kotlin.test.assertFalse(matchesQuery(nodeWithPin, ""))
     }
 
 }


### PR DESCRIPTION
This PR adds unit tests for `SidebarMode` values and `matchesQuery` in `MainProtocolHelpersTest`. 
It ensures that the `SidebarMode` Enum has expected values and that `matchesQuery` perfectly delegates its job and handles normal search strings and empty strings without faults, which increases the test robustness without affecting any production logic.

---
*PR created automatically by Jules for task [8917629626722283457](https://jules.google.com/task/8917629626722283457) started by @tajemniktv*

## Summary by Sourcery

Expand test coverage for query matching and sidebar mode enumeration.

Tests:
- Add unit tests for matchesQuery to cover exact, negative, and blank search cases.
- Add unit tests verifying SidebarMode entries and expected ordering.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

