### PR TITLE
fix(website): disable Starlight default 404 route to prevent build collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -19,6 +19,8 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "Docs",
+      // Disabling default 404 route because a custom src/pages/404.astro exists
+      disable404Route: true,
       description: "TajsOS Documentation",
 
       components: {


### PR DESCRIPTION
This PR resolves a build warning in the Astro website project caused by a collision on the `/404` route.

Starlight injects its own default `/404` static route. Because the project already defines a custom 404 page at `src/pages/404.astro`, Astro emits a hard collision warning during the build process. 

This PR sets `disable404Route: true` in the `starlight` integration configuration within `website/astro.config.mjs` to prevent Starlight from injecting the default route, allowing the custom 404 page to be used properly. An explanatory inline comment is also added.

---
*PR created automatically by Jules for task [17624954833010804107](https://jules.google.com/task/17624954833010804107) started by @tajemniktv*

## Summary by Sourcery

Build:
- Update Astro Starlight integration config to turn off the autogenerated /404 route in favor of the project’s custom 404 page.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

