### PR TITLE
test: add edge cases for empty fields in FilterHelper.matchesQuery

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
@@ -43,4 +43,15 @@ class FilterHelperMatchesQueryEdgeTest {
         assertTrue(FilterHelper.matchesQuery(nodeTag, "tag"))
         assertFalse(FilterHelper.matchesQuery(nodeNone, "title"))
     }
+
+    @Test
+    fun testMatchesQuery_emptyFields() {
+        val nodeNullContent = buildTestNode(1, "my title", "")
+        assertTrue(FilterHelper.matchesQuery(nodeNullContent, "title"))
+        assertFalse(FilterHelper.matchesQuery(nodeNullContent, "content"))
+
+        val nodeNullTitle = buildTestNode(2, "", "my content")
+        assertTrue(FilterHelper.matchesQuery(nodeNullTitle, "content"))
+        assertFalse(FilterHelper.matchesQuery(nodeNullTitle, "title"))
+    }
 }


### PR DESCRIPTION
Added tests to verify how `FilterHelper.matchesQuery` behaves when the node's title or content are empty strings (e.g. `""`). These tests ensure that edge cases around empty inputs are handled correctly without regressions.

---
*PR created automatically by Jules for task [6509186513816969119](https://jules.google.com/task/6509186513816969119) started by @tajemniktv*

## Summary by Sourcery

Tests:
- Add unit test coverage for matchesQuery behavior when node title or content are empty strings.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

