### PR TITLE
feat(ui): append pointerHoverIcon to interactive components for better UX

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/NodeCards.kt
@@ -63,6 +63,8 @@ import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
 import kotlin.time.Clock
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 fun NodeCard(
@@ -267,7 +269,7 @@ fun NodeCard(
                         }
                     }
                     if (isDone) {
-                        IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+                        IconButton(onClick = onArchive, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                             Icon(
                                 imageVector = Icons.Default.Delete,
                                 contentDescription = stringResource(Res.string.detail_archive),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/OperationsCards.kt
@@ -52,6 +52,8 @@ import tajsos.composeapp.generated.resources.open_loop_none
 import tajsos.composeapp.generated.resources.open_loop_unassigned
 import tajsos.composeapp.generated.resources.open_loop_untyped
 import kotlin.time.Clock
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Displays a card for an open loop (unresolved thought, idea, or pending task).
@@ -180,7 +182,7 @@ fun OpenLoopCard(
                         label = { Text(stringResource(Res.string.open_loop_action_convert_note)) },
                     )
                 } else {
-                    Button(onClick = onArchive) { Text(stringResource(Res.string.open_loop_action_archive)) }
+                    Button(onClick = onArchive, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text(stringResource(Res.string.open_loop_action_archive)) }
                 }
             }
         }
@@ -311,7 +313,7 @@ fun MaintenanceCard(
                         label = { Text("RESOLVE") },
                     )
                 } else {
-                    Button(onClick = onArchive) { Text("ARCHIVE") }
+                    Button(onClick = onArchive, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text("ARCHIVE") }
                 }
             }
         }
