### PR TITLE
perf: replace groupBy with distinctBy to avoid unnecessary allocations

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -1734,11 +1734,14 @@ fun calculateCapacitySnapshot(
                 (maintenance.overdue.size * 4) +
                 (overdueCount * 5)
         ).coerceIn(0, 100)
+    /**
+     * Performance: distinctBy is used instead of groupBy to avoid unnecessary map allocations.
+     */
     val fragmentationScore =
         (
-                activeTasks.groupBy { it.node.projectId }.size *
+                activeTasks.distinctBy { it.node.projectId }.size *
                         7 +
-                        activeTasks.groupBy { it.node.areaId }.size *
+                        activeTasks.distinctBy { it.node.areaId }.size *
                         4
         ).coerceIn(0, 100)
 
@@ -1761,8 +1764,11 @@ fun calculateCapacitySnapshot(
         nodes.count { it.node.status == "done" && (it.node.completedAt ?: 0L) >= now - weekMs }
     val unrealisticWeekSignal =
         if (weeklyCreatedActive > weeklyDone * 2 + 5) "THIS WEEK IS UNREALISTIC // INTAKE OUTPACES EXECUTION" else null
+    /**
+     * Performance: distinctBy is used instead of groupBy to avoid unnecessary map allocations.
+     */
     val tooManyActiveFrontsIndicator =
-        if (activeTasks.groupBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
+        if (activeTasks.distinctBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
     val attentionFragmentedIndicator =
         if (fragmentationScore >= 55) "ATTENTION IS TOO FRAGMENTED" else null
     val weeklyStructuralOverloadWarning =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -443,7 +443,10 @@ suspend fun buildDashboardUIState(
     val areaHealthMetrics = areaSnapshot.areas.associateBy { it.areaId }
 
     val loadScore = (activeTasks.size * 2) + (openLoops.size * 3) + (overdue.size * 5)
-    val fragmentation = activeTasks.groupBy { it.node.projectId }.size * 5
+    /**
+     * Performance: distinctBy is used instead of groupBy to avoid unnecessary map allocations.
+     */
+    val fragmentation = activeTasks.distinctBy { it.node.projectId }.size * 5
     val capWarning =
         when
             {


### PR DESCRIPTION
Replaces instances of `groupBy { ... }.size` with `distinctBy { ... }.size` in `MainStateAssemblers.kt` and `MainSnapshotCalculators.kt`. This eliminates unnecessary allocations of `ArrayList`s and intermediate HashMaps, improving calculation performance when evaluating active task fragmentation. Adds KDocs to document the optimization.

---
*PR created automatically by Jules for task [541290212202168419](https://jules.google.com/task/541290212202168419) started by @tajemniktv*

## Summary by Sourcery

Optimize main dashboard capacity and fragmentation calculations by using a more efficient way to count distinct projects and areas.

Enhancements:
- Replace group-based distinct counting with distinctBy-based counting in main snapshot and state assemblers to reduce intermediate allocations and improve performance.
- Document the performance rationale for the distinct counting approach with KDoc comments near the affected calculations.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

