### PR TITLE
docs: add missing KDoc to platform-specific code and server entry points

### DIFF
--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -15,6 +15,12 @@ import io.ktor.server.auth.*
 
 import kotlinx.serialization.json.Json
 
+/**
+ * Application entry point.
+ *
+ * Configures and starts the embedded Netty server. The server listens on the host specified by the
+ * `SERVER_HOST` environment variable (defaulting to 127.0.0.1) and the port defined by `SERVER_PORT`.
+ */
 fun main() {
     val host = System.getenv("SERVER_HOST") ?: "127.0.0.1"
     embeddedServer(Netty, port = SERVER_PORT, host = host, module = Application::module)

--- a/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/Platform.android.kt
@@ -6,6 +6,11 @@ package com.tajemniktv.tajsos
 
 import android.os.Build
 
+/**
+ * Android-specific implementation of the generic [Platform] interface.
+ *
+ * Provides runtime information specific to Android environments, exposing the device's SDK version.
+ */
 class AndroidPlatform : Platform {
     override val name: String = "Android ${Build.VERSION.SDK_INT}"
 }

--- a/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
+++ b/shared/src/androidMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
@@ -7,6 +7,14 @@ package com.tajemniktv.tajsos.data
 import android.content.Context
 import androidx.room.Room
 
+/**
+ * Instantiates the Room AppDatabase for the Android target.
+ *
+ * Uses the standard Android Context to resolve the application's internal database directory.
+ * Configures the database to fall back to destructive migration on schema changes.
+ *
+ * @param context The Android Application Context.
+ */
 fun createDatabase(context: Context): AppDatabase {
     val dbFile = context.getDatabasePath("tajsos.db")
     return Room

--- a/shared/src/iosMain/kotlin/com/tajemniktv/tajsos/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/com/tajemniktv/tajsos/Platform.ios.kt
@@ -6,6 +6,11 @@ package com.tajemniktv.tajsos
 
 import platform.UIKit.UIDevice
 
+/**
+ * iOS-specific implementation of the generic [Platform] interface.
+ *
+ * Provides runtime information specific to iOS environments, exposing the device's system name and version.
+ */
 class IOSPlatform: Platform {
     override val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
 }

--- a/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/Platform.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/Platform.jvm.kt
@@ -4,6 +4,11 @@
 
 package com.tajemniktv.tajsos
 
+/**
+ * JVM-specific implementation of the generic [Platform] interface.
+ *
+ * Provides runtime information specific to desktop/JVM environments, exposing the Java version.
+ */
 class JVMPlatform: Platform {
     override val name: String = "Java ${System.getProperty("java.version")}"
 }

--- a/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
+++ b/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/data/Database.kt
@@ -9,6 +9,13 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import java.io.File
 import com.tajemniktv.tajsos.utils.AppDirs
 
+/**
+ * Instantiates the Room AppDatabase for the JVM target.
+ *
+ * It resolves the target database file location using [AppDirs.getAppDataDir] and applies
+ * the BundledSQLiteDriver to ensure consistent SQLite features are available without relying
+ * on system-level SQLite installations.
+ */
 fun createDatabase(): AppDatabase {
     val dbFile = File(AppDirs.getAppDataDir(), "tajsos.db")
     return Room

--- a/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/utils/AppDirs.kt
+++ b/shared/src/jvmMain/kotlin/com/tajemniktv/tajsos/utils/AppDirs.kt
@@ -6,7 +6,21 @@ package com.tajemniktv.tajsos.utils
 
 import java.io.File
 
+/**
+ * Provides access to standard platform-specific directories for storing application data.
+ *
+ * Used primarily for locating database storage and configuration files outside the project working
+ * directory to ensure user data persists across updates.
+ */
 object AppDirs {
+    /**
+     * Resolves and creates (if absent) the canonical TajsOS application data directory based on the host OS.
+     *
+     * Implementations logic:
+     * - Windows: Uses %APPDATA% or defaults to `AppData/Roaming`.
+     * - macOS: Uses `~/Library/Application Support`.
+     * - Linux/Other: Follows XDG Base Directory specs (`$XDG_DATA_HOME` or defaults to `~/.local/share`).
+     */
     fun getAppDataDir(): File {
         val os = System.getProperty("os.name").lowercase()
         val userHome = System.getProperty("user.home")

--- a/shared/src/wasmJsMain/kotlin/com/tajemniktv/tajsos/Platform.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/com/tajemniktv/tajsos/Platform.wasmJs.kt
@@ -1,5 +1,10 @@
 ﻿package com.tajemniktv.tajsos
 
+/**
+ * WebAssembly-specific implementation of the generic [Platform] interface.
+ *
+ * Provides runtime information specific to Wasm browser environments.
+ */
 class WasmPlatform: Platform {
     override val name: String = "Web with Kotlin/Wasm"
 }


### PR DESCRIPTION
Added comprehensive KDoc to various platform-specific implementations (`Platform.*.kt`), database initializers (`Database.kt`), utility classes (`AppDirs.kt`), and the application entry point (`Application.kt`) across server, Android, iOS, JVM, and WasmJS modules. This clarifies platform-specific behaviors, environmental fallbacks, and dependencies, reducing onboarding friction and improving maintainability.

---
*PR created automatically by Jules for task [13955991675769772561](https://jules.google.com/task/13955991675769772561) started by @tajemniktv*

## Summary by Sourcery

Document platform-specific utilities and entry points across Android, iOS, JVM, WasmJS, and server modules.

Documentation:
- Add KDoc for platform-specific Platform implementations on Android, iOS, JVM, and WasmJS targets.
- Add KDoc for Android and JVM database initialization helpers, including storage locations and migration behavior.
- Add KDoc for JVM AppDirs utility to describe OS-specific app data directory resolution.
- Add KDoc for the server Application entry point to clarify host and port configuration via environment variables.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