@@ -386,7 +388,7 @@ fun ProtocolCard(
             ) {
                 AssistChip(onClick = { onEditNode(item.node.node.id) }, label = { Text("OPEN") })
                 AssistChip(onClick = onRun, label = { Text("RUN") })
-                Button(onClick = onArchive) { Text("ARCHIVE") }
+                Button(onClick = onArchive, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text("ARCHIVE") }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/StudentCards.kt
@@ -64,6 +64,8 @@ import tajsos.composeapp.generated.resources.study_label_assignments
 import tajsos.composeapp.generated.resources.study_label_flashcards
 import tajsos.composeapp.generated.resources.study_label_study_time
 import tajsos.composeapp.generated.resources.templates_title
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Student summary card
@@ -310,13 +312,13 @@ fun ProgressControlCard(
             Text(title, style = MaterialTheme.typography.titleSmall)
             Text("$value%", style = MaterialTheme.typography.bodySmall, color = TajsOSTheme.Accent)
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                OutlinedButton(onClick = onDecrease) { Text("-10") }
-                OutlinedButton(onClick = onIncrease) { Text("+10") }
-                OutlinedButton(onClick = onOpen) { Text(stringResource(Res.string.common_open)) }
+                OutlinedButton(onClick = onDecrease, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text("-10") }
+                OutlinedButton(onClick = onIncrease, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text("+10") }
+                OutlinedButton(onClick = onOpen, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text(stringResource(Res.string.common_open)) }
             }
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                OutlinedButton(onClick = onOpen) { Text(stringResource(Res.string.student_action_details)) }
-                OutlinedButton(onClick = {}) {
+                OutlinedButton(onClick = onOpen, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text(stringResource(Res.string.student_action_details)) }
+                OutlinedButton(onClick = {}, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(
                         stringResource(
                             Res.string.student_id_label,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/common/CaptureSheet.kt
@@ -87,6 +87,8 @@ import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a modal bottom sheet that collects capture text and related metadata, then submits it via the provided callback.
@@ -286,7 +288,7 @@ fun CaptureSheet(
                 )
 
                 if (onVoiceCaptureClick != null) {
-                    IconButton(onClick = onVoiceCaptureClick, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onVoiceCaptureClick, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                         Icon(
                             imageVector = Icons.Default.Mic,
                             contentDescription = stringResource(Res.string.capture_voice),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -69,6 +69,8 @@ import tajsos.composeapp.generated.resources.header_mode_label
 import tajsos.composeapp.generated.resources.header_notifications
 import tajsos.composeapp.generated.resources.header_notifications_title
 import tajsos.composeapp.generated.resources.header_search_placeholder
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Mode option model shown by the header mode switcher.
@@ -136,7 +138,7 @@ fun AppShellHeader(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (!isDesktop && onMenuClick != null) {
-                    IconButton(onClick = onMenuClick, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onMenuClick, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                         Icon(
                             imageVector = Icons.Default.Menu,
                             contentDescription = stringResource(Res.string.header_menu),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
@@ -119,7 +119,7 @@ fun DashHeader(
                 }
             }
             Spacer(Modifier.width(12.dp))
-            IconButton(onClick = onSettingsClick, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onSettingsClick, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.Settings, contentDescription = null, tint = TajsOSTheme.Muted)
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSuggestionBanner.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/modes/ModeSuggestionBanner.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a themed banner suggesting a mode change and exposes actions to accept or dismiss it.
@@ -83,7 +85,7 @@ fun ModeSuggestionBanner(
                 }
             }
             Row {
-                TextButton(onClick = onDismiss) {
+                TextButton(onClick = onDismiss, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(
                         "IGNORE",
                         style = MaterialTheme.typography.labelSmall,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -226,7 +226,7 @@ fun DecisionDetailContent(
                 style = MaterialTheme.typography.bodySmall,
                 color = TajsOSTheme.Muted,
             )
-            TextButton(onClick = { showPeopleDialog = true }) {
+            TextButton(onClick = { showPeopleDialog = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(stringResource(Res.string.decision_action_link_person))
             }
         }
@@ -289,7 +289,7 @@ fun DecisionDetailContent(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             SectionTitle(stringResource(Res.string.decision_options_label))
-            IconButton(onClick = { showAddOptionDialog = true }, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = { showAddOptionDialog = true }, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = stringResource(Res.string.cd_add_option),
@@ -490,7 +490,7 @@ fun DecisionDetailContent(
                 }
             },
             confirmButton = {
-                TextButton(onClick = { showPeopleDialog = false }) {
+                TextButton(onClick = { showPeopleDialog = false }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(stringResource(Res.string.common_close))
                 }
             },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskRow.kt
@@ -45,6 +45,8 @@ import tajsos.composeapp.generated.resources.dash_heavy
 import tajsos.composeapp.generated.resources.dash_unclear
 import tajsos.composeapp.generated.resources.detail_archive
 import tajsos.composeapp.generated.resources.task_row_unpin_desc
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Renders a single task row for the given node, showing its title, metadata and action controls.
@@ -187,7 +189,7 @@ fun TaskRow(
                     }
                 }
                 if (isDone) {
-                    IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onArchive, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                         Icon(
                             imageVector = Icons.Default.Delete,
                             contentDescription = stringResource(Res.string.detail_archive),
@@ -195,7 +197,7 @@ fun TaskRow(
                         )
                     }
                 }
-                IconButton(onClick = onUnpin, modifier = Modifier.size(48.dp)) {
+                IconButton(onClick = onUnpin, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(
                         Icons.Default.Close,
                         contentDescription = stringResource(Res.string.task_row_unpin_desc),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/AreasDashboardBlocks.kt
@@ -84,6 +84,8 @@ import tajsos.composeapp.generated.resources.areas_recent_activity
 import tajsos.composeapp.generated.resources.areas_title
 import tajsos.composeapp.generated.resources.areas_upcoming_deadlines
 import tajsos.composeapp.generated.resources.common_open
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object AreasDashboardBlocks {
     private val renderers: Map<String, AreasDashboardBlockRenderer> =
@@ -123,7 +125,7 @@ internal fun AreasMainBlock(
                 color = TajsOSTheme.Text,
             )
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                OutlinedButton(onClick = { showAddDialog = true }) {
+                OutlinedButton(onClick = { showAddDialog = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(stringResource(Res.string.areas_new))
                 }
             }
@@ -132,7 +134,7 @@ internal fun AreasMainBlock(
         if (areas.isEmpty()) {
             EmptyState(message = stringResource(Res.string.areas_empty)) {
                 Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
-                Button(onClick = { showAddDialog = true }) {
+                Button(onClick = { showAddDialog = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(stringResource(Res.string.areas_create_first))
                 }
             }
@@ -475,7 +477,7 @@ fun AddAreaDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text(stringResource(Res.string.areas_dialog_cancel)) }
+            TextButton(onClick = onDismiss, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text(stringResource(Res.string.areas_dialog_cancel)) }
         },
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
@@ -155,9 +155,9 @@ private fun renderAreaHero(context: AreaDetailContext) {
                 trackColor = TajsOSTheme.SurfaceLow,
             )
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                FilledTonalButton(onClick = {}) { Text(stringResource(Res.string.area_detail_tab_work)) }
-                FilledTonalButton(onClick = {}) { Text(stringResource(Res.string.area_detail_tab_notes)) }
-                FilledTonalButton(onClick = {}) { Text(stringResource(Res.string.area_detail_tab_projects)) }
+                FilledTonalButton(onClick = {}, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text(stringResource(Res.string.area_detail_tab_work)) }
+                FilledTonalButton(onClick = {}, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text(stringResource(Res.string.area_detail_tab_notes)) }
+                FilledTonalButton(onClick = {}, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) { Text(stringResource(Res.string.area_detail_tab_projects)) }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -148,14 +148,14 @@ fun CalendarHeader(
             )
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            TextButton(onClick = onTodayClick) {
+            TextButton(onClick = onTodayClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(
                     stringResource(Res.string.cal_today),
                     style = MaterialTheme.typography.labelSmall,
                     color = TajsOSTheme.Primary,
                 )
             }
-            IconButton(onClick = onSyncClick, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onSyncClick, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.Refresh,
                     contentDescription = stringResource(Res.string.cal_sync),
@@ -163,13 +163,13 @@ fun CalendarHeader(
                     modifier = Modifier.size(20.dp),
                 )
             }
-            IconButton(onClick = onPreviousMonth, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onPreviousMonth, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.ChevronLeft,
                     contentDescription = stringResource(Res.string.cal_previous),
                 )
             }
-            IconButton(onClick = onNextMonth, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onNextMonth, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.ChevronRight,
                     contentDescription = stringResource(Res.string.cal_next),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsBlocks.kt
@@ -37,6 +37,8 @@ import tajsos.composeapp.generated.resources.archive_delete
 import tajsos.composeapp.generated.resources.cal_settings_add
 import tajsos.composeapp.generated.resources.cal_settings_empty
 import tajsos.composeapp.generated.resources.cal_settings_title
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object CalendarSettingsBlockRegistry {
     private val renderers: Map<String, CalendarSettingsBlockRenderer> =
@@ -60,7 +62,7 @@ private fun renderCalendarSettingsHeader(context: CalendarSettingsContext) {
             style = MaterialTheme.typography.displaySmall,
             color = TajsOSTheme.Text,
         )
-        IconButton(onClick = context.onShowAddDialog, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = context.onShowAddDialog, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
             Icon(
                 Icons.Default.Add,
                 contentDescription = stringResource(Res.string.cal_settings_add),
@@ -75,7 +77,7 @@ private fun renderCalendarSettingsList(context: CalendarSettingsContext) {
     if (context.providers.isEmpty()) {
         EmptyState(message = stringResource(Res.string.cal_settings_empty)) {
             Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
-            Button(onClick = context.onShowAddDialog) {
+            Button(onClick = context.onShowAddDialog, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(stringResource(Res.string.cal_settings_add))
             }
         }
@@ -125,7 +127,7 @@ private fun ProviderRow(
                     )
                 }
             }
-            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.Delete,
                     contentDescription = stringResource(Res.string.archive_delete),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarSettingsScreen.kt
@@ -31,6 +31,8 @@ import tajsos.composeapp.generated.resources.cal_settings_dialog_cancel
 import tajsos.composeapp.generated.resources.cal_settings_dialog_name
 import tajsos.composeapp.generated.resources.cal_settings_dialog_title
 import tajsos.composeapp.generated.resources.cal_settings_dialog_url
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Central calendar settings entry point that collects system state and coordinates layout.
@@ -146,7 +148,7 @@ private fun AddCalendarDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(onClick = onDismiss, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(stringResource(Res.string.cal_settings_dialog_cancel))
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesEditorPane.kt
@@ -59,6 +59,8 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.math.max
 import kotlin.time.Instant
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Primary note viewer/editor pane with metadata and action row.
@@ -196,24 +198,24 @@ fun NotesEditorHeaderActions(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Row {
-            IconButton(onClick = onToggleFavorite, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleFavorite, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     imageVector = if (favorite) Icons.Default.Star else Icons.Default.StarBorder,
                     contentDescription = null,
                     tint = if (favorite) TajsOSTheme.Primary else TajsOSTheme.Text,
                 )
             }
-            IconButton(onClick = onArchive, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onArchive, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.Archive, contentDescription = null, tint = TajsOSTheme.Text)
             }
-            IconButton(onClick = onToggleFocusMode, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleFocusMode, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.CenterFocusStrong,
                     contentDescription = null,
                     tint = if (focusMode) TajsOSTheme.Primary else TajsOSTheme.Text,
                 )
             }
-            IconButton(onClick = onToggleContextPanel, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onToggleContextPanel, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.Info,
                     contentDescription = null,
@@ -222,7 +224,7 @@ fun NotesEditorHeaderActions(
             }
         }
         Box {
-            IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = { menuOpen = true }, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.MoreVert, contentDescription = null)
             }
             DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesRoute.kt
@@ -42,6 +42,8 @@ import com.tajemniktv.tajsos.ui.components.screen.ScreenScaffold
 import com.tajemniktv.tajsos.ui.components.screen.ScreenScrollBehavior
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import kotlinx.coroutines.launch
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Responsive route for the notes workspace.
@@ -215,7 +217,7 @@ fun NotesRoute(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
-                            IconButton(onClick = { mobileInDetail = false }, modifier = Modifier.size(48.dp)) {
+                            IconButton(onClick = { mobileInDetail = false }, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -206,7 +206,7 @@ fun NotesWorkspaceDetail(
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconButton(onClick = onBack, modifier = Modifier.size(48.dp)) {
+                    IconButton(onClick = onBack, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                     }
                     Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailScreen.kt
@@ -114,6 +114,8 @@ import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Detailed view for a single node (Note, Idea, Task, etc.)
@@ -244,7 +246,7 @@ fun NoteDetailScreen(
                 modifier = Modifier.size(18.dp),
             )
         }
-        IconButton(onClick = { showMoreDialog = true }, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = { showMoreDialog = true }, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
             Icon(
                 Icons.Default.MoreVert,
                 contentDescription = null,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileBlocks.kt
@@ -76,6 +76,8 @@ import tajsos.composeapp.generated.resources.profile_select_avatar
 import tajsos.composeapp.generated.resources.profile_time_zone
 import tajsos.composeapp.generated.resources.profile_unsaved
 import tajsos.composeapp.generated.resources.profile_website
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 private val profileBlockRenderers: Map<String, ProfileDashboardBlockRenderer> =
     mapOf(
@@ -390,7 +392,7 @@ private fun renderMedicationsModuleBlock(context: ProfileScreenContext) {
             verticalAlignment = Alignment.CenterVertically,
         ) {
             ModuleTitle(title = stringResource(Res.string.profile_medications))
-            IconButton(onClick = context.onOpenAddMedication, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = context.onOpenAddMedication, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = null,
@@ -589,7 +591,7 @@ private fun MedicationItem(
                     color = TajsOSTheme.Primary,
                 )
             }
-            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp)) {
+            IconButton(onClick = onDelete, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.Delete, contentDescription = "Delete", tint = TajsOSTheme.Error)
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileRoute.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/profile/ProfileRoute.kt
@@ -44,6 +44,8 @@ import tajsos.composeapp.generated.resources.med_save
 import tajsos.composeapp.generated.resources.med_substance
 import tajsos.composeapp.generated.resources.med_take_at
 import tajsos.composeapp.generated.resources.profile_add_med
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Profile feature route that owns state orchestration and delegates visual sections to block
@@ -255,7 +257,7 @@ private fun AddMedicationDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(onClick = onDismiss, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(stringResource(Res.string.common_back))
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/ProjectsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/ProjectsScreen.kt
@@ -45,6 +45,8 @@ import tajsos.composeapp.generated.resources.projects_dialog_new
 import tajsos.composeapp.generated.resources.projects_empty
 import tajsos.composeapp.generated.resources.projects_filter_active
 import tajsos.composeapp.generated.resources.projects_filter_someday
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Central projects entry point that collects system state and coordinates layout.
@@ -163,7 +165,7 @@ fun AddProjectDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(onClick = onDismiss, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(stringResource(Res.string.projects_dialog_cancel))
             }
         },
@@ -197,7 +199,7 @@ fun ProjectListContent(
             message = stringResource(Res.string.projects_empty),
         ) {
             Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
-            Button(onClick = onShowAddDialog) {
+            Button(onClick = onShowAddDialog, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(stringResource(Res.string.projects_create_first))
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
@@ -214,12 +214,12 @@ private fun renderProjectHero(context: ProjectDetailContext) {
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                FilledTonalButton(onClick = context.onStatusClick) {
+                FilledTonalButton(onClick = context.onStatusClick, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(Icons.Default.Tune, null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.project_detail_set_status))
                 }
-                FilledTonalButton(onClick = {}) {
+                FilledTonalButton(onClick = {}, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(Icons.Default.FolderOpen, null)
                     Spacer(Modifier.width(6.dp))
                     Text(context.areaName ?: stringResource(Res.string.detail_unassign))

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/protocols/ProtocolsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/protocols/ProtocolsScreen.kt
@@ -101,6 +101,8 @@ import tajsos.composeapp.generated.resources.protocols_placeholder_search
 import tajsos.composeapp.generated.resources.protocols_session_notes
 import tajsos.composeapp.generated.resources.screen_protocols
 import kotlin.math.max
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 /**
  * Central protocols entry point that collects system state and coordinates layout.
@@ -561,7 +563,7 @@ private fun ProtocolLibraryCard(
                 color = TajsOSTheme.Muted,
             )
             Row(horizontalArrangement = Arrangement.spacedBy(TajsOSTheme.SpacingSm)) {
-                Button(onClick = onRun) {
+                Button(onClick = onRun, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(stringResource(Res.string.protocols_action_run))
                 }
                 AssistChip(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/review/ReviewDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/review/ReviewDashboardBlocks.kt
@@ -61,6 +61,8 @@ import tajsos.composeapp.generated.resources.review_step_plan
 import tajsos.composeapp.generated.resources.review_step_stats
 import tajsos.composeapp.generated.resources.review_step_wins
 import tajsos.composeapp.generated.resources.review_weekly
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object ReviewDashboardBlocks {
     private val renderers: Map<String, ReviewDashboardBlockRenderer> =
@@ -234,7 +236,7 @@ private fun renderReviewFlow(context: ReviewDashboardContext) {
             horizontalArrangement = Arrangement.End,
         ) {
             if (currentStep < steps.size - 1) {
-                Button(onClick = context.onNext) {
+                Button(onClick = context.onNext, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(stringResource(Res.string.review_next))
                 }
             } else {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/search/SearchDashboardBlocks.kt
@@ -84,6 +84,8 @@ import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
 import kotlin.math.max
 import kotlin.math.min
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object SearchDashboardBlocks {
     private val renderers: Map<String, SearchDashboardBlockRenderer> =
@@ -125,7 +127,7 @@ private fun renderSearchInput(context: SearchDashboardContext) {
                     unfocusedContainerColor = TajsOSTheme.Surface,
                 ),
         )
-        IconButton(onClick = context.onToggleFilters, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = context.onToggleFilters, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
             Icon(
                 Icons.Default.FilterList,
                 contentDescription = "Toggle filters",
@@ -531,13 +533,13 @@ private fun SearchResultsHeader(
             )
         }
         Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
-            TextButton(onClick = onToggleFilters) {
+            TextButton(onClick = onToggleFilters, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(
                     "FILTER",
                     style = MaterialTheme.typography.labelSmall,
                 )
             }
-            TextButton(onClick = onToggleSort) {
+            TextButton(onClick = onToggleSort, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(
                     if (sortMode == "relevance") "RELEVANCE" else "UPDATED",
                     style = MaterialTheme.typography.labelSmall,
@@ -759,7 +761,7 @@ private fun SearchResultCard(
 
             Spacer(modifier = Modifier.height(TajsOSTheme.SpacingSm))
             Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                TextButton(onClick = onOpen) {
+                TextButton(onClick = onOpen, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(
                         "OPEN",
                         style = MaterialTheme.typography.labelSmall,
@@ -777,7 +779,7 @@ private fun SearchResultCard(
                         style = MaterialTheme.typography.labelSmall,
                     )
                 }
-                TextButton(onClick = onArchive) {
+                TextButton(onClick = onArchive, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(
                         "ARCHIVE",
                         style = MaterialTheme.typography.labelSmall,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/settings/SettingsDashboardBlocks.kt
@@ -87,6 +87,8 @@ import tajsos.composeapp.generated.resources.settings_window_startup_mode
 import tajsos.composeapp.generated.resources.settings_window_startup_mode_desc
 import tajsos.composeapp.generated.resources.settings_window_startup_restore_last
 import tajsos.composeapp.generated.resources.settings_window_startup_title
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object SettingsDashboardBlocks {
     private val renderers: Map<String, SettingsDashboardBlockRenderer> =
@@ -721,7 +723,7 @@ private fun SettingsMedicationItem(
             color = TajsOSTheme.Muted,
         )
         Spacer(Modifier.height(TajsOSTheme.SpacingSm))
-        TextButton(onClick = onDelete) {
+        TextButton(onClick = onDelete, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
             Text(stringResource(Res.string.med_delete))
         }
     }
@@ -792,7 +794,7 @@ private fun SettingsAddMedicationDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(onClick = onDismiss, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(stringResource(Res.string.common_back))
             }
         },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/study/StudyDashboardBlocks.kt
@@ -34,6 +34,8 @@ import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.education_desc
 import tajsos.composeapp.generated.resources.education_title
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @Composable
 internal fun renderStudyHeaderBlock(context: StudyDashboardContext) {
@@ -268,7 +270,7 @@ internal fun renderLinksGraphBlock(context: StudyDashboardContext) {
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(TajsOSTheme.SpacingSm))
-            Button(onClick = context.onOpenTopicLink) {
+            Button(onClick = context.onOpenTopicLink, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.Link, contentDescription = null)
                 Text("Create Topic Link")
             }
@@ -283,7 +285,7 @@ internal fun renderLinksGraphBlock(context: StudyDashboardContext) {
                 style = MaterialTheme.typography.bodySmall,
             )
             Spacer(Modifier.height(TajsOSTheme.SpacingSm))
-            Button(onClick = context.onOpenPaperLink) {
+            Button(onClick = context.onOpenPaperLink, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Icon(Icons.Default.Link, contentDescription = null)
                 Text("Create Paper Link")
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -111,6 +111,8 @@ import tajsos.composeapp.generated.resources.task_detail_queued
 import tajsos.composeapp.generated.resources.task_detail_snooze
 import tajsos.composeapp.generated.resources.tasks_detail_updated
 import tajsos.composeapp.generated.resources.track_empty
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 private val detailPanelShape = RoundedCornerShape(TajsOSTheme.RadiusMd)
 private val detailPanelBorder = TajsOSTheme.GhostBorder.copy(alpha = 0.22f)
@@ -327,21 +329,21 @@ private fun TaskActionBar(
     ) {
         if (isEditing) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = onCancel) {
+                OutlinedButton(onClick = onCancel, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(stringResource(Res.string.common_cancel))
                 }
-                Button(onClick = onSave) {
+                Button(onClick = onSave, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(stringResource(Res.string.common_save))
                 }
             }
         } else {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = onToggleEdit) {
+                OutlinedButton(onClick = onToggleEdit, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(Icons.Default.Edit, contentDescription = null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.common_edit))
                 }
-                OutlinedButton(onClick = onSnooze) {
+                OutlinedButton(onClick = onSnooze, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(Icons.Default.AccessTime, contentDescription = null)
                     Spacer(Modifier.width(6.dp))
                     Text(stringResource(Res.string.task_detail_snooze))
@@ -478,7 +480,7 @@ private fun renderTaskSubtasks(context: TaskDetailContext) {
                 }
             }
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = context.onSplitIntoSubtasks) {
+                OutlinedButton(onClick = context.onSplitIntoSubtasks, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(stringResource(Res.string.detail_split_subtasks))
                 }
             }
@@ -620,7 +622,7 @@ private fun SubtaskRow(
                 color = tint,
             )
             if (subtask.source == TaskSubtaskSource.InlineChecklist && onRemove != null) {
-                IconButton(onClick = onRemove, modifier = Modifier.size(48.dp)) {
+                IconButton(onClick = onRemove, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = null,
@@ -704,7 +706,7 @@ private fun AttachmentRow(
                 )
             }
         }
-        IconButton(onClick = onRemove, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = onRemove, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
             Icon(Icons.Default.Delete, contentDescription = null, tint = TajsOSTheme.Muted)
         }
     }
@@ -1130,7 +1132,7 @@ private fun TaskEditablePropertyRow(
             )
         }
         Box {
-            TextButton(onClick = { expanded = true }) {
+            TextButton(onClick = { expanded = true }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(selected)
             }
             DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesDashboardBlocks.kt
@@ -32,6 +32,8 @@ import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object TemplatesDashboardBlocks {
     private val renderers: Map<String, TemplatesDashboardBlockRenderer> =
@@ -48,7 +50,7 @@ private fun renderTemplatesList(context: TemplatesDashboardContext) {
     if (templates.isEmpty()) {
         EmptyState(message = stringResource(Res.string.templates_empty)) {
             Spacer(modifier = Modifier.height(TajsOSTheme.SpacingMd))
-            Button(onClick = context.onShowAddDialog) {
+            Button(onClick = context.onShowAddDialog, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(stringResource(Res.string.templates_add_desc))
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/templates/TemplatesScreen.kt
@@ -48,6 +48,8 @@ import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_project
 import tajsos.composeapp.generated.resources.type_record
 import tajsos.composeapp.generated.resources.type_task
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -70,7 +72,7 @@ fun TemplatesScreen(
         )
 
     val actions: @Composable RowScope.() -> Unit = {
-        IconButton(onClick = { showAddDialog = true }, modifier = Modifier.size(48.dp)) {
+        IconButton(onClick = { showAddDialog = true }, modifier = Modifier.size(48.dp).pointerHoverIcon(PointerIcon.Hand)) {
             Icon(
                 Icons.Default.Add,
                 contentDescription = stringResource(Res.string.templates_add_desc),
@@ -142,7 +144,7 @@ fun TemplatesScreen(
                 ) { Text(stringResource(Res.string.templates_dialog_create)) }
             },
             dismissButton = {
-                TextButton(onClick = { showAddDialog = false }) {
+                TextButton(onClick = { showAddDialog = false }, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                     Text(
                         stringResource(
                             Res.string.templates_dialog_cancel,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/timearchitecture/TimeArchitectureDashboardBlocks.kt
@@ -62,6 +62,8 @@ import tajsos.composeapp.generated.resources.time_architecture_temporal_anchors
 import tajsos.composeapp.generated.resources.time_architecture_title
 import tajsos.composeapp.generated.resources.time_architecture_weekly_alignment
 import tajsos.composeapp.generated.resources.time_architecture_weekly_detail
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 
 object TimeArchitectureDashboardBlocks {
     private val renderers: Map<String, TimeArchitectureDashboardBlockRenderer> =
@@ -347,7 +349,7 @@ private fun TimeArchitectureCadenceCard(
                     ),
                 status = "Pending",
             )
-            Button(onClick = onRunMonthlyReset) {
+            Button(onClick = onRunMonthlyReset, modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)) {
                 Text(stringResource(Res.string.time_architecture_run_monthly_reset))
             }
         }


### PR DESCRIPTION
This PR improves the user experience on desktop/web targets by appending `.pointerHoverIcon(PointerIcon.Hand)` to interactive components (such as `Button`, `IconButton`, `TextButton`, and `Modifier.clickable`). 

Previously, Compose Multiplatform for desktop did not show a hand cursor by default when hovering over these basic clickable components, which made them harder to discover as interactive elements. This change addresses that consistently across various screens and components.

---
*PR created automatically by Jules for task [12260426428128613531](https://jules.google.com/task/12260426428128613531) started by @tajemniktv*

## Summary by Sourcery

Enhance desktop/web UX by consistently showing a hand cursor over interactive controls across the app.

New Features:
- Add pointer hover hand cursor to buttons, icon buttons, text buttons, and clickable controls on desktop/web to make interactivity more discoverable.

Enhancements:
- Apply pointerHoverIcon(PointerIcon.Hand) across task, notes, search, areas, calendar, decisions, tasks, profiles, projects, protocols, review, templates, study, time architecture, and shared layout components for consistent hover behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

