### PR TITLE
perf: Optimize map sizes using groupingBy and eachCount

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -43,6 +43,9 @@ import kotlin.time.Instant
  * @param tracks A list of recorded [TrackEntryEntity] records detailing mood, energy, and sleep.
  * @param projects A curated list of nodes strictly identified as "project" entities.
  * @return An analytical [InsightsData] snapshot summarizing the user's historical performance.
+ *
+ * Performance note: This function uses `groupingBy { ... }.eachCount()` for grouping frequency counts,
+ * avoiding intermediate Map allocations that occur with `groupBy { ... }.mapValues { it.value.size }`.
  */
 fun calculateInsights(
     nodes: List<NodeWithPin>,
@@ -128,13 +131,13 @@ fun calculateInsights(
     val completionsByArea =
         recentCompletions
             .mapNotNull { item -> item.node.areaId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .groupingBy { it.first }
+            .eachCount()
     val completionsByProject =
         recentCompletions
             .mapNotNull { item -> item.node.projectId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .groupingBy { it.first }
+            .eachCount()
 
     val inboxGrowth = recentNodes.count { it.node.inboxState }
     val archivedCount =
@@ -175,23 +178,23 @@ fun calculateInsights(
     // Correlating track entries with activity
     val dailyCompletions =
         recentCompletions
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.completedAt ?: 0)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyCaptures =
         recentNodes
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.createdAt)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyFocus =
         recentSessions


### PR DESCRIPTION
This PR implements a standard, low-risk performance optimization in Kotlin by replacing `.groupBy { ... }.mapValues { it.value.size }` with `.groupingBy { ... }.eachCount()` in `MainSnapshotCalculators.kt`. This avoids generating intermediate maps and lists, directly accumulating grouped counts, saving memory allocation. It also includes documentation on the optimization within the `calculateInsights` KDoc.

---
*PR created automatically by Jules for task [12950239939712913819](https://jules.google.com/task/12950239939712913819) started by @tajemniktv*

## Summary by Sourcery

Optimize insight calculation performance by using more efficient frequency counting for grouped data.

Enhancements:
- Replace groupBy/mapValues patterns with groupingBy/eachCount for completion and capture frequency counts.
- Document the performance rationale for using groupingBy/eachCount in the calculateInsights KDoc.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

