### PR TITLE
perf: Optimize map sizes using groupingBy and eachCount

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -35,13 +35,18 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Instant
 
 /**
- * Aggregates analytical tracking data to compute a comprehensive [InsightsData] payload
- * detailing focus hours, completion rates, backlog pressure, and identified chaotic patterns.
+ * Calculates insights and metrics from the user's active graph, history, and completions.
  *
- * @param nodes The complete list of active nodes in the system.
- * @param sessions A list of recorded [FocusSessionEntity] records tracking deep work time.
- * @param tracks A list of recorded [TrackEntryEntity] records detailing mood, energy, and sleep.
+ * Performance note: This heavily relies on collections operations. To optimize memory usage,
+ * size aggregation over grouped sequences relies on `groupingBy { ... }.eachCount()` rather than
+ * intermediate lists from `groupBy { ... }.mapValues { ... }`.
+ *
+ * @param nodes List of all nodes currently tracked.
+ * @param sessions Focus sessions to calculate unique contexts per day.
+ * @param tracks Items being tracked (mood/metrics).
+ * @param history Track entries corresponding to completed tasks.
  * @param projects A curated list of nodes strictly identified as "project" entities.
+ * @param sysZone TimeZone used for daily/date based grouping.
  * @return An analytical [InsightsData] snapshot summarizing the user's historical performance.
  */
 fun calculateInsights(
@@ -127,14 +132,12 @@ fun calculateInsights(
 
     val completionsByArea =
         recentCompletions
-            .mapNotNull { item -> item.node.areaId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .mapNotNull { item -> item.node.areaId }
+            .groupingBy { it }.eachCount()
     val completionsByProject =
         recentCompletions
-            .mapNotNull { item -> item.node.projectId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .mapNotNull { item -> item.node.projectId }
+            .groupingBy { it }.eachCount()
 
     val inboxGrowth = recentNodes.count { it.node.inboxState }
     val archivedCount =
@@ -175,23 +178,23 @@ fun calculateInsights(
     // Correlating track entries with activity
     val dailyCompletions =
         recentCompletions
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.completedAt ?: 0)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyCaptures =
         recentNodes
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.createdAt)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyFocus =
         recentSessions


### PR DESCRIPTION
Refactored multiple occurrences of `groupBy { ... }.mapValues { it.value.size }` in `MainSnapshotCalculators.kt` to instead use the idiomatic `groupingBy { ... }.eachCount()`. 

This avoids allocating intermediate lists for each group when we only care about the count, saving memory and processing time during insight calculations.

Also added a KDoc explanation of this behavior in the function signature.

---
*PR created automatically by Jules for task [14459038221135488063](https://jules.google.com/task/14459038221135488063) started by @tajemniktv*

## Summary by Sourcery

Optimize insight calculation performance and clarify the calculateInsights documentation.

Enhancements:
- Replace groupBy/mapValues size calculations with groupingBy/eachCount to avoid intermediate list allocations in insight-related aggregations.
- Update KDoc for calculateInsights to better describe inputs, outputs, and the performance considerations around collection operations.

Documentation:
- Refresh the calculateInsights KDoc with clearer parameter descriptions and a note on collection performance optimizations.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

