### PR TITLE
perf: optimize list grouping memory allocations in MainSnapshotCalculators

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -128,13 +128,11 @@ fun calculateInsights(
     val completionsByArea =
         recentCompletions
             .mapNotNull { item -> item.node.areaId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .groupingBy { it.first }.eachCount()
     val completionsByProject =
         recentCompletions
             .mapNotNull { item -> item.node.projectId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .groupingBy { it.first }.eachCount()
 
     val inboxGrowth = recentNodes.count { it.node.inboxState }
     val archivedCount =
@@ -1736,9 +1734,9 @@ fun calculateCapacitySnapshot(
         ).coerceIn(0, 100)
     val fragmentationScore =
         (
-                activeTasks.groupBy { it.node.projectId }.size *
+                activeTasks.distinctBy { it.node.projectId }.size *
                         7 +
-                        activeTasks.groupBy { it.node.areaId }.size *
+                        activeTasks.distinctBy { it.node.areaId }.size *
                         4
         ).coerceIn(0, 100)
 
@@ -1762,7 +1760,7 @@ fun calculateCapacitySnapshot(
     val unrealisticWeekSignal =
         if (weeklyCreatedActive > weeklyDone * 2 + 5) "THIS WEEK IS UNREALISTIC // INTAKE OUTPACES EXECUTION" else null
     val tooManyActiveFrontsIndicator =
-        if (activeTasks.groupBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
+        if (activeTasks.distinctBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
     val attentionFragmentedIndicator =
         if (fragmentationScore >= 55) "ATTENTION IS TOO FRAGMENTED" else null
     val weeklyStructuralOverloadWarning =
@@ -1863,8 +1861,7 @@ fun calculateCapacitySnapshot(
                 val fallbackFrag =
                     nodes
                         .filter { it.node.status == "active" && it.node.createdAt <= bucketEnd }
-                        .groupBy { it.node.projectId }
-                        .size
+                        .distinctBy { it.node.projectId }.size
                         .times(8)
                         .coerceIn(0, 100)
                 LoadTrendPoint(


### PR DESCRIPTION
This PR refactors Kotlin collection operations in `MainSnapshotCalculators.kt` to reduce memory allocations and Garbage Collection (GC) pressure. By replacing `.groupBy().mapValues { it.value.size }` with `.groupingBy().eachCount()` and replacing `.groupBy { ... }.size` with `.distinctBy { ... }.size`, we significantly reduce the creation of intermediate lists and hash maps. This directly improves application robustness by lowering the risk of Out-Of-Memory errors and shortening GC pauses during heavy background calculations.

---
*PR created automatically by Jules for task [11146417279200932288](https://jules.google.com/task/11146417279200932288) started by @tajemniktv*

## Summary by Sourcery

Optimize snapshot capacity and insights calculations by reducing collection allocations in MainSnapshotCalculators.

Enhancements:
- Improve performance of completion aggregation by replacing groupBy/mapValues with groupingBy/eachCount to avoid intermediate collections.
- Reduce memory usage and GC pressure in fragmentation and active-front calculations by using distinctBy instead of groupBy for counting unique areas and projects.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

