### PR TITLE
fix(website): disable starlight 404 route to avoid collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,6 +20,8 @@ export default defineConfig({
     starlight({
       title: "Docs",
       description: "TajsOS Documentation",
+      // Disabling default 404 route because a custom src/pages/404.astro exists
+      disable404Route: true,
 
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",


### PR DESCRIPTION
Fixes a router collision warning between Starlight's default 404 page and the custom `src/pages/404.astro` by setting `disable404Route: true` in the configuration.

---
*PR created automatically by Jules for task [8343771008404695855](https://jules.google.com/task/8343771008404695855) started by @tajemniktv*

## Summary by Sourcery

Bug Fixes:
- Resolve router collision between Starlight’s default 404 page and the existing custom 404.astro page in the docs site configuration.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

