### PR TITLE
docs: add KDoc for DomainMatcher class and its properties

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueries.kt
@@ -256,6 +256,11 @@ object DomainLensQueries {
     /**
      * Configuration class to group matching heuristics. This avoids having functions with many string/collection
      * arguments, which can trigger code health violations.
+     *
+     * @property maintenanceTypes The set of explicitly recognized maintenance type strings (e.g., "bill", "subscription") that imply this domain.
+     * @property tagMarkers The set of specific tags (e.g., "finance", "budget") that imply this domain.
+     * @property titleKeywords The list of keywords to look for within the node's title or content.
+     * @property validNoteTypes An optional set of specific note types (e.g., "reflection", "journal") that implicitly associate a note with this domain.
      */
     private class DomainMatcher(
         val maintenanceTypes: Set<String>,


### PR DESCRIPTION
Added KDoc to the private DomainMatcher class in DomainLensQueries to document the intent and usage of its primary constructor parameters (maintenanceTypes, tagMarkers, titleKeywords, validNoteTypes). This clarifies the heuristic rules used to implicitly map items into specific domains without requiring explicit database associations.

---
*PR created automatically by Jules for task [4996514112180729251](https://jules.google.com/task/4996514112180729251) started by @tajemniktv*

## Summary by Sourcery

Documentation:
- Add KDoc descriptions for DomainMatcher constructor properties to clarify domain inference heuristics.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

