### PR TITLE
test: improve coverage for InetAddressParser and FilterHelper

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserNegativeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserNegativeTest.kt
@@ -62,5 +62,7 @@ class InetAddressParserNegativeTest {
         assertNull(parseIpAddress("1:2:3::4:5:6:7:8:9"), "Should reject left and right parsed out of bounds combined")
         assertNull(parseIpAddress("1:2:3:4::5:6:7:8"), "Should reject when leftParsed + rightParsed > 7")
 
+        assertNull(parseIpAddress("1::+2"), "Should reject positive values with plus sign in abbreviated form")
+        assertNull(parseIpAddress("1::-2"), "Should reject negative values in abbreviated form")
     }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperEdgeTest.kt
@@ -271,4 +271,27 @@ class FilterHelperEdgeTest {
         )
         assertEquals(6, resultInvalid.size)
     }
+
+    @Test
+    fun testFilterLinkedToId() {
+        val node1 = buildTestNode(1, "Node 1")
+        val node2 = buildTestNode(2, "Node 2")
+        val node3 = buildTestNode(3, "Node 3")
+
+        val relation1 = com.tajemniktv.tajsos.data.RelationEntity(id = 1, fromNodeId = 1, toNodeId = 2, relationType = "blocks", createdAt = 0)
+        val relation2 = com.tajemniktv.tajsos.data.RelationEntity(id = 2, fromNodeId = 3, toNodeId = 1, relationType = "relates", createdAt = 0)
+
+        val result1 = FilterHelper.filterAndSortNodes(
+            nodes = listOf(node1, node2, node3),
+            query = "", type = null, status = null, projectId = null, areaId = null, linkedToId = 1L,
+            maxMins = null, energy = null, friction = null, locationContext = null, energyContext = null, deviceContext = null, socialContext = null,
+            timeWindowContext = null, timeHorizon = null, relations = listOf(relation1, relation2), sortMode = "updated"
+        )
+        // Node 1 is linked to 2 and 3. So when searching for linkedToId = 1:
+        // Node 2 should match because relation1.fromNodeId = 1, relation1.toNodeId = 2
+        // Node 3 should match because relation2.fromNodeId = 3, relation2.toNodeId = 1
+        assertEquals(2, result1.size)
+        assertEquals(setOf(2L, 3L), result1.map { it.node.id }.toSet())
+    }
+
 }


### PR DESCRIPTION
Improves test coverage for `InetAddressParser.kt` and `FilterHelper.kt` logic.

Changes:
- Added `InetAddressParserNegativeTest` cases to explicitly verify that positive (e.g., `+2`) and negative (e.g., `-2`) inputs are safely rejected when parsing abbreviated IPv6 segments. 
- Added a `testFilterLinkedToId` method to `FilterHelperEdgeTest` to explicitly verify bidirectional edge cases when searching for relationships attached to a specific `linkedToId`.

---
*PR created automatically by Jules for task [15090266558911691572](https://jules.google.com/task/15090266558911691572) started by @tajemniktv*

## Summary by Sourcery

Expand test coverage for edge-case handling in node filtering and IPv6 address parsing.

Tests:
- Add FilterHelperEdgeTest coverage for nodes linked via relations to a specific linkedToId, including bidirectional links.
- Extend InetAddressParserNegativeTest to verify that abbreviated IPv6 segments reject signed positive and negative values.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

