### PR TITLE
fix(ui): Prevent exceptions during navigation string splitting and mouse forward tracking

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -239,7 +239,7 @@ fun App(
                                 val canPop = navController.previousBackStackEntry != null
                                 if (!canPop) return@mouseButtons
                                 if (isForwardNavigable(currentRoute)) {
-                                    mouseForwardRoutes.addLast(currentRoute!!)
+                                    currentRoute?.let { mouseForwardRoutes.addLast(it) }
                                 }
                                 navController.popBackStack()
                             },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/Screen.kt
@@ -683,12 +683,15 @@ sealed class Screen(
          */
         fun fromRoute(route: String?): Screen? {
             if (route == null) return null
-            val currentRouteBase =
+            val baseSplit =
                 route
                     .split("/")
-                    .first()
-                    .split("?")
-                    .first()
+                    .firstOrNull()
+                    ?: route
+
+            val currentRouteBase = baseSplit.split("?")
+                    .firstOrNull()
+                    ?: baseSplit
             if (currentRouteBase == StudyLegacy.route) return Education
 
             // Try exact match first (for Sub screens with query params)
@@ -709,7 +712,7 @@ sealed class Screen(
 
             // Try base route match, ensuring we don't accidentally match sub-screens that share a base
             // unless they are explicitly the root screen.
-            return rootScreens.find { it.route.split("/").first() == currentRouteBase }
+            return rootScreens.find { it.route.split("/").firstOrNull() == currentRouteBase }
         }
 
         /**


### PR DESCRIPTION
This PR improves app reliability by addressing two potential sources of crashes in the UI layer:
1. Replaces an unsafe non-null assertion operator (`!!`) in `App.kt` when navigating forward with a safe call (`?.let`) to prevent potential NullPointerExceptions.
2. Replaces unsafe `.first()` calls on string splits in `Screen.kt` with `.firstOrNull()` and provides safe fallbacks to prevent `NoSuchElementException`s in edge cases.

These changes ensure the app gracefully handles missing navigation routes or unexpected URL formats without crashing.

---
*PR created automatically by Jules for task [14651228111502829551](https://jules.google.com/task/14651228111502829551) started by @tajemniktv*

## Summary by Sourcery

Harden navigation-related UI logic to avoid crashes when handling routes and mouse forward navigation.

Bug Fixes:
- Prevent potential NullPointerExceptions when tracking forward navigation routes by safely handling nullable currentRoute.
- Avoid NoSuchElementExceptions during route parsing by safely handling string splits and missing segments in Screen.fromRoute().

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

