### PR TITLE
fix: enforce minimum length for sync token

### DIFF
--- a/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
+++ b/server/src/main/kotlin/com/tajemniktv/tajsos/Application.kt
@@ -34,6 +34,10 @@ fun Application.module() {
         ?: System.getenv("TAJSOS_SYNC_TOKEN")
         ?: error("TAJSOS_SYNC_TOKEN environment variable must be set")
 
+    require(expectedToken.length >= 16) {
+        "TAJSOS_SYNC_TOKEN must be at least 16 characters long to satisfy entropy enforcement rules."
+    }
+
     val expectedTokenHash =
         MessageDigest
             .getInstance("SHA-256")


### PR DESCRIPTION
This pull request improves security by enforcing a minimum length of 16 characters for the `TAJSOS_SYNC_TOKEN` in `Application.kt`. This ensures that tokens have a baseline level of entropy and helps protect against brute-force attacks on the authentication mechanism.

---
*PR created automatically by Jules for task [5413880260418477834](https://jules.google.com/task/5413880260418477834) started by @tajemniktv*

## Summary by Sourcery

Enhancements:
- Add runtime validation that TAJSOS_SYNC_TOKEN must be at least 16 characters long before computing its hash.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

