### PR TITLE
perf: optimize memory allocations for collection groupings

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -1736,9 +1736,9 @@ fun calculateCapacitySnapshot(
         ).coerceIn(0, 100)
     val fragmentationScore =
         (
-                activeTasks.groupBy { it.node.projectId }.size *
+                activeTasks.distinctBy { it.node.projectId }.size *
                         7 +
-                        activeTasks.groupBy { it.node.areaId }.size *
+                        activeTasks.distinctBy { it.node.areaId }.size *
                         4
         ).coerceIn(0, 100)
 
@@ -1762,7 +1762,7 @@ fun calculateCapacitySnapshot(
     val unrealisticWeekSignal =
         if (weeklyCreatedActive > weeklyDone * 2 + 5) "THIS WEEK IS UNREALISTIC // INTAKE OUTPACES EXECUTION" else null
     val tooManyActiveFrontsIndicator =
-        if (activeTasks.groupBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
+        if (activeTasks.distinctBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
     val attentionFragmentedIndicator =
         if (fragmentationScore >= 55) "ATTENTION IS TOO FRAGMENTED" else null
     val weeklyStructuralOverloadWarning =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -443,7 +443,7 @@ suspend fun buildDashboardUIState(
     val areaHealthMetrics = areaSnapshot.areas.associateBy { it.areaId }
 
     val loadScore = (activeTasks.size * 2) + (openLoops.size * 3) + (overdue.size * 5)
-    val fragmentation = activeTasks.groupBy { it.node.projectId }.size * 5
+    val fragmentation = activeTasks.distinctBy { it.node.projectId }.size * 5
     val capWarning =
         when
             {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
@@ -262,7 +262,7 @@ class CalendarManagerTest {
         assertTrue(events.isNotEmpty(), "Should have saved at least one event")
 
         // Group by external ID, every group should have size 1
-        val duplicates = events.groupBy { it.externalId }.filter { it.value.size > 1 }
+        val duplicates = events.groupingBy { it.externalId }.eachCount().filter { it.value > 1 }
         assertTrue(duplicates.isEmpty(), "Should deduplicate events to a single event per externalId")
     }
 


### PR DESCRIPTION
Replaces inefficient `groupBy { ... }.size` with `distinctBy { ... }.size` to prevent unnecessary list allocations, and updates tests to use `groupingBy { ... }.eachCount()` which is much more efficient than using `groupBy` for occurrence counting.

---
*PR created automatically by Jules for task [3320864345305593927](https://jules.google.com/task/3320864345305593927) started by @tajemniktv*

## Summary by Sourcery

Optimize collection-based fragmentation and deduplication calculations to reduce unnecessary allocations.

Enhancements:
- Use distinctBy for project and area aggregation metrics to avoid building intermediate grouped lists.
- Update calendar tests to use groupingBy.eachCount for duplicate detection instead of groupBy.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

