### PR TITLE
feat(ui): Use mouseClickable modifier consistently for desktop hover support

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/TrackCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/TrackCards.kt
@@ -4,7 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.components.cards
 
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -88,8 +88,7 @@ fun MedicationSyncCard(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { onToggleMed(med.id) }
-                                .pointerHoverIcon(PointerIcon.Hand)
+                                .mouseClickable(onClick = { onToggleMed(med.id) })
                                 .padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.components.layout
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -60,7 +60,7 @@ fun DashHeader(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.clickable { onMenuClick() }.pointerHoverIcon(PointerIcon.Hand),
+            modifier = Modifier.mouseClickable(onClick = { onMenuClick() }),
         ) {
             Box(
                 modifier =

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.components.nodes
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -426,8 +426,7 @@ fun DecisionDetailContent(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { selectedOptionId = option.id }
-                                    .pointerHoverIcon(PointerIcon.Hand),
+                                    .mouseClickable(onClick = { selectedOptionId = option.id }),
                         ) {
                             RadioButton(
                                 selected = selectedOptionId == option.id,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
@@ -6,7 +6,7 @@ package com.tajemniktv.tajsos.ui.components.nodes
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -73,7 +73,7 @@ fun TaskBrief(
                             1.dp,
                             if (isDone) TajsOSTheme.Primary else TajsOSTheme.GhostBorder,
                             CircleShape,
-                        ).clickable { onToggle() }.pointerHoverIcon(PointerIcon.Hand),
+                        ).mouseClickable(onClick = { onToggle() }),
                 contentAlignment = Alignment.Center,
             ) {
                 if (isDone) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.components.notifications
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -71,8 +71,7 @@ fun TajsNotificationCard(
             modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(TajsOSTheme.RadiusMd))
-                .clickable { notification.onClick() }
-                .pointerHoverIcon(PointerIcon.Hand),
+                .mouseClickable(onClick = { notification.onClick() }),
         color = TajsOSTheme.SurfaceLow,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
@@ -4,7 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.areas.detail
 
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -416,8 +416,7 @@ private fun renderAreaSidebar(context: AreaDetailContext) {
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clickable { context.onEditNode(node.id) }
-                            .pointerHoverIcon(PointerIcon.Hand),
+                            .mouseClickable(onClick = { context.onEditNode(node.id) }),
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.screens.calendar
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -261,8 +261,7 @@ fun MonthView(
                                         } else {
                                             TajsOSTheme.CalendarIdleDay
                                         },
-                                    ).clickable { onDateSelected(date) }
-                                        .pointerHoverIcon(PointerIcon.Hand),
+                                    ).mouseClickable(onClick = { onDateSelected(date) }),
                             contentAlignment = Alignment.Center,
                         ) {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
@@ -7,7 +7,7 @@ package com.tajemniktv.tajsos.ui.screens.dashboard
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -444,8 +444,7 @@ private fun RenderDashboardBlock(
                     Row(
                         modifier =
                             Modifier
-                                .clickable { context.onNewEntry() }
-                                .pointerHoverIcon(PointerIcon.Hand)
+                                .mouseClickable(onClick = { context.onNewEntry() })
                                 .background(TajsOSTheme.Primary, RoundedCornerShape(TajsOSTheme.RadiusXs))
                                 .padding(horizontal = 12.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -607,8 +606,7 @@ private fun DashboardOperationsOverview(
                                 1.dp,
                                 TajsOSTheme.Border,
                                 RoundedCornerShape(TajsOSTheme.RadiusMd),
-                            ).clickable { onNavigate(module.screen.route) }
-                                .pointerHoverIcon(PointerIcon.Hand)
+                            ).mouseClickable(onClick = { onNavigate(module.screen.route) })
                               .padding(TajsOSTheme.SpacingMd),
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
@@ -7,7 +7,7 @@
 package com.tajemniktv.tajsos.ui.screens.finance
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -216,8 +216,7 @@ internal fun renderFinanceActivityBlock(context: FinanceDashboardContext) {
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clickable { context.onEditNode(item.node.id) }
-                            .pointerHoverIcon(PointerIcon.Hand)
+                            .mouseClickable(onClick = { context.onEditNode(item.node.id) })
                             .padding(vertical = 4.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -4,7 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.notes
 
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -138,8 +138,7 @@ fun NotesContextPanel(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onOpenNode(task.id) }
-                                        .pointerHoverIcon(PointerIcon.Hand)
+                                        .mouseClickable(onClick = { onOpenNode(task.id) })
                                         .padding(vertical = 2.dp),
                             )
                         }
@@ -163,8 +162,7 @@ fun NotesContextPanel(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onOpenNode(note.id) }
-                                        .pointerHoverIcon(PointerIcon.Hand)
+                                        .mouseClickable(onClick = { onOpenNode(note.id) })
                                         .padding(vertical = 2.dp),
                             )
                         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -7,7 +7,7 @@ package com.tajemniktv.tajsos.ui.screens.notes
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -247,8 +247,7 @@ fun NotesWorkspaceDetail(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { onNavigateToNode(item.id) }
-                                    .pointerHoverIcon(PointerIcon.Hand),
+                                    .mouseClickable(onClick = { onNavigateToNode(item.id) }),
                             shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                             color =
                                 if (item.id ==
@@ -422,8 +421,7 @@ fun NotesWorkspaceDetail(
                             "• ${linkedNode.title}",
                             modifier =
                                 Modifier
-                                    .clickable { onNavigateToNode(linkedNode.id) }
-                                    .pointerHoverIcon(PointerIcon.Hand),
+                                    .mouseClickable(onClick = { onNavigateToNode(linkedNode.id) }),
                             color = TajsOSTheme.Text,
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
@@ -7,7 +7,7 @@ package com.tajemniktv.tajsos.ui.screens.notes.detail
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -296,9 +296,9 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                 ) {
                     Column(
                         modifier =
-                            Modifier.weight(1f).clickable {
+                            Modifier.weight(1f).mouseClickable(onClick = {
                                 context.onShowEnergyDialog()
-                            }.pointerHoverIcon(PointerIcon.Hand),
+                            }),
                     ) {
                         Text(
                             "ENERGY",
@@ -326,9 +326,9 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                     }
                     Column(
                         modifier =
-                            Modifier.weight(1f).clickable {
+                            Modifier.weight(1f).mouseClickable(onClick = {
                                 context.onShowFrictionDialog()
-                            }.pointerHoverIcon(PointerIcon.Hand),
+                            }),
                     ) {
                         Text(
                             "FRICTION",
@@ -356,8 +356,7 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowEstimateDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onShowEstimateDialog() }),
                     ) {
                         Text(
                             "ESTIMATE",
@@ -460,8 +459,7 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowMediaTypeDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onShowMediaTypeDialog() }),
                     ) {
                         Text(
                             "MEDIA TYPE",
@@ -479,8 +477,7 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowRatingDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onShowRatingDialog() }),
                     ) {
                         Text(
                             "RATING",
@@ -599,12 +596,12 @@ private fun renderNoteContextGraph(context: NoteDetailContext) {
                                 Icons.Default.Close,
                                 null,
                                 modifier =
-                                    Modifier.size(14.dp).clickable {
+                                    Modifier.size(14.dp).mouseClickable(onClick = {
                                         viewModel.detachTagFromNode(
                                             noteId,
                                             tag.id,
                                         )
-                                    }.pointerHoverIcon(PointerIcon.Hand),
+                                    }),
                             )
                         },
                         colors =
@@ -821,8 +818,7 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .clickable { context.onShowAreaDialog() }
-                            .pointerHoverIcon(PointerIcon.Hand),
+                            .mouseClickable(onClick = { context.onShowAreaDialog() }),
                 ) {
                     Text(
                         "AREA",
@@ -840,8 +836,7 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .clickable { context.onShowProjectDialog() }
-                            .pointerHoverIcon(PointerIcon.Hand),
+                            .mouseClickable(onClick = { context.onShowProjectDialog() }),
                 ) {
                     Text(
                         "PROJECT",
@@ -911,8 +906,7 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowNoteTypeDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onShowNoteTypeDialog() }),
                     ) {
                         Text(
                             "NOTE TYPE",
@@ -930,8 +924,7 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowNoteStateDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onShowNoteStateDialog() }),
                     ) {
                         Text(
                             "STATE",

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.screens.projects.detail
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -495,8 +495,7 @@ private fun renderProjectSidebar(context: ProjectDetailContext) {
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { context.onEditNode(node.id) }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onEditNode(node.id) }),
                     )
                 }
             }


### PR DESCRIPTION
This PR refactors various files in `composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/` to consistently use the `mouseClickable` modifier instead of the standard `clickable` modifier.

The standard `Modifier.clickable` does not automatically provide a pointer hover icon on Desktop Compose, nor does it inherently support right-click/middle-click behaviors that might be desired on non-mobile platforms. TajsOS already has a custom `mouseClickable` modifier to address these UX gaps.

- Replaced instances of `Modifier.clickable` with `Modifier.mouseClickable`.
- Replaced `onClick` lambda with named arguments since `onClick` is not the last argument in `mouseClickable` (e.g., `.mouseClickable(onClick = { ... })`).
- Removed redundant `.pointerHoverIcon(PointerIcon.Hand)` modifiers where `mouseClickable` was introduced, as the custom modifier provides this natively.
- Tests pass (`./gradlew :composeApp:jvmTest`).

---
*PR created automatically by Jules for task [16475243103162428545](https://jules.google.com/task/16475243103162428545) started by @tajemniktv*

## Summary by Sourcery

Enhancements:
- Adopt mouseClickable for interactive elements in notes, dashboard, calendar, finance, projects, areas, notifications, and shared components to provide consistent desktop hover and mouse behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

