### PR TITLE
fix(ui): improve accessibility and fix 404 route collision

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -21,6 +21,8 @@ export default defineConfig({
       title: "Docs",
       description: "TajsOS Documentation",
 
+      disable404Route: true,
+      // Disable Starlight default 404 route because a custom src/pages/404.astro exists
       components: {
         MarkdownContent: "./src/components/MarkdownContent.astro",
       },

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -80,7 +80,7 @@ const title = "Changelog";
             </div>
             <span
               class="material-symbols-outlined text-primary"
-              style="font-variation-settings: 'FILL' 1;">psychology</span
+              style="font-variation-settings: 'FILL' 1;" aria-hidden="true">psychology</span
             >
           </div>
           <div class="w-full h-12 flex items-center justify-between gap-1">
@@ -151,7 +151,7 @@ const title = "Changelog";
           >
             <div class="flex justify-between items-start">
               <span class="material-symbols-outlined text-xs text-primary"
-                >hub</span
+                 aria-hidden="true">hub</span
               >
               <div
                 class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse shadow-[0_0_20px_#ba9eff]"
@@ -167,7 +167,7 @@ const title = "Changelog";
           >
             <div class="flex justify-between items-start">
               <span class="material-symbols-outlined text-xs text-zinc-500"
-                >memory</span
+                 aria-hidden="true">memory</span
               >
               <div class="w-1.5 h-1.5 rounded-full bg-zinc-700"></div>
             </div>
@@ -181,7 +181,7 @@ const title = "Changelog";
           >
             <div class="flex justify-between items-start">
               <span class="material-symbols-outlined text-xs text-primary"
-                >security</span
+                 aria-hidden="true">security</span
               >
               <div
                 class="w-1.5 h-1.5 rounded-full bg-primary shadow-[0_0_20px_#ba9eff]"
@@ -197,7 +197,7 @@ const title = "Changelog";
           >
             <div class="flex justify-between items-start">
               <span class="material-symbols-outlined text-xs text-tertiary"
-                >warning</span
+                 aria-hidden="true">warning</span
               >
               <div class="w-1.5 h-1.5 rounded-full bg-tertiary"></div>
             </div>
@@ -370,11 +370,11 @@ const title = "Changelog";
           <div class="flex gap-3">
             <span
               class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors"
-              >history</span
+               aria-hidden="true">history</span
             >
             <span
               class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors"
-              >terminal</span
+               aria-hidden="true">terminal</span
             >
           </div>
         </div>
@@ -387,7 +387,7 @@ const title = "Changelog";
           <div
             class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary border border-outline-variant/10"
           >
-            <span class="material-symbols-outlined">analytics</span>
+            <span class="material-symbols-outlined" aria-hidden="true">analytics</span>
           </div>
           <div>
             <h4 class="font-headline font-bold">Deep Insights</h4>
@@ -404,7 +404,7 @@ const title = "Changelog";
           <div
             class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-secondary border border-outline-variant/10"
           >
-            <span class="material-symbols-outlined">dns</span>
+            <span class="material-symbols-outlined" aria-hidden="true">dns</span>
           </div>
           <div>
             <h4 class="font-headline font-bold">Node Manager</h4>
@@ -421,7 +421,7 @@ const title = "Changelog";
           <div
             class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-tertiary border border-outline-variant/10"
           >
-            <span class="material-symbols-outlined">security</span>
+            <span class="material-symbols-outlined" aria-hidden="true">security</span>
           </div>
           <div>
             <h4 class="font-headline font-bold">Security Hub</h4>

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -36,7 +36,7 @@ const title = "FEATURES";
             <span
               class="material-symbols-outlined text-4xl text-primary mb-6"
               style="font-variation-settings: 'FILL' 1;"
-            >
+             aria-hidden="true">
               {feature.icon}
             </span>
             <h3 class="font-headline font-bold text-2xl mb-4 text-on-surface">

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -65,7 +65,7 @@ const title = "PRICING";
             <p class="text-on-surface-variant text-sm">Base Layer Access</p>
           </div>
           <span class="material-symbols-outlined text-primary-dim text-3xl"
-            >token</span
+             aria-hidden="true">token</span
           >
         </div>
         <div class="mb-12">
@@ -82,20 +82,20 @@ const title = "PRICING";
         <ul class="space-y-4 mb-12 flex-grow">
           <li class="flex items-center gap-3 text-sm">
             <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+               aria-hidden="true">check_circle</span
             >
             <span>Basic Neural Capture</span>
           </li>
           <li class="flex items-center gap-3 text-sm">
             <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+               aria-hidden="true">check_circle</span
             >
             <span>Today's Payload Sync</span>
           </li>
           <li
             class="flex items-center gap-3 text-sm text-on-surface-variant/50"
           >
-            <span class="material-symbols-outlined text-sm">block</span>
+            <span class="material-symbols-outlined text-sm" aria-hidden="true">block</span>
             <span class="line-through">Pattern Tracking</span>
           </li>
         </ul>
@@ -126,7 +126,7 @@ const title = "PRICING";
           </div>
           <span
             class="material-symbols-outlined text-primary text-3xl"
-            style="font-variation-settings: 'FILL' 1;">psychology</span
+            style="font-variation-settings: 'FILL' 1;" aria-hidden="true">psychology</span
           >
         </div>
         <div class="mb-12">
@@ -143,19 +143,19 @@ const title = "PRICING";
         <ul class="space-y-4 mb-12 flex-grow">
           <li class="flex items-center gap-3 text-sm">
             <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+               aria-hidden="true">check_circle</span
             >
             <span>Advanced Focus Mode</span>
           </li>
           <li class="flex items-center gap-3 text-sm">
             <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+               aria-hidden="true">check_circle</span
             >
             <span>Pattern Tracking &amp; Analysis</span>
           </li>
           <li class="flex items-center gap-3 text-sm">
             <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+               aria-hidden="true">check_circle</span
             >
             <span>Multi-Kernel Synchronization</span>
           </li>
@@ -181,7 +181,7 @@ const title = "PRICING";
             </p>
           </div>
           <span class="material-symbols-outlined text-primary-dim text-3xl"
-            >all_inclusive</span
+             aria-hidden="true">all_inclusive</span
           >
         </div>
         <div class="mb-12">
@@ -198,19 +198,19 @@ const title = "PRICING";
         <ul class="space-y-4 mb-12 flex-grow">
           <li class="flex items-center gap-3 text-sm">
             <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+               aria-hidden="true">check_circle</span
             >
             <span>Priority Neural Linkage</span>
           </li>
           <li class="flex items-center gap-3 text-sm">
             <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+               aria-hidden="true">check_circle</span
             >
             <span>Early Alpha Module Access</span>
           </li>
           <li class="flex items-center gap-3 text-sm">
             <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+               aria-hidden="true">check_circle</span
             >
             <span>White-Glove Tech Support</span>
           </li>
@@ -265,14 +265,14 @@ const title = "PRICING";
               <td class="p-8 text-on-surface-variant">Neural Patterning</td>
               <td class="p-8"
                 ><span class="material-symbols-outlined text-error opacity-40"
-                  >close</span
+                   aria-hidden="true">close</span
                 ></td
               >
               <td class="p-8 text-primary"
-                ><span class="material-symbols-outlined">check_circle</span></td
+                ><span class="material-symbols-outlined" aria-hidden="true">check_circle</span></td
               >
               <td class="p-8"
-                ><span class="material-symbols-outlined">check_circle</span></td
+                ><span class="material-symbols-outlined" aria-hidden="true">check_circle</span></td
               >
             </tr>
             <tr
@@ -310,7 +310,7 @@ const title = "PRICING";
             >
             <span
               class="material-symbols-outlined group-open:rotate-180 transition-transform"
-              >expand_more</span
+               aria-hidden="true">expand_more</span
             >
           </summary>
           <div
@@ -332,7 +332,7 @@ const title = "PRICING";
             >
             <span
               class="material-symbols-outlined group-open:rotate-180 transition-transform"
-              >expand_more</span
+               aria-hidden="true">expand_more</span
             >
           </summary>
           <div
@@ -354,7 +354,7 @@ const title = "PRICING";
             >
             <span
               class="material-symbols-outlined group-open:rotate-180 transition-transform"
-              >expand_more</span
+               aria-hidden="true">expand_more</span
             >
           </summary>
           <div

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -64,7 +64,7 @@ const title = "PRIVACY";
           <span
             class="material-symbols-outlined text-primary text-4xl mb-6"
             data-icon="lock"
-            style="font-variation-settings: 'FILL' 1;">lock</span
+            style="font-variation-settings: 'FILL' 1;" aria-hidden="true">lock</span
           >
           <h2 class="font-headline text-4xl font-bold tracking-tight mb-4">
             Data Encryption
@@ -97,7 +97,7 @@ const title = "PRIVACY";
         >
           <span
             class="material-symbols-outlined text-[20rem]"
-            data-icon="security">security</span
+            data-icon="security" aria-hidden="true">security</span
           >
         </div>
       </div>
@@ -146,7 +146,7 @@ const title = "PRIVACY";
           >
             <span
               class="material-symbols-outlined"
-              data-icon="sync_saved_locally">sync_saved_locally</span
+              data-icon="sync_saved_locally" aria-hidden="true">sync_saved_locally</span
             >
           </div>
           <span class="font-mono text-[10px] text-on-surface-variant"
@@ -166,7 +166,7 @@ const title = "PRIVACY";
         >
           Review Protocol <span
             class="material-symbols-outlined text-sm"
-            data-icon="arrow_forward">arrow_forward</span
+            data-icon="arrow_forward" aria-hidden="true">arrow_forward</span
           >
         </button>
       </div>
@@ -206,7 +206,7 @@ const title = "PRIVACY";
           <div class="hidden sm:block">
             <span
               class="material-symbols-outlined text-6xl text-outline-variant/20"
-              data-icon="delete_sweep">delete_sweep</span
+              data-icon="delete_sweep" aria-hidden="true">delete_sweep</span
             >
           </div>
         </div>
@@ -278,7 +278,7 @@ const title = "PRIVACY";
         >
           INITIALIZE INTERFACE <span
             class="material-symbols-outlined"
-            data-icon="bolt">bolt</span
+            data-icon="bolt" aria-hidden="true">bolt</span
           >
         </button>
         <button

--- a/website/src/pages/security.astro
+++ b/website/src/pages/security.astro
@@ -116,7 +116,7 @@ const title = "SECURITY";
                 class="material-symbols-outlined text-3xl"
                 data-icon="biometric_setup"
                 style="font-variation-settings: 'FILL' 1;"
-                >android_fingerprint</span
+                 aria-hidden="true">android_fingerprint</span
               >
             </div>
             <h3 class="font-headline text-xl font-bold mb-4 uppercase">
@@ -133,7 +133,7 @@ const title = "SECURITY";
             >
               <span
                 class="material-symbols-outlined text-sm"
-                data-icon="check_circle">check_circle</span
+                data-icon="check_circle" aria-hidden="true">check_circle</span
               >
               ACTIVE
             </div>
@@ -150,7 +150,7 @@ const title = "SECURITY";
               <span
                 class="material-symbols-outlined text-3xl"
                 data-icon="v_loss"
-                style="font-variation-settings: 'FILL' 1;">water_loss</span
+                style="font-variation-settings: 'FILL' 1;" aria-hidden="true">water_loss</span
               >
             </div>
             <h3 class="font-headline text-xl font-bold mb-4 uppercase">
@@ -167,7 +167,7 @@ const title = "SECURITY";
             >
               <span
                 class="material-symbols-outlined text-sm"
-                data-icon="check_circle">check_circle</span
+                data-icon="check_circle" aria-hidden="true">check_circle</span
               >
               ACTIVE
             </div>
@@ -184,7 +184,7 @@ const title = "SECURITY";
               <span
                 class="material-symbols-outlined text-3xl"
                 data-icon="shield_lock"
-                style="font-variation-settings: 'FILL' 1;">shield_lock</span
+                style="font-variation-settings: 'FILL' 1;" aria-hidden="true">shield_lock</span
               >
             </div>
             <h3 class="font-headline text-xl font-bold mb-4 uppercase">
@@ -201,7 +201,7 @@ const title = "SECURITY";
             >
               <span
                 class="material-symbols-outlined text-sm"
-                data-icon="check_circle">check_circle</span
+                data-icon="check_circle" aria-hidden="true">check_circle</span
               >
               ACTIVE
             </div>

--- a/website/src/pages/status.astro
+++ b/website/src/pages/status.astro
@@ -90,7 +90,7 @@ const title = "SYSTEM STATUS";
         <div>
           <span
             class="material-symbols-outlined text-primary mb-4"
-            style="font-variation-settings: 'FILL' 1;">analytics</span
+            style="font-variation-settings: 'FILL' 1;" aria-hidden="true">analytics</span
           >
           <p
             class="font-mono text-xs text-on-surface-variant uppercase tracking-widest"
@@ -399,7 +399,7 @@ const title = "SYSTEM STATUS";
                 class="font-bold text-on-surface flex items-center gap-2 group-hover:text-primary transition-colors"
               >
                 <span class="material-symbols-outlined text-sm"
-                  >check_circle</span
+                   aria-hidden="true">check_circle</span
                 >
                 No Incidents Reported
               </h4>
@@ -424,7 +424,7 @@ const title = "SYSTEM STATUS";
                 class="font-bold text-on-surface flex items-center gap-2 group-hover:text-primary transition-colors"
               >
                 <span class="material-symbols-outlined text-sm"
-                  >check_circle</span
+                   aria-hidden="true">check_circle</span
                 >
                 System Maintenance
               </h4>
@@ -445,7 +445,7 @@ const title = "SYSTEM STATUS";
             </div>
             <div class="space-y-2">
               <h4 class="font-bold text-on-surface flex items-center gap-2">
-                <span class="material-symbols-outlined text-sm">warning</span>
+                <span class="material-symbols-outlined text-sm" aria-hidden="true">warning</span>
                 Minor Latency Spike
               </h4>
               <p
@@ -465,7 +465,7 @@ const title = "SYSTEM STATUS";
           View Archive
           <span
             class="material-symbols-outlined text-sm group-hover:translate-x-1 transition-transform"
-            >arrow_right_alt</span
+             aria-hidden="true">arrow_right_alt</span
           >
         </button>
       </div>

--- a/website/src/pages/terms.astro
+++ b/website/src/pages/terms.astro
@@ -82,7 +82,7 @@ const title = "TERMS";
         >
           <span
             class="material-symbols-outlined text-primary mb-4"
-            style="font-variation-settings: 'FILL' 1;">info</span
+            style="font-variation-settings: 'FILL' 1;" aria-hidden="true">info</span
           >
           <h4
             class="font-headline text-xs font-bold uppercase tracking-widest mb-2"
@@ -183,7 +183,7 @@ const title = "TERMS";
             <div class="flex items-center justify-between">
               <div class="flex items-center gap-3">
                 <span class="material-symbols-outlined text-primary"
-                  >verified_user</span
+                   aria-hidden="true">verified_user</span
                 >
                 <span
                   class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest"
@@ -192,7 +192,7 @@ const title = "TERMS";
               </div>
               <div class="flex items-center gap-3">
                 <span class="material-symbols-outlined text-primary"
-                  >lock_open</span
+                   aria-hidden="true">lock_open</span
                 >
                 <span
                   class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest"

--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -90,12 +90,12 @@ const title = "WAITLIST";
             >
               <span
                 class="material-symbols-outlined text-on-primary animate-spin"
-                >progress_activity</span
+                 aria-hidden="true">progress_activity</span
               >
             </div>
             <span
               class="material-symbols-outlined text-xl transition-transform group-hover/btn:translate-x-1"
-              data-icon="arrow_forward">arrow_forward</span
+              data-icon="arrow_forward" aria-hidden="true">arrow_forward</span
             >
           </button>
         </form>
@@ -127,7 +127,7 @@ const title = "WAITLIST";
         >
           <span
             class="material-symbols-outlined text-primary-dim"
-            data-icon="waves">waves</span
+            data-icon="waves" aria-hidden="true">waves</span
           >
           <div class="text-left">
             <div
@@ -143,7 +143,7 @@ const title = "WAITLIST";
         >
           <span
             class="material-symbols-outlined text-primary-dim"
-            data-icon="cloud_done">cloud_done</span
+            data-icon="cloud_done" aria-hidden="true">cloud_done</span
           >
           <div class="text-left">
             <div
@@ -159,7 +159,7 @@ const title = "WAITLIST";
         >
           <span
             class="material-symbols-outlined text-primary-dim"
-            data-icon="encrypted">encrypted</span
+            data-icon="encrypted" aria-hidden="true">encrypted</span
           >
           <div class="text-left">
             <div


### PR DESCRIPTION
This PR addresses two UI and configuration issues:
1. **404 Route Collision:** Configured Astro/Starlight to `disable404Route: true` to fix the warning and prevent collision with the custom `src/pages/404.astro` page.
2. **Accessibility:** Added `aria-hidden="true"` to Google Material Symbols (`class="material-symbols-outlined"`) across the site. Since these icons use text ligatures (e.g., the word "lock" renders a lock icon), screen readers would previously read the ligature text aloud, which causes confusion. Hiding them significantly improves the experience for visually impaired users.

---
*PR created automatically by Jules for task [12455882826884737684](https://jules.google.com/task/12455882826884737684) started by @tajemniktv*

## Summary by Sourcery

Improve UI accessibility and resolve a 404 routing conflict between Starlight and the custom 404 page.

Enhancements:
- Mark Material Symbols icon spans as aria-hidden to prevent screen readers from announcing ligature text across multiple pages.
- Clarify icon rendering in the features page by setting accessibility attributes on dynamic Material Symbols.

Build:
- Configure Starlight in astro.config.mjs to disable its default 404 route in favor of the existing custom 404.astro page.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

