### PR TITLE
fix(navigation): replace non-null assertion with safe call

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -239,7 +239,7 @@ fun App(
                                 val canPop = navController.previousBackStackEntry != null
                                 if (!canPop) return@mouseButtons
                                 if (isForwardNavigable(currentRoute)) {
-                                    mouseForwardRoutes.addLast(currentRoute!!)
+                                    currentRoute?.let { mouseForwardRoutes.addLast(it) }
                                 }
                                 navController.popBackStack()
                             },


### PR DESCRIPTION
Replaced an unsafe non-null assertion (`!!`) with a safe call (`?.let`) on `currentRoute` inside the `AppShell` mouse navigation logic in `App.kt`. This improves the reliability of the application by preventing a potential `NullPointerException` crash during forward navigation, making the app more fault-tolerant.

---
*PR created automatically by Jules for task [993903400976066426](https://jules.google.com/task/993903400976066426) started by @tajemniktv*

## Summary by Sourcery

Bug Fixes:
- Guard forward navigation route tracking with a null-safe check instead of a non-null assertion to avoid crashes when the current route is null.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

