### PR TITLE
fix(website): disable starlight 404 route and add aria-hidden to material symbols

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -18,6 +18,7 @@ export default defineConfig({
   base: "/TajsOS/",
   integrations: [
     starlight({
+      disable404Route: true, // Disable default 404 since we have a custom src/pages/404.astro
       title: "Docs",
       description: "TajsOS Documentation",
 

--- a/website/src/components/landing/CTA.astro
+++ b/website/src/components/landing/CTA.astro
@@ -41,8 +41,8 @@ import { SITE } from "../../data/site";
         VIEW_PRICING
         <span
           aria-hidden="true"
-          class="material-symbols-outlined group-hover:translate-x-4 transition-transform text-3xl"
-          data-icon="arrow_right_alt">arrow_right_alt</span
+          class="material-symbols-outlined group-hover:translate-x-4 transition-transform text-3xl" aria-hidden="true"
+          data-icon="arrow_right_alt" aria-hidden="true">arrow_right_alt</span
         >
       </a>
     </div>

--- a/website/src/components/landing/InstrumentPanel.astro
+++ b/website/src/components/landing/InstrumentPanel.astro
@@ -31,8 +31,8 @@
         </div>
         <span
           aria-hidden="true"
-          class="material-symbols-outlined text-primary/20 text-6xl"
-          data-icon="sensors">sensors</span
+          class="material-symbols-outlined text-primary/20 text-6xl" aria-hidden="true"
+          data-icon="sensors" aria-hidden="true">sensors</span
         >
       </div>
       <div>
@@ -68,8 +68,8 @@
         <div class="flex justify-end items-center">
           <span
             aria-hidden="true"
-            class="material-symbols-outlined text-primary group-hover:translate-x-4 transition-transform text-4xl"
-            data-icon="arrow_forward">arrow_forward</span
+            class="material-symbols-outlined text-primary group-hover:translate-x-4 transition-transform text-4xl" aria-hidden="true"
+            data-icon="arrow_forward" aria-hidden="true">arrow_forward</span
           >
         </div>
       </div>
@@ -96,8 +96,8 @@
             </div>
             <span
               aria-hidden="true"
-              class="material-symbols-outlined text-secondary animate-pulse"
-              data-icon="downloading">downloading</span
+              class="material-symbols-outlined text-secondary animate-pulse" aria-hidden="true"
+              data-icon="downloading" aria-hidden="true">downloading</span
             >
           </div>
           <div
@@ -154,9 +154,9 @@
         </div>
         <span
           aria-hidden="true"
-          class="material-symbols-outlined text-8xl opacity-30"
+          class="material-symbols-outlined text-8xl opacity-30" aria-hidden="true"
           data-icon="bolt"
-          style="font-variation-settings: 'FILL' 1;">bolt</span
+          style="font-variation-settings: 'FILL' 1;" aria-hidden="true">bolt</span
         >
       </div>
     </div>

--- a/website/src/components/landing/Navbar.astro
+++ b/website/src/components/landing/Navbar.astro
@@ -34,14 +34,14 @@ import { SITE, NAV_LINKS } from "../../data/site";
       <div class="flex gap-4">
         <button
           type="button"
-          class="material-symbols-outlined text-on-surface-variant hover:text-primary cursor-pointer transition-colors"
+          class="material-symbols-outlined text-on-surface-variant hover:text-primary cursor-pointer transition-colors" aria-hidden="true"
           aria-label="Settings"
-          data-icon="settings">settings</button
+          data-icon="settings" aria-hidden="true">settings</button
         >
         <button
-          class="material-symbols-outlined text-on-surface-variant hover:text-primary cursor-pointer transition-colors"
+          class="material-symbols-outlined text-on-surface-variant hover:text-primary cursor-pointer transition-colors" aria-hidden="true"
           aria-label="Account"
-          data-icon="account_circle">account_circle</button
+          data-icon="account_circle" aria-hidden="true">account_circle</button
         >
       </div>
       <a

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -79,8 +79,8 @@ const title = "Changelog";
               </p>
             </div>
             <span
-              class="material-symbols-outlined text-primary"
-              style="font-variation-settings: 'FILL' 1;">psychology</span
+              class="material-symbols-outlined text-primary" aria-hidden="true"
+              style="font-variation-settings: 'FILL' 1;" aria-hidden="true">psychology</span
             >
           </div>
           <div class="w-full h-12 flex items-center justify-between gap-1">
@@ -150,8 +150,8 @@ const title = "Changelog";
             class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2"
           >
             <div class="flex justify-between items-start">
-              <span class="material-symbols-outlined text-xs text-primary"
-                >hub</span
+              <span class="material-symbols-outlined text-xs text-primary" aria-hidden="true"
+                 aria-hidden="true">hub</span
               >
               <div
                 class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse shadow-[0_0_20px_#ba9eff]"
@@ -166,8 +166,8 @@ const title = "Changelog";
             class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2"
           >
             <div class="flex justify-between items-start">
-              <span class="material-symbols-outlined text-xs text-zinc-500"
-                >memory</span
+              <span class="material-symbols-outlined text-xs text-zinc-500" aria-hidden="true"
+                 aria-hidden="true">memory</span
               >
               <div class="w-1.5 h-1.5 rounded-full bg-zinc-700"></div>
             </div>
@@ -180,8 +180,8 @@ const title = "Changelog";
             class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2"
           >
             <div class="flex justify-between items-start">
-              <span class="material-symbols-outlined text-xs text-primary"
-                >security</span
+              <span class="material-symbols-outlined text-xs text-primary" aria-hidden="true"
+                 aria-hidden="true">security</span
               >
               <div
                 class="w-1.5 h-1.5 rounded-full bg-primary shadow-[0_0_20px_#ba9eff]"
@@ -196,8 +196,8 @@ const title = "Changelog";
             class="bg-surface-container-highest p-3 rounded-lg border border-outline-variant/5 flex flex-col gap-2"
           >
             <div class="flex justify-between items-start">
-              <span class="material-symbols-outlined text-xs text-tertiary"
-                >warning</span
+              <span class="material-symbols-outlined text-xs text-tertiary" aria-hidden="true"
+                 aria-hidden="true">warning</span
               >
               <div class="w-1.5 h-1.5 rounded-full bg-tertiary"></div>
             </div>
@@ -369,12 +369,12 @@ const title = "Changelog";
           />
           <div class="flex gap-3">
             <span
-              class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors"
-              >history</span
+              class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors" aria-hidden="true"
+               aria-hidden="true">history</span
             >
             <span
-              class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors"
-              >terminal</span
+              class="material-symbols-outlined text-zinc-600 cursor-pointer hover:text-white transition-colors" aria-hidden="true"
+               aria-hidden="true">terminal</span
             >
           </div>
         </div>
@@ -387,7 +387,7 @@ const title = "Changelog";
           <div
             class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary border border-outline-variant/10"
           >
-            <span class="material-symbols-outlined">analytics</span>
+            <span class="material-symbols-outlined" aria-hidden="true">analytics</span>
           </div>
           <div>
             <h4 class="font-headline font-bold">Deep Insights</h4>
@@ -404,7 +404,7 @@ const title = "Changelog";
           <div
             class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-secondary border border-outline-variant/10"
           >
-            <span class="material-symbols-outlined">dns</span>
+            <span class="material-symbols-outlined" aria-hidden="true">dns</span>
           </div>
           <div>
             <h4 class="font-headline font-bold">Node Manager</h4>
@@ -421,7 +421,7 @@ const title = "Changelog";
           <div
             class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-tertiary border border-outline-variant/10"
           >
-            <span class="material-symbols-outlined">security</span>
+            <span class="material-symbols-outlined" aria-hidden="true">security</span>
           </div>
           <div>
             <h4 class="font-headline font-bold">Security Hub</h4>

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -34,9 +34,9 @@ const title = "FEATURES";
         FEATURES.map((feature) => (
           <div class="bg-surface-container-low p-8 rounded-3xl border border-transparent hover:border-primary/30 transition-all group">
             <span
-              class="material-symbols-outlined text-4xl text-primary mb-6"
+              class="material-symbols-outlined text-4xl text-primary mb-6" aria-hidden="true"
               style="font-variation-settings: 'FILL' 1;"
-            >
+             aria-hidden="true">
               {feature.icon}
             </span>
             <h3 class="font-headline font-bold text-2xl mb-4 text-on-surface">

--- a/website/src/pages/pricing.astro
+++ b/website/src/pages/pricing.astro
@@ -64,8 +64,8 @@ const title = "PRICING";
             </h3>
             <p class="text-on-surface-variant text-sm">Base Layer Access</p>
           </div>
-          <span class="material-symbols-outlined text-primary-dim text-3xl"
-            >token</span
+          <span class="material-symbols-outlined text-primary-dim text-3xl" aria-hidden="true"
+             aria-hidden="true">token</span
           >
         </div>
         <div class="mb-12">
@@ -81,21 +81,21 @@ const title = "PRICING";
         </div>
         <ul class="space-y-4 mb-12 flex-grow">
           <li class="flex items-center gap-3 text-sm">
-            <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+            <span class="material-symbols-outlined text-primary text-sm" aria-hidden="true"
+               aria-hidden="true">check_circle</span
             >
             <span>Basic Neural Capture</span>
           </li>
           <li class="flex items-center gap-3 text-sm">
-            <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+            <span class="material-symbols-outlined text-primary text-sm" aria-hidden="true"
+               aria-hidden="true">check_circle</span
             >
             <span>Today's Payload Sync</span>
           </li>
           <li
             class="flex items-center gap-3 text-sm text-on-surface-variant/50"
           >
-            <span class="material-symbols-outlined text-sm">block</span>
+            <span class="material-symbols-outlined text-sm" aria-hidden="true">block</span>
             <span class="line-through">Pattern Tracking</span>
           </li>
         </ul>
@@ -125,8 +125,8 @@ const title = "PRICING";
             </p>
           </div>
           <span
-            class="material-symbols-outlined text-primary text-3xl"
-            style="font-variation-settings: 'FILL' 1;">psychology</span
+            class="material-symbols-outlined text-primary text-3xl" aria-hidden="true"
+            style="font-variation-settings: 'FILL' 1;" aria-hidden="true">psychology</span
           >
         </div>
         <div class="mb-12">
@@ -142,20 +142,20 @@ const title = "PRICING";
         </div>
         <ul class="space-y-4 mb-12 flex-grow">
           <li class="flex items-center gap-3 text-sm">
-            <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+            <span class="material-symbols-outlined text-primary text-sm" aria-hidden="true"
+               aria-hidden="true">check_circle</span
             >
             <span>Advanced Focus Mode</span>
           </li>
           <li class="flex items-center gap-3 text-sm">
-            <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+            <span class="material-symbols-outlined text-primary text-sm" aria-hidden="true"
+               aria-hidden="true">check_circle</span
             >
             <span>Pattern Tracking &amp; Analysis</span>
           </li>
           <li class="flex items-center gap-3 text-sm">
-            <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+            <span class="material-symbols-outlined text-primary text-sm" aria-hidden="true"
+               aria-hidden="true">check_circle</span
             >
             <span>Multi-Kernel Synchronization</span>
           </li>
@@ -180,8 +180,8 @@ const title = "PRICING";
               Absolute Interface Unity
             </p>
           </div>
-          <span class="material-symbols-outlined text-primary-dim text-3xl"
-            >all_inclusive</span
+          <span class="material-symbols-outlined text-primary-dim text-3xl" aria-hidden="true"
+             aria-hidden="true">all_inclusive</span
           >
         </div>
         <div class="mb-12">
@@ -197,20 +197,20 @@ const title = "PRICING";
         </div>
         <ul class="space-y-4 mb-12 flex-grow">
           <li class="flex items-center gap-3 text-sm">
-            <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+            <span class="material-symbols-outlined text-primary text-sm" aria-hidden="true"
+               aria-hidden="true">check_circle</span
             >
             <span>Priority Neural Linkage</span>
           </li>
           <li class="flex items-center gap-3 text-sm">
-            <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+            <span class="material-symbols-outlined text-primary text-sm" aria-hidden="true"
+               aria-hidden="true">check_circle</span
             >
             <span>Early Alpha Module Access</span>
           </li>
           <li class="flex items-center gap-3 text-sm">
-            <span class="material-symbols-outlined text-primary text-sm"
-              >check_circle</span
+            <span class="material-symbols-outlined text-primary text-sm" aria-hidden="true"
+               aria-hidden="true">check_circle</span
             >
             <span>White-Glove Tech Support</span>
           </li>
@@ -264,15 +264,15 @@ const title = "PRICING";
             >
               <td class="p-8 text-on-surface-variant">Neural Patterning</td>
               <td class="p-8"
-                ><span class="material-symbols-outlined text-error opacity-40"
-                  >close</span
+                 aria-hidden="true"><span class="material-symbols-outlined text-error opacity-40"
+                   aria-hidden="true">close</span
                 ></td
               >
               <td class="p-8 text-primary"
-                ><span class="material-symbols-outlined">check_circle</span></td
+                ><span class="material-symbols-outlined" aria-hidden="true">check_circle</span></td
               >
               <td class="p-8"
-                ><span class="material-symbols-outlined">check_circle</span></td
+                ><span class="material-symbols-outlined" aria-hidden="true">check_circle</span></td
               >
             </tr>
             <tr
@@ -309,8 +309,8 @@ const title = "PRICING";
               >How secure is my neural data payload?</span
             >
             <span
-              class="material-symbols-outlined group-open:rotate-180 transition-transform"
-              >expand_more</span
+              class="material-symbols-outlined group-open:rotate-180 transition-transform" aria-hidden="true"
+               aria-hidden="true">expand_more</span
             >
           </summary>
           <div
@@ -331,8 +331,8 @@ const title = "PRICING";
               >Can I downgrade my subscription tier?</span
             >
             <span
-              class="material-symbols-outlined group-open:rotate-180 transition-transform"
-              >expand_more</span
+              class="material-symbols-outlined group-open:rotate-180 transition-transform" aria-hidden="true"
+               aria-hidden="true">expand_more</span
             >
           </summary>
           <div
@@ -353,8 +353,8 @@ const title = "PRICING";
               >What happens if my neural link fails?</span
             >
             <span
-              class="material-symbols-outlined group-open:rotate-180 transition-transform"
-              >expand_more</span
+              class="material-symbols-outlined group-open:rotate-180 transition-transform" aria-hidden="true"
+               aria-hidden="true">expand_more</span
             >
           </summary>
           <div

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -62,9 +62,9 @@ const title = "PRIVACY";
         </div>
         <div class="mb-12">
           <span
-            class="material-symbols-outlined text-primary text-4xl mb-6"
+            class="material-symbols-outlined text-primary text-4xl mb-6" aria-hidden="true"
             data-icon="lock"
-            style="font-variation-settings: 'FILL' 1;">lock</span
+            style="font-variation-settings: 'FILL' 1;" aria-hidden="true">lock</span
           >
           <h2 class="font-headline text-4xl font-bold tracking-tight mb-4">
             Data Encryption
@@ -96,8 +96,8 @@ const title = "PRIVACY";
           class="absolute -bottom-10 -right-10 opacity-5 pointer-events-none"
         >
           <span
-            class="material-symbols-outlined text-[20rem]"
-            data-icon="security">security</span
+            class="material-symbols-outlined text-[20rem]" aria-hidden="true"
+            data-icon="security" aria-hidden="true">security</span
           >
         </div>
       </div>
@@ -145,8 +145,8 @@ const title = "PRIVACY";
             class="w-12 h-12 rounded-lg bg-surface-container-highest flex items-center justify-center text-primary border border-outline-variant/20"
           >
             <span
-              class="material-symbols-outlined"
-              data-icon="sync_saved_locally">sync_saved_locally</span
+              class="material-symbols-outlined" aria-hidden="true"
+              data-icon="sync_saved_locally" aria-hidden="true">sync_saved_locally</span
             >
           </div>
           <span class="font-mono text-[10px] text-on-surface-variant"
@@ -165,8 +165,8 @@ const title = "PRIVACY";
           class="font-label text-xs uppercase tracking-widest text-primary flex items-center gap-2 group-hover:gap-4 transition-all min-h-[48px]"
         >
           Review Protocol <span
-            class="material-symbols-outlined text-sm"
-            data-icon="arrow_forward">arrow_forward</span
+            class="material-symbols-outlined text-sm" aria-hidden="true"
+            data-icon="arrow_forward" aria-hidden="true">arrow_forward</span
           >
         </button>
       </div>
@@ -205,8 +205,8 @@ const title = "PRIVACY";
           </div>
           <div class="hidden sm:block">
             <span
-              class="material-symbols-outlined text-6xl text-outline-variant/20"
-              data-icon="delete_sweep">delete_sweep</span
+              class="material-symbols-outlined text-6xl text-outline-variant/20" aria-hidden="true"
+              data-icon="delete_sweep" aria-hidden="true">delete_sweep</span
             >
           </div>
         </div>
@@ -277,8 +277,8 @@ const title = "PRIVACY";
           class="bg-linear-to-br from-primary to-primary-dim text-on-primary-fixed font-headline font-bold py-4 px-10 rounded-xl hover:scale-105 transition-transform duration-300 flex items-center gap-3 mx-auto sm:mx-0 min-h-[48px]"
         >
           INITIALIZE INTERFACE <span
-            class="material-symbols-outlined"
-            data-icon="bolt">bolt</span
+            class="material-symbols-outlined" aria-hidden="true"
+            data-icon="bolt" aria-hidden="true">bolt</span
           >
         </button>
         <button

--- a/website/src/pages/security.astro
+++ b/website/src/pages/security.astro
@@ -113,10 +113,10 @@ const title = "SECURITY";
               class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-8 text-primary"
             >
               <span
-                class="material-symbols-outlined text-3xl"
+                class="material-symbols-outlined text-3xl" aria-hidden="true"
                 data-icon="biometric_setup"
                 style="font-variation-settings: 'FILL' 1;"
-                >android_fingerprint</span
+                 aria-hidden="true">android_fingerprint</span
               >
             </div>
             <h3 class="font-headline text-xl font-bold mb-4 uppercase">
@@ -132,8 +132,8 @@ const title = "SECURITY";
               class="flex items-center gap-2 font-mono text-[10px] text-primary"
             >
               <span
-                class="material-symbols-outlined text-sm"
-                data-icon="check_circle">check_circle</span
+                class="material-symbols-outlined text-sm" aria-hidden="true"
+                data-icon="check_circle" aria-hidden="true">check_circle</span
               >
               ACTIVE
             </div>
@@ -148,9 +148,9 @@ const title = "SECURITY";
               class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-8 text-primary"
             >
               <span
-                class="material-symbols-outlined text-3xl"
+                class="material-symbols-outlined text-3xl" aria-hidden="true"
                 data-icon="v_loss"
-                style="font-variation-settings: 'FILL' 1;">water_loss</span
+                style="font-variation-settings: 'FILL' 1;" aria-hidden="true">water_loss</span
               >
             </div>
             <h3 class="font-headline text-xl font-bold mb-4 uppercase">
@@ -166,8 +166,8 @@ const title = "SECURITY";
               class="flex items-center gap-2 font-mono text-[10px] text-primary"
             >
               <span
-                class="material-symbols-outlined text-sm"
-                data-icon="check_circle">check_circle</span
+                class="material-symbols-outlined text-sm" aria-hidden="true"
+                data-icon="check_circle" aria-hidden="true">check_circle</span
               >
               ACTIVE
             </div>
@@ -182,9 +182,9 @@ const title = "SECURITY";
               class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mb-8 text-primary"
             >
               <span
-                class="material-symbols-outlined text-3xl"
+                class="material-symbols-outlined text-3xl" aria-hidden="true"
                 data-icon="shield_lock"
-                style="font-variation-settings: 'FILL' 1;">shield_lock</span
+                style="font-variation-settings: 'FILL' 1;" aria-hidden="true">shield_lock</span
               >
             </div>
             <h3 class="font-headline text-xl font-bold mb-4 uppercase">
@@ -200,8 +200,8 @@ const title = "SECURITY";
               class="flex items-center gap-2 font-mono text-[10px] text-primary"
             >
               <span
-                class="material-symbols-outlined text-sm"
-                data-icon="check_circle">check_circle</span
+                class="material-symbols-outlined text-sm" aria-hidden="true"
+                data-icon="check_circle" aria-hidden="true">check_circle</span
               >
               ACTIVE
             </div>

--- a/website/src/pages/status.astro
+++ b/website/src/pages/status.astro
@@ -89,8 +89,8 @@ const title = "SYSTEM STATUS";
       >
         <div>
           <span
-            class="material-symbols-outlined text-primary mb-4"
-            style="font-variation-settings: 'FILL' 1;">analytics</span
+            class="material-symbols-outlined text-primary mb-4" aria-hidden="true"
+            style="font-variation-settings: 'FILL' 1;" aria-hidden="true">analytics</span
           >
           <p
             class="font-mono text-xs text-on-surface-variant uppercase tracking-widest"
@@ -398,8 +398,8 @@ const title = "SYSTEM STATUS";
               <h4
                 class="font-bold text-on-surface flex items-center gap-2 group-hover:text-primary transition-colors"
               >
-                <span class="material-symbols-outlined text-sm"
-                  >check_circle</span
+                <span class="material-symbols-outlined text-sm" aria-hidden="true"
+                   aria-hidden="true">check_circle</span
                 >
                 No Incidents Reported
               </h4>
@@ -423,8 +423,8 @@ const title = "SYSTEM STATUS";
               <h4
                 class="font-bold text-on-surface flex items-center gap-2 group-hover:text-primary transition-colors"
               >
-                <span class="material-symbols-outlined text-sm"
-                  >check_circle</span
+                <span class="material-symbols-outlined text-sm" aria-hidden="true"
+                   aria-hidden="true">check_circle</span
                 >
                 System Maintenance
               </h4>
@@ -445,7 +445,7 @@ const title = "SYSTEM STATUS";
             </div>
             <div class="space-y-2">
               <h4 class="font-bold text-on-surface flex items-center gap-2">
-                <span class="material-symbols-outlined text-sm">warning</span>
+                <span class="material-symbols-outlined text-sm" aria-hidden="true">warning</span>
                 Minor Latency Spike
               </h4>
               <p
@@ -464,8 +464,8 @@ const title = "SYSTEM STATUS";
         >
           View Archive
           <span
-            class="material-symbols-outlined text-sm group-hover:translate-x-1 transition-transform"
-            >arrow_right_alt</span
+            class="material-symbols-outlined text-sm group-hover:translate-x-1 transition-transform" aria-hidden="true"
+             aria-hidden="true">arrow_right_alt</span
           >
         </button>
       </div>

--- a/website/src/pages/terms.astro
+++ b/website/src/pages/terms.astro
@@ -81,8 +81,8 @@ const title = "TERMS";
           class="mt-24 p-6 bg-surface-container-low rounded-3xl border border-outline-variant/30"
         >
           <span
-            class="material-symbols-outlined text-primary mb-4"
-            style="font-variation-settings: 'FILL' 1;">info</span
+            class="material-symbols-outlined text-primary mb-4" aria-hidden="true"
+            style="font-variation-settings: 'FILL' 1;" aria-hidden="true">info</span
           >
           <h4
             class="font-headline text-xs font-bold uppercase tracking-widest mb-2"
@@ -182,8 +182,8 @@ const title = "TERMS";
             <div class="mt-8 w-full h-[1px] bg-outline-variant/20 mb-8"></div>
             <div class="flex items-center justify-between">
               <div class="flex items-center gap-3">
-                <span class="material-symbols-outlined text-primary"
-                  >verified_user</span
+                <span class="material-symbols-outlined text-primary" aria-hidden="true"
+                   aria-hidden="true">verified_user</span
                 >
                 <span
                   class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest"
@@ -191,8 +191,8 @@ const title = "TERMS";
                 >
               </div>
               <div class="flex items-center gap-3">
-                <span class="material-symbols-outlined text-primary"
-                  >lock_open</span
+                <span class="material-symbols-outlined text-primary" aria-hidden="true"
+                   aria-hidden="true">lock_open</span
                 >
                 <span
                   class="font-mono text-[10px] text-on-surface-variant uppercase tracking-widest"

--- a/website/src/pages/waitlist.astro
+++ b/website/src/pages/waitlist.astro
@@ -89,13 +89,13 @@ const title = "WAITLIST";
               class="hidden absolute inset-0 bg-primary flex items-center justify-center"
             >
               <span
-                class="material-symbols-outlined text-on-primary animate-spin"
-                >progress_activity</span
+                class="material-symbols-outlined text-on-primary animate-spin" aria-hidden="true"
+                 aria-hidden="true">progress_activity</span
               >
             </div>
             <span
-              class="material-symbols-outlined text-xl transition-transform group-hover/btn:translate-x-1"
-              data-icon="arrow_forward">arrow_forward</span
+              class="material-symbols-outlined text-xl transition-transform group-hover/btn:translate-x-1" aria-hidden="true"
+              data-icon="arrow_forward" aria-hidden="true">arrow_forward</span
             >
           </button>
         </form>
@@ -126,8 +126,8 @@ const title = "WAITLIST";
           class="bg-surface-container-low/40 p-6 rounded-3xl border border-outline-variant/10 flex flex-col items-start gap-4"
         >
           <span
-            class="material-symbols-outlined text-primary-dim"
-            data-icon="waves">waves</span
+            class="material-symbols-outlined text-primary-dim" aria-hidden="true"
+            data-icon="waves" aria-hidden="true">waves</span
           >
           <div class="text-left">
             <div
@@ -142,8 +142,8 @@ const title = "WAITLIST";
           class="bg-surface-container-low/40 p-6 rounded-3xl border border-outline-variant/10 flex flex-col items-start gap-4"
         >
           <span
-            class="material-symbols-outlined text-primary-dim"
-            data-icon="cloud_done">cloud_done</span
+            class="material-symbols-outlined text-primary-dim" aria-hidden="true"
+            data-icon="cloud_done" aria-hidden="true">cloud_done</span
           >
           <div class="text-left">
             <div
@@ -158,8 +158,8 @@ const title = "WAITLIST";
           class="bg-surface-container-low/40 p-6 rounded-3xl border border-outline-variant/10 flex flex-col items-start gap-4"
         >
           <span
-            class="material-symbols-outlined text-primary-dim"
-            data-icon="encrypted">encrypted</span
+            class="material-symbols-outlined text-primary-dim" aria-hidden="true"
+            data-icon="encrypted" aria-hidden="true">encrypted</span
           >
           <div class="text-left">
             <div


### PR DESCRIPTION
This PR disables the Starlight default 404 route in `astro.config.mjs` to prevent collisions with the custom `src/pages/404.astro` page. It also adds the `aria-hidden="true"` attribute to all Google Material Symbols icon elements (`class="material-symbols-outlined"`) in the `.astro` files to prevent screen readers from reading the ligature text.

---
*PR created automatically by Jules for task [6239328314714832329](https://jules.google.com/task/6239328314714832329) started by @tajemniktv*

## Summary by Sourcery

Disable Starlight’s built-in 404 route and mark Material Symbols icons as decorative for improved accessibility.

Bug Fixes:
- Prevent routing conflicts by disabling the default Starlight 404 in favor of the custom 404 page.
- Stop screen readers from announcing Material Symbols ligature text by adding aria-hidden to icon elements.

Enhancements:
- Apply consistent aria-hidden attributes across website pages and landing components to treat Material Symbols icons as non-text UI decoration.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

