### PR TITLE
perf: replace exception-based enum parsing with safe lookups

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailBlocks.kt
@@ -941,10 +941,10 @@ private fun RenderTaskMetadataProperties(
                 TaskPropertyOption(TaskDuePreset.InSevenDays.name, "In 7 days"),
             ),
         onSelect = { value ->
-            try {
-                context.onDuePresetChange(TaskDuePreset.valueOf(value))
-            } catch (e: IllegalArgumentException) {
-                // Ignore invalid values to prevent crashes
+            // Safe enum lookup to avoid exception overhead
+            val preset = TaskDuePreset.entries.find { it.name == value }
+            if (preset != null) {
+                context.onDuePresetChange(preset)
             }
         },
     )

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -134,11 +134,8 @@ class PreferencesRepository(
         safeData
             .map { preferences ->
             val modeStr = preferences[PreferencesKeys.SIDEBAR_MODE]
-            try {
-                if (modeStr != null) SidebarMode.valueOf(modeStr) else SidebarMode.EXPANDED
-            } catch (_: IllegalArgumentException) {
-                SidebarMode.EXPANDED
-            }
+            // Safe enum lookup to avoid exception overhead
+            SidebarMode.entries.find { it.name == modeStr } ?: SidebarMode.EXPANDED
         }
 
     /**
@@ -173,15 +170,8 @@ class PreferencesRepository(
         safeData
             .map { preferences ->
             val rawValue = preferences[PreferencesKeys.DESKTOP_WINDOW_STARTUP_MODE]
-            try {
-                if (rawValue != null) {
-                    DesktopWindowStartupMode.valueOf(rawValue)
-                } else {
-                    DesktopWindowStartupMode.RESTORE_LAST
-                }
-            } catch (_: IllegalArgumentException) {
-                DesktopWindowStartupMode.RESTORE_LAST
-            }
+            // Safe enum lookup to avoid exception overhead
+            DesktopWindowStartupMode.entries.find { it.name == rawValue } ?: DesktopWindowStartupMode.RESTORE_LAST
         }
 
     val enabledPacks: Flow<PackRegistry> =


### PR DESCRIPTION
Replaced `Enum.valueOf(str)` wrapped in `try/catch` with `.entries.find { it.name == str }` for `SidebarMode`, `DesktopWindowStartupMode`, and `TaskDuePreset`. This avoids the expensive overhead of generating stack traces for known fallback paths while maintaining the identical behavior and default values.

---
*PR created automatically by Jules for task [6401804014555111767](https://jules.google.com/task/6401804014555111767) started by @tajemniktv*

## Summary by Sourcery

Optimize enum parsing in preferences and task detail UI by replacing exception-based lookups with safe enum entry searches.

Enhancements:
- Replace exception-driven enum parsing for sidebar and desktop window startup preferences with direct enum entry lookups while preserving defaults.
- Update task due preset selection to use safe enum entry resolution instead of relying on IllegalArgumentException for invalid values.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

