### PR TITLE
test: Add dashboard UI state edge case tests

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblersDashboardEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblersDashboardEdgeTest.kt
@@ -1,0 +1,135 @@
+package com.tajemniktv.tajsos.ui.main.calculators
+
+import com.tajemniktv.tajsos.data.*
+import com.tajemniktv.tajsos.ui.DashboardUIState
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class MainStateAssemblersDashboardEdgeTest {
+
+    private fun createTestNodeWithPin(
+        node: NodeEntity
+    ): NodeWithPin {
+        return NodeWithPin(
+            node = node,
+            pin = null,
+            tags = emptyList()
+        )
+    }
+
+    private fun defaultNode(id: Long, type: String = "task", status: String = "active") = NodeEntity(
+        id = id,
+        title = "Test Node $id",
+        content = "",
+        type = type,
+        status = status,
+        inboxState = false,
+        reminderAt = null,
+        updatedAt = 0L,
+        createdAt = 0L
+    )
+
+    private fun createRepo(): AppRepository {
+        return AppRepository(
+            nodeDao = FakeNodeDao(),
+            focusSessionDao = FakeFocusSessionDao(),
+            trackDao = FakeTrackDao(),
+            relationDao = FakeRelationDao(),
+            tagDao = FakeTagDao(),
+            eventLogDao = FakeEventLogDao(),
+            attachmentDao = FakeAttachmentDao(),
+            templateDao = FakeTemplateDao(),
+            protocolDao = FakeProtocolDao(),
+            userDao = FakeUserDao(),
+            modeDao = FakeModeDao(),
+            medicationDao = FakeMedicationDao(),
+            decisionDao = FakeDecisionDao(),
+            nodeSnapshotDao = FakeNodeSnapshotDao(),
+            reviewDao = FakeReviewDao(),
+            calendarProviderDao = FakeCalendarProviderDao(),
+            calendarEventDao = FakeCalendarEventDao()
+        )
+    }
+
+    private suspend fun assembleState(
+        repo: AppRepository,
+        nodes: List<NodeWithPin>,
+        mode: ModeEntity? = null
+    ): DashboardUIState {
+        val modesList = mode?.let { listOf(it) } ?: emptyList()
+        return buildDashboardUIState(
+            repository = repo,
+            nodes = nodes,
+            modesList = modesList,
+            activeId = mode?.id,
+            areasList = emptyList(),
+            packs = PackRegistry(emptySet(), emptySet())
+        )
+    }
+
+    @Test
+    fun `buildDashboardUIState identifies vaults and incubator correctly`() = runTest {
+        val repo = createRepo()
+
+        val readLaterNode = createTestNodeWithPin(defaultNode(1, "note").copy(noteType = "read_later"))
+        val quoteNode = createTestNodeWithPin(defaultNode(2, "note").copy(noteType = "quote"))
+        val ideaNode = createTestNodeWithPin(defaultNode(3, "idea").copy(projectId = null)) // No project
+        val ideaWithProject = createTestNodeWithPin(defaultNode(4, "idea").copy(projectId = 100L)) // Excluded from incubator
+        val inactiveReadLater = createTestNodeWithPin(defaultNode(5, "note", "archived").copy(noteType = "read_later"))
+
+        val nodes = listOf(readLaterNode, quoteNode, ideaNode, ideaWithProject, inactiveReadLater)
+        val state = assembleState(repo, nodes)
+
+        assertEquals(1, state.readLaterVault.size)
+        assertEquals(1L, state.readLaterVault[0].node.id)
+
+        assertEquals(1, state.quoteVault.size)
+        assertEquals(2L, state.quoteVault[0].node.id)
+
+        assertEquals(1, state.ideaIncubator.size)
+        assertEquals(3L, state.ideaIncubator[0].node.id)
+    }
+
+    @Test
+    fun `buildDashboardUIState surfaces forgotten wisdom correctly`() = runTest {
+        val repo = createRepo()
+        val now = kotlin.time.Clock.System.now().toEpochMilliseconds()
+        val staleTime = now - (31L * 24 * 60 * 60 * 1000L) // 31 days ago
+
+        val evergreenNote = createTestNodeWithPin(defaultNode(1, "note").copy(noteType = "evergreen", updatedAt = now)) // Included despite recent update
+        val staleIdea = createTestNodeWithPin(defaultNode(2, "idea").copy(updatedAt = staleTime)) // Included due to stale update
+        val recentNote = createTestNodeWithPin(defaultNode(3, "note").copy(updatedAt = now)) // Excluded (not evergreen, not stale)
+        val inactiveEvergreen = createTestNodeWithPin(defaultNode(4, "note", "archived").copy(noteType = "evergreen")) // Excluded (not active)
+
+        val nodes = listOf(evergreenNote, staleIdea, recentNote, inactiveEvergreen)
+
+        // forgottenWisdom uses firstOrNull after shuffling, so we just check if it finds ONE of the valid ones
+        val state = assembleState(repo, nodes)
+
+        assertNotNull(state.forgottenWisdom)
+        val id = state.forgottenWisdom!!.node.id
+        assertTrue(id == 1L || id == 2L, "Expected ID to be 1 or 2, was $id")
+    }
+
+    @Test
+    fun `buildDashboardUIState surfaces deserves attention correctly`() = runTest {
+        val repo = createRepo()
+        val now = kotlin.time.Clock.System.now().toEpochMilliseconds()
+        val staleTime = now - (8L * 24 * 60 * 60 * 1000L) // 8 days ago
+
+        val neglectedTask = createTestNodeWithPin(defaultNode(1, "task").copy(isPinned = false, dueAt = null, updatedAt = staleTime))
+        val pinnedNeglectedTask = createTestNodeWithPin(defaultNode(2, "task").copy(isPinned = true, dueAt = null, updatedAt = staleTime)) // Excluded (pinned)
+        val dueNeglectedTask = createTestNodeWithPin(defaultNode(3, "task").copy(isPinned = false, dueAt = now + 10000L, updatedAt = staleTime)) // Excluded (has due date)
+        val recentTask = createTestNodeWithPin(defaultNode(4, "task").copy(isPinned = false, dueAt = null, updatedAt = now)) // Excluded (updated recently)
+        val inactiveNeglectedTask = createTestNodeWithPin(defaultNode(5, "task", "archived").copy(isPinned = false, dueAt = null, updatedAt = staleTime)) // Excluded (inactive)
+
+        val nodes = listOf(neglectedTask, pinnedNeglectedTask, dueNeglectedTask, recentTask, inactiveNeglectedTask)
+        val state = assembleState(repo, nodes)
+
+        assertEquals(1, state.deservesAttention.size)
+        assertEquals(1L, state.deservesAttention[0].node.id)
+    }
+}


### PR DESCRIPTION
This PR improves test coverage and robustness by adding tests specifically addressing edge cases in `buildDashboardUIState`. 

The new test class `MainStateAssemblersDashboardEdgeTest` verifies:
- Identifying vaults (`readLaterVault`, `quoteVault`) and the `ideaIncubator`.
- Surfacing `forgottenWisdom` based on evergreen notes and staleness.
- Surfacing `deservesAttention` based on unpinned neglected tasks without due dates.

---
*PR created automatically by Jules for task [7903455296975780916](https://jules.google.com/task/7903455296975780916) started by @tajemniktv*

## Summary by Sourcery

Add targeted tests to validate dashboard UI state behavior for edge cases.

Tests:
- Add tests ensuring dashboard vaults and idea incubator are populated correctly from nodes.
- Add tests verifying forgotten wisdom selection from evergreen or stale items.
- Add tests confirming only unpinned, undated, stale tasks are surfaced as deserving attention.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

