### PR TITLE
test: Improve test coverage for InetAddressParser edge cases

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserExtraTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/InetAddressParserExtraTest.kt
@@ -1,0 +1,42 @@
+package com.tajemniktv.tajsos.calendar
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class InetAddressParserExtraTest {
+
+    @Test
+    fun testIpv4BoundaryValues() {
+        assertNotNull(parseIpAddress("0.0.0.0"), "Should parse 0.0.0.0")
+        assertNotNull(parseIpAddress("255.255.255.255"), "Should parse 255.255.255.255")
+    }
+
+    @Test
+    fun testIpv4LeadingZerosRejected() {
+        assertNull(parseIpAddress("192.168.01.1"), "Should reject leading zero in any segment unless it is exactly 0")
+        assertNull(parseIpAddress("01.0.0.0"), "Should reject leading zero")
+        assertNull(parseIpAddress("192.168.1.00"), "Should reject multiple zeros")
+    }
+
+    @Test
+    fun testIpv6BoundaryValues() {
+        assertNotNull(parseIpAddress("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"), "Should parse max IPv6 values")
+        assertNotNull(parseIpAddress("0:0:0:0:0:0:0:0"), "Should parse all zeros IPv6")
+    }
+
+    @Test
+    fun testIpv6DoubleColonAtEdges() {
+        assertNotNull(parseIpAddress("::1"), "Should handle double colon at the start")
+        assertNotNull(parseIpAddress("1::"), "Should handle double colon at the end")
+        assertNotNull(parseIpAddress("::"), "Should handle just double colon")
+    }
+
+    @Test
+    fun testIpv6InvalidSegments() {
+        assertNull(parseIpAddress("12345::1"), "Should reject segments with more than 4 hex digits")
+        assertNull(parseIpAddress("1::g"), "Should reject invalid hex characters")
+        assertNull(parseIpAddress("-1::1"), "Should reject negative signs")
+        assertNull(parseIpAddress("+1::1"), "Should reject positive signs")
+    }
+}


### PR DESCRIPTION
This PR introduces additional tests for `InetAddressParser` to cover critical edge cases and bug-prone parsing scenarios, including:
- IPv4 boundary tests (e.g. 0.0.0.0 and 255.255.255.255)
- IPv4 leading zero rejection
- IPv6 max and min values boundary checks
- IPv6 double colons handling at edges
- IPv6 invalid segments rejection (e.g. more than 4 hex digits, invalid chars, signs)

This is a test-only change to safely verify correct parsing behavior without modifying production code.

---
*PR created automatically by Jules for task [15516768798828394077](https://jules.google.com/task/15516768798828394077) started by @tajemniktv*

## Summary by Sourcery

Add additional test coverage for InetAddressParser to validate IPv4 and IPv6 edge-case parsing behavior without changing production code.

Tests:
- Introduce new InetAddressParserExtraTest covering IPv4 boundary addresses and leading-zero rejection.
- Add IPv6 tests for boundary values, edge-position double colon usage, and invalid segment rejection including length, characters, and signs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

