### PR TITLE
perf(shared): optimize aggregations and remove non-null assertions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -239,7 +239,7 @@ fun App(
                                 val canPop = navController.previousBackStackEntry != null
                                 if (!canPop) return@mouseButtons
                                 if (isForwardNavigable(currentRoute)) {
-                                    mouseForwardRoutes.addLast(currentRoute!!)
+                                    currentRoute?.let { mouseForwardRoutes.addLast(it) }
                                 }
                                 navController.popBackStack()
                             },

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -128,13 +128,11 @@ fun calculateInsights(
     val completionsByArea =
         recentCompletions
             .mapNotNull { item -> item.node.areaId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .groupingBy { it.first }.eachCount()
     val completionsByProject =
         recentCompletions
             .mapNotNull { item -> item.node.projectId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .groupingBy { it.first }.eachCount()
 
     val inboxGrowth = recentNodes.count { it.node.inboxState }
     val archivedCount =
@@ -175,23 +173,23 @@ fun calculateInsights(
     // Correlating track entries with activity
     val dailyCompletions =
         recentCompletions
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.completedAt ?: 0)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyCaptures =
         recentNodes
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.createdAt)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyFocus =
         recentSessions


### PR DESCRIPTION
This PR identifies and implements two reliability and performance improvements:

1. **Remove Unsafe Access**: In `App.kt`, an unnecessary and potentially unsafe non-null assertion `!!` when appending `currentRoute` to the `mouseForwardRoutes` tracking deque was replaced with a null-safe `?.let { ... }` block, improving robustness and preventing a potential `NullPointerException`.
2. **Optimize Aggregations**: In `MainSnapshotCalculators.kt`, inefficient chained calls to `.groupBy { ... }.mapValues { it.value.size }` for calculating group sizes were replaced with `.groupingBy { ... }.eachCount()`. This eliminates the intermediate map of lists and map of counts, reducing allocation pressure and improving execution efficiency during complex state assembly.

These fixes conform to safe Kotlin coding practices and increase the overall predictability of the application state processing.

---
*PR created automatically by Jules for task [8137133671821003085](https://jules.google.com/task/8137133671821003085) started by @tajemniktv*

## Summary by Sourcery

Improve snapshot aggregation performance and navigation safety.

Enhancements:
- Optimize completion and capture aggregations by replacing groupBy/mapValues chains with groupingBy/eachCount to reduce allocations and improve efficiency.
- Make mouse forward navigation tracking null-safe by avoiding non-null assertions on the current route.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

