### PR TITLE
fix(website): disable Starlight default 404 route

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,8 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      // Disable Starlight's default 404 route because a custom src/pages/404.astro exists
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
This PR adds `disable404Route: true` to the Starlight configuration in `astro.config.mjs`.

Since the website implements its own custom `404.astro` at `src/pages/404.astro`, Astro's router correctly identifies that a static route collision would occur in following versions of Astro when it tries to render the default `404.astro` from the `starlight` component tree. Disabling the default Starlight 404 route effectively removes the conflict.

---
*PR created automatically by Jules for task [2303848044221203587](https://jules.google.com/task/2303848044221203587) started by @tajemniktv*

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Build:
- Update Astro/Starlight configuration to turn off the default 404 route to avoid conflicts with the custom 404 page.