### PR TITLE
perf: optimize groupBy size calculations

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -1734,11 +1734,15 @@ fun calculateCapacitySnapshot(
                 (maintenance.overdue.size * 4) +
                 (overdueCount * 5)
         ).coerceIn(0, 100)
+    /**
+     * Calculates a combined fragmentation score weighted by distinct projects and areas.
+     * Optimization: Uses `distinctBy { ... }.size` instead of `groupBy { ... }.size` to avoid unnecessary list allocations.
+     */
     val fragmentationScore =
         (
-                activeTasks.groupBy { it.node.projectId }.size *
+                activeTasks.distinctBy { it.node.projectId }.size *
                         7 +
-                        activeTasks.groupBy { it.node.areaId }.size *
+                        activeTasks.distinctBy { it.node.areaId }.size *
                         4
         ).coerceIn(0, 100)
 
@@ -1761,8 +1765,12 @@ fun calculateCapacitySnapshot(
         nodes.count { it.node.status == "done" && (it.node.completedAt ?: 0L) >= now - weekMs }
     val unrealisticWeekSignal =
         if (weeklyCreatedActive > weeklyDone * 2 + 5) "THIS WEEK IS UNREALISTIC // INTAKE OUTPACES EXECUTION" else null
+    /**
+     * Indicator warning when tasks are spread across too many distinct areas.
+     * Optimization: Uses `distinctBy { ... }.size` instead of `groupBy { ... }.size` to minimize memory allocation.
+     */
     val tooManyActiveFrontsIndicator =
-        if (activeTasks.groupBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
+        if (activeTasks.distinctBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
     val attentionFragmentedIndicator =
         if (fragmentationScore >= 55) "ATTENTION IS TOO FRAGMENTED" else null
     val weeklyStructuralOverloadWarning =

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -443,7 +443,11 @@ suspend fun buildDashboardUIState(
     val areaHealthMetrics = areaSnapshot.areas.associateBy { it.areaId }
 
     val loadScore = (activeTasks.size * 2) + (openLoops.size * 3) + (overdue.size * 5)
-    val fragmentation = activeTasks.groupBy { it.node.projectId }.size * 5
+    /**
+     * Calculates the fragmentation score based on the number of distinct projects among active tasks.
+     * Optimization: Uses `distinctBy { ... }.size` instead of `groupBy { ... }.size` to avoid allocating lists of items.
+     */
+    val fragmentation = activeTasks.distinctBy { it.node.projectId }.size * 5
     val capWarning =
         when
             {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
@@ -262,7 +262,7 @@ class CalendarManagerTest {
         assertTrue(events.isNotEmpty(), "Should have saved at least one event")
 
         // Group by external ID, every group should have size 1
-        val duplicates = events.groupBy { it.externalId }.filter { it.value.size > 1 }
+        val duplicates = events.groupingBy { it.externalId }.eachCount().filter { it.value > 1 }
         assertTrue(duplicates.isEmpty(), "Should deduplicate events to a single event per externalId")
     }
 


### PR DESCRIPTION
Replaced inefficient `groupBy { ... }.size` logic with `distinctBy { ... }.size` to prevent unnecessary allocations of intermediate lists when only unique keys counts are needed. Replaced `groupBy { ... }.filter { it.value.size > 1 }` with `groupingBy { ... }.eachCount().filter { it.value > 1 }` to avoid allocating objects during uniqueness checks. Added KDocs explaining the optimization intent.

---
*PR created automatically by Jules for task [198861719927739180](https://jules.google.com/task/198861719927739180) started by @tajemniktv*

## Summary by Sourcery

Optimize fragmentation and deduplication calculations across capacity, dashboard, and calendar logic to reduce unnecessary allocations while documenting the intent of these metrics.

Enhancements:
- Optimize fragmentation-related metrics by using distinct counts instead of grouping to reduce memory allocations.
- Clarify the intent of fragmentation and active fronts calculations with KDoc documentation.
- Improve duplicate event detection in calendar tests by using count-based grouping without allocating full groups.

Tests:
- Adjust calendar deduplication test logic to rely on efficient count-based grouping while preserving behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

