### PR TITLE
test: Add coverage for parsing logic and sidebar modes

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectModelsParseTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectModelsParseTest.kt
@@ -1,0 +1,36 @@
+package com.tajemniktv.tajsos.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LifeObjectModelsParseTest {
+
+    @Test
+    fun parseCapturedText_emptyOrBlank() {
+        assertEquals(ParsedCaptureText("", ""), parseCapturedText(""))
+        assertEquals(ParsedCaptureText("", ""), parseCapturedText("   "))
+        assertEquals(ParsedCaptureText("", ""), parseCapturedText("\n\n\t"))
+    }
+
+    @Test
+    fun parseCapturedText_singleLine() {
+        assertEquals(ParsedCaptureText("Hello world", ""), parseCapturedText("Hello world"))
+        assertEquals(ParsedCaptureText("Trim me", ""), parseCapturedText("  Trim me  "))
+    }
+
+    @Test
+    fun parseCapturedText_multiLine() {
+        val raw = "Title goes here\n\nBody line 1\nBody line 2\n"
+        val parsed = parseCapturedText(raw)
+        assertEquals("Title goes here", parsed.title)
+        assertEquals("Body line 1\nBody line 2", parsed.content)
+    }
+
+    @Test
+    fun parseCapturedText_withLeadingBlankLines() {
+        val raw = "\n\n  \nFirst real line\nSecond line"
+        val parsed = parseCapturedText(raw)
+        assertEquals("First real line", parsed.title)
+        assertEquals("Second line", parsed.content)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/SidebarModeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/SidebarModeTest.kt
@@ -1,0 +1,14 @@
+package com.tajemniktv.tajsos.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SidebarModeTest {
+    @Test
+    fun testSidebarModeValues() {
+        assertEquals("EXPANDED", SidebarMode.EXPANDED.name)
+        assertEquals("COLLAPSED", SidebarMode.COLLAPSED.name)
+        assertEquals("HOVER_EXPAND", SidebarMode.HOVER_EXPAND.name)
+        assertEquals(3, SidebarMode.values().size)
+    }
+}


### PR DESCRIPTION
This PR improves test coverage by adding tests for the `parseCapturedText` utility function in `LifeObjectModels.kt` and the `SidebarMode` enum.

- `LifeObjectModelsParseTest` verifies that the `parseCapturedText` function correctly splits strings into a title and content, handling edge cases like empty strings, blank strings, strings with only newlines, strings with leading/trailing whitespaces, single-line strings, and multi-line strings.
- `SidebarModeTest` ensures that the `SidebarMode` enum has the expected values (`EXPANDED`, `COLLAPSED`, `HOVER_EXPAND`) and size, providing a small regression safety net.

Both tests reside in the `shared` module and pass successfully. No production code was modified.

---
*PR created automatically by Jules for task [784472043919352342](https://jules.google.com/task/784472043919352342) started by @tajemniktv*

## Summary by Sourcery

Add shared module tests to validate captured text parsing behavior and sidebar mode definitions.

Tests:
- Add LifeObjectModelsParseTest to cover parseCapturedText for empty, single-line, multi-line, and leading-blank input cases.
- Add SidebarModeTest to assert expected enum names and count for sidebar modes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

