### PR TITLE
perf: optimize list size aggregations to use distinctBy

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -1736,9 +1736,10 @@ fun calculateCapacitySnapshot(
         ).coerceIn(0, 100)
     val fragmentationScore =
         (
-                activeTasks.groupBy { it.node.projectId }.size *
+                // Use distinctBy instead of groupBy to avoid allocating lists for each group, improving performance when only counting distinct sizes.
+                activeTasks.distinctBy { it.node.projectId }.size *
                         7 +
-                        activeTasks.groupBy { it.node.areaId }.size *
+                        activeTasks.distinctBy { it.node.areaId }.size *
                         4
         ).coerceIn(0, 100)
 
@@ -1762,7 +1763,7 @@ fun calculateCapacitySnapshot(
     val unrealisticWeekSignal =
         if (weeklyCreatedActive > weeklyDone * 2 + 5) "THIS WEEK IS UNREALISTIC // INTAKE OUTPACES EXECUTION" else null
     val tooManyActiveFrontsIndicator =
-        if (activeTasks.groupBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
+        if (activeTasks.distinctBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
     val attentionFragmentedIndicator =
         if (fragmentationScore >= 55) "ATTENTION IS TOO FRAGMENTED" else null
     val weeklyStructuralOverloadWarning =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -443,7 +443,8 @@ suspend fun buildDashboardUIState(
     val areaHealthMetrics = areaSnapshot.areas.associateBy { it.areaId }
 
     val loadScore = (activeTasks.size * 2) + (openLoops.size * 3) + (overdue.size * 5)
-    val fragmentation = activeTasks.groupBy { it.node.projectId }.size * 5
+    // Use distinctBy instead of groupBy to avoid allocating lists for each group, improving performance when only counting distinct sizes.
+    val fragmentation = activeTasks.distinctBy { it.node.projectId }.size * 5
     val capWarning =
         when
             {


### PR DESCRIPTION
Replaced `groupBy { ... }.size` with `distinctBy { ... }.size` in `MainSnapshotCalculators.kt` and `MainStateAssemblers.kt`.

Using `groupBy { ... }.size` when only the count of unique keys is needed is highly inefficient because it allocates a `LinkedHashMap` and constructs multiple `ArrayLists` to hold all matching elements. Replacing it with `distinctBy { ... }.size` successfully avoids allocating the inner grouping lists, leading to a much smaller memory footprint and faster execution. 

Also added KDocs (inline comments) explaining the performance reasoning.

---
*PR created automatically by Jules for task [7962600379377360295](https://jules.google.com/task/7962600379377360295) started by @tajemniktv*

## Summary by Sourcery

Optimize active task fragmentation calculations by using distinctBy-based uniqueness counts instead of groupBy, and document the performance rationale inline.

Enhancements:
- Replace groupBy-based distinct counts with distinctBy.size in capacity and dashboard fragmentation metrics to reduce allocations and improve performance.
- Add inline KDoc-style comments explaining why distinctBy is preferred over groupBy when only unique key counts are needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

