### PR TITLE
perf: optimize memory allocation for size and count operations

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -1734,11 +1734,12 @@ fun calculateCapacitySnapshot(
                 (maintenance.overdue.size * 4) +
                 (overdueCount * 5)
         ).coerceIn(0, 100)
+    /** Score representing execution fragmentation based on active projects and areas. */
     val fragmentationScore =
         (
-                activeTasks.groupBy { it.node.projectId }.size *
+                activeTasks.distinctBy { it.node.projectId }.size *
                         7 +
-                        activeTasks.groupBy { it.node.areaId }.size *
+                        activeTasks.distinctBy { it.node.areaId }.size *
                         4
         ).coerceIn(0, 100)
 
@@ -1762,7 +1763,7 @@ fun calculateCapacitySnapshot(
     val unrealisticWeekSignal =
         if (weeklyCreatedActive > weeklyDone * 2 + 5) "THIS WEEK IS UNREALISTIC // INTAKE OUTPACES EXECUTION" else null
     val tooManyActiveFrontsIndicator =
-        if (activeTasks.groupBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
+        if (activeTasks.distinctBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
     val attentionFragmentedIndicator =
         if (fragmentationScore >= 55) "ATTENTION IS TOO FRAGMENTED" else null
     val weeklyStructuralOverloadWarning =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -443,7 +443,8 @@ suspend fun buildDashboardUIState(
     val areaHealthMetrics = areaSnapshot.areas.associateBy { it.areaId }
 
     val loadScore = (activeTasks.size * 2) + (openLoops.size * 3) + (overdue.size * 5)
-    val fragmentation = activeTasks.groupBy { it.node.projectId }.size * 5
+    /** Calculates attention fragmentation score based on unique active projects. */
+    val fragmentation = activeTasks.distinctBy { it.node.projectId }.size * 5
     val capWarning =
         when
             {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
@@ -262,7 +262,8 @@ class CalendarManagerTest {
         assertTrue(events.isNotEmpty(), "Should have saved at least one event")
 
         // Group by external ID, every group should have size 1
-        val duplicates = events.groupBy { it.externalId }.filter { it.value.size > 1 }
+        /** Identify any external IDs that mapped to more than one distinct event. */
+        val duplicates = events.groupingBy { it.externalId }.eachCount().filter { it.value > 1 }
         assertTrue(duplicates.isEmpty(), "Should deduplicate events to a single event per externalId")
     }
 


### PR DESCRIPTION
This PR optimizes instances where `groupBy` was used inefficiently.

Specifically:
- `groupBy { ... }.size` was replaced with `distinctBy { ... }.size`.
- `groupBy { ... }.filter { it.value.size > 1 }` was replaced with `groupingBy { ... }.eachCount().filter { it.value > 1 }`.

These changes prevent unnecessary memory allocations of `ArrayList` and `LinkedHashMap` objects when only counts or uniqueness are needed.
It also adds KDoc comments to the optimized variables.

---
*PR created automatically by Jules for task [6300634019111044748](https://jules.google.com/task/6300634019111044748) started by @tajemniktv*

## Summary by Sourcery

Optimize fragmentation-related calculations and duplicate detection to reduce unnecessary allocations when counting unique items.

New Features:
- Document fragmentation metrics and duplicate detection logic with brief KDoc-style comments.

Enhancements:
- Replace groupBy-based uniqueness calculations with distinctBy to avoid building full maps when only counts are needed.
- Rewrite duplicate event detection in calendar tests to use groupingBy/eachCount for more efficient counting of repeated external IDs.

Tests:
- Update calendar duplicate event test logic to rely on count-based grouping rather than group sizes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

