### PR TITLE
fix(ui): hook up shell global search bar clicks

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShell.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShell.kt
@@ -158,6 +158,7 @@ fun AppShell(
                             isDesktop = true,
                             onModeSelect = onModeSelect,
                             screenHeader = screenHeader,
+                            onSearchClick = { onNavigate(Screen.Search) },
                             modifier = Modifier.padding(bottom = 2.dp),
                         )
 
@@ -222,6 +223,7 @@ fun AppShell(
                             onModeSelect = onModeSelect,
                             onMenuClick = { scope.launch { drawerState.open() } },
                             screenHeader = screenHeader,
+                            onSearchClick = { onNavigate(Screen.Search) },
                         )
                         Box(modifier = Modifier.fillMaxSize()) {
                             content()

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/AppShellHeader.kt
@@ -109,6 +109,7 @@ fun AppShellHeader(
     isDesktop: Boolean,
     onModeSelect: (Long) -> Unit,
     screenHeader: ScreenHeaderModel,
+    onSearchClick: () -> Unit = {},
     modifier: Modifier = Modifier,
     onMenuClick: (() -> Unit)? = null,
 ) {
@@ -154,7 +155,7 @@ fun AppShellHeader(
 
                 if (isDesktop) {
                     Spacer(Modifier.width(24.dp))
-                    GlobalSearchBar(modifier = Modifier.weight(1f))
+                    GlobalSearchBar(modifier = Modifier.weight(1f), onClick = onSearchClick)
                     Spacer(Modifier.width(24.dp))
                     HeaderScreenContext(
                         model = screenHeader,
@@ -326,14 +327,15 @@ private fun HeaderBreadcrumbs(breadcrumbs: List<ScreenHeaderBreadcrumb>) {
  * Header search entry placeholder prepared as a global shell search point.
  */
 @Composable
-fun GlobalSearchBar(modifier: Modifier = Modifier) {
+fun GlobalSearchBar(modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
     TactileOutlinedTextField(
         value = "",
         onValueChange = {},
         readOnly = true,
         singleLine = true,
         modifier =
-            modifier.glassChrome(
+            modifier.mouseClickable(onClick = onClick)
+                .glassChrome(
                 shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
                 material = GlassMaterial.THIN,
             ),


### PR DESCRIPTION
This PR hooks up the placeholder `GlobalSearchBar` in the `AppShellHeader` to the active router, making it a functional interactive component that successfully navigates the user to the `Screen.Search` destination on click. This polish addresses an open-ended UX improvement without altering product direction.

---
*PR created automatically by Jules for task [7110861044505911457](https://jules.google.com/task/7110861044505911457) started by @tajemniktv*

## Summary by Sourcery

Wire the App shell header’s global search bar to trigger navigation to the Search screen when clicked.

New Features:
- Enable the GlobalSearchBar component to act as an interactive entry point that navigates to the Search screen on click.

Enhancements:
- Add a configurable search click handler to AppShellHeader and GlobalSearchBar to support shell-level search interactions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

