### PR TITLE
fix: replace unsafe collection accesses with safe alternatives

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -239,7 +239,7 @@ fun App(
                                 val canPop = navController.previousBackStackEntry != null
                                 if (!canPop) return@mouseButtons
                                 if (isForwardNavigable(currentRoute)) {
-                                    mouseForwardRoutes.addLast(currentRoute!!)
+                                    currentRoute?.let { mouseForwardRoutes.addLast(it) }
                                 }
                                 navController.popBackStack()
                             },

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/Screen.kt
@@ -709,7 +709,7 @@ sealed class Screen(
 
             // Try base route match, ensuring we don't accidentally match sub-screens that share a base
             // unless they are explicitly the root screen.
-            return rootScreens.find { it.route.split("/").first() == currentRouteBase }
+            return rootScreens.find { it.route.split("/").firstOrNull() == currentRouteBase }
         }
 
         /**

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/tasks/detail/TaskDetailScreen.kt
@@ -490,7 +490,7 @@ private fun replaceInlineChecklist(
             }.toMutableList()
 
     if (updatedChecklist.isNotEmpty()) {
-        if (baseLines.isNotEmpty() && baseLines.last().isNotBlank()) {
+        if (baseLines.isNotEmpty() && baseLines.lastOrNull()?.isNotBlank() == true) {
             baseLines.add("")
         }
         baseLines.addAll(

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectModels.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/LifeObjectModels.kt
@@ -961,7 +961,7 @@ fun parseCapturedText(rawText: String): ParsedCaptureText {
         return ParsedCaptureText(title = "", content = "")
     }
 
-    val title = lines.first()
+    val title = lines.firstOrNull() ?: ""
     val content = lines.drop(1).joinToString("\n").trim()
     return ParsedCaptureText(title = title, content = content)
 }

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/actions/NodeCommands.kt
@@ -323,13 +323,7 @@ class NodeCommands(
                     val lines = node.content.lines().filter { it.isNotBlank() }
                     if (lines.isNotEmpty()) {
                         val firstLine =
-                            lines
-                                .first()
-                                .trim()
-                                .removePrefix("-")
-                                .removePrefix("*")
-                                .trim()
-                                .ifBlank { defaultNextStepLabel() }
+                            lines.firstOrNull()?.trim()?.removePrefix("-")?.removePrefix("*")?.trim()?.ifBlank { defaultNextStepLabel() } ?: defaultNextStepLabel()
                         repository.updateNode(
                             node.copy(
                                 nextSmallestStep = firstLine,
@@ -485,11 +479,7 @@ class NodeCommands(
                     for (section in sections) {
                         val lines = section.lines()
                         val title =
-                            lines
-                                .first()
-                                .removePrefix("# ")
-                                .trim()
-                                .ifBlank { defaultUntitledLabel() }
+                            lines.firstOrNull()?.removePrefix("# ")?.trim()?.ifBlank { defaultUntitledLabel() } ?: defaultUntitledLabel()
                         val content = lines.drop(1).joinToString("\n").trim()
 
                         repository.insertNode(


### PR DESCRIPTION
This pull request replaces several potentially crash-prone operators (like the `!!` not-null assertion operator, `.first()`, and `.last()`) with their safer equivalents (`?.let`, `.firstOrNull()`, and `.lastOrNull()`). Eliminating these methods reduces the risk of runtime crashes like `NullPointerException` or `NoSuchElementException`, making the application more robust and predictable.

The fallback logic using Elvis operators (e.g., `?: ""`) ensures the original behaviors are preserved safely.

---
*PR created automatically by Jules for task [4888364530736652229](https://jules.google.com/task/4888364530736652229) started by @tajemniktv*

## Summary by Sourcery

Improve collection handling safety to avoid crashes when working with node content, navigation routes, and parsed text.

Bug Fixes:
- Prevent potential crashes when deriving next step labels and section titles from empty or malformed content.
- Avoid NullPointerExceptions when pushing navigation routes onto the forward stack.
- Eliminate NoSuchElementExceptions when matching root screens and when checking trailing checklist lines.
- Handle empty captured text lines safely when parsing titles in captured text.

Enhancements:
- Preserve existing labeling and parsing behavior while introducing safer fallbacks for missing or blank content.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

