### PR TITLE
fix/feat(ui): replace clickable with mouseClickable for better UX

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/TrackCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/TrackCards.kt
@@ -4,7 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.components.cards
 
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -88,7 +88,7 @@ fun MedicationSyncCard(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { onToggleMed(med.id) }
+                                .mouseClickable(onClick = { onToggleMed(med.id) })
                                 .pointerHoverIcon(PointerIcon.Hand)
                                 .padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.components.layout
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -60,7 +60,7 @@ fun DashHeader(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.clickable { onMenuClick() }.pointerHoverIcon(PointerIcon.Hand),
+            modifier = Modifier.mouseClickable(onClick = { onMenuClick() }).pointerHoverIcon(PointerIcon.Hand),
         ) {
             Box(
                 modifier =

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.components.nodes
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -426,7 +426,7 @@ fun DecisionDetailContent(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { selectedOptionId = option.id }
+                                    .mouseClickable(onClick = { selectedOptionId = option.id })
                                     .pointerHoverIcon(PointerIcon.Hand),
                         ) {
                             RadioButton(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
@@ -6,7 +6,7 @@ package com.tajemniktv.tajsos.ui.components.nodes
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -73,7 +73,7 @@ fun TaskBrief(
                             1.dp,
                             if (isDone) TajsOSTheme.Primary else TajsOSTheme.GhostBorder,
                             CircleShape,
-                        ).clickable { onToggle() }.pointerHoverIcon(PointerIcon.Hand),
+                        ).mouseClickable(onClick = { onToggle() }).pointerHoverIcon(PointerIcon.Hand),
                 contentAlignment = Alignment.Center,
             ) {
                 if (isDone) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.components.notifications
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -71,7 +71,7 @@ fun TajsNotificationCard(
             modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(TajsOSTheme.RadiusMd))
-                .clickable { notification.onClick() }
+                .mouseClickable(onClick = { notification.onClick() })
                 .pointerHoverIcon(PointerIcon.Hand),
         color = TajsOSTheme.SurfaceLow,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
@@ -4,7 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.areas.detail
 
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -416,7 +416,7 @@ private fun renderAreaSidebar(context: AreaDetailContext) {
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clickable { context.onEditNode(node.id) }
+                            .mouseClickable(onClick = { context.onEditNode(node.id) })
                             .pointerHoverIcon(PointerIcon.Hand),
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.screens.calendar
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -261,7 +261,7 @@ fun MonthView(
                                         } else {
                                             TajsOSTheme.CalendarIdleDay
                                         },
-                                    ).clickable { onDateSelected(date) }
+                                    ).mouseClickable(onClick = { onDateSelected(date) })
                                         .pointerHoverIcon(PointerIcon.Hand),
                             contentAlignment = Alignment.Center,
                         ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
@@ -7,7 +7,7 @@ package com.tajemniktv.tajsos.ui.screens.dashboard
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -444,7 +444,7 @@ private fun RenderDashboardBlock(
                     Row(
                         modifier =
                             Modifier
-                                .clickable { context.onNewEntry() }
+                                .mouseClickable(onClick = { context.onNewEntry() })
                                 .pointerHoverIcon(PointerIcon.Hand)
                                 .background(TajsOSTheme.Primary, RoundedCornerShape(TajsOSTheme.RadiusXs))
                                 .padding(horizontal = 12.dp, vertical = 6.dp),
@@ -607,7 +607,7 @@ private fun DashboardOperationsOverview(
                                 1.dp,
                                 TajsOSTheme.Border,
                                 RoundedCornerShape(TajsOSTheme.RadiusMd),
-                            ).clickable { onNavigate(module.screen.route) }
+                            ).mouseClickable(onClick = { onNavigate(module.screen.route) })
                                 .pointerHoverIcon(PointerIcon.Hand)
                               .padding(TajsOSTheme.SpacingMd),
                     verticalArrangement = Arrangement.spacedBy(6.dp),

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
@@ -7,7 +7,7 @@
 package com.tajemniktv.tajsos.ui.screens.finance
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -216,7 +216,7 @@ internal fun renderFinanceActivityBlock(context: FinanceDashboardContext) {
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clickable { context.onEditNode(item.node.id) }
+                            .mouseClickable(onClick = { context.onEditNode(item.node.id) })
                             .pointerHoverIcon(PointerIcon.Hand)
                             .padding(vertical = 4.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -4,7 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.notes
 
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -138,7 +138,7 @@ fun NotesContextPanel(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onOpenNode(task.id) }
+                                        .mouseClickable(onClick = { onOpenNode(task.id) })
                                         .pointerHoverIcon(PointerIcon.Hand)
                                         .padding(vertical = 2.dp),
                             )
@@ -163,7 +163,7 @@ fun NotesContextPanel(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onOpenNode(note.id) }
+                                        .mouseClickable(onClick = { onOpenNode(note.id) })
                                         .pointerHoverIcon(PointerIcon.Hand)
                                         .padding(vertical = 2.dp),
                             )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -7,7 +7,7 @@ package com.tajemniktv.tajsos.ui.screens.notes
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -247,7 +247,7 @@ fun NotesWorkspaceDetail(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { onNavigateToNode(item.id) }
+                                    .mouseClickable(onClick = { onNavigateToNode(item.id) })
                                     .pointerHoverIcon(PointerIcon.Hand),
                             shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                             color =
@@ -422,7 +422,7 @@ fun NotesWorkspaceDetail(
                             "• ${linkedNode.title}",
                             modifier =
                                 Modifier
-                                    .clickable { onNavigateToNode(linkedNode.id) }
+                                    .mouseClickable(onClick = { onNavigateToNode(linkedNode.id) })
                                     .pointerHoverIcon(PointerIcon.Hand),
                             color = TajsOSTheme.Text,
                         )

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
@@ -7,7 +7,7 @@ package com.tajemniktv.tajsos.ui.screens.notes.detail
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -296,9 +296,7 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                 ) {
                     Column(
                         modifier =
-                            Modifier.weight(1f).clickable {
-                                context.onShowEnergyDialog()
-                            }.pointerHoverIcon(PointerIcon.Hand),
+                            Modifier.weight(1f).mouseClickable(onClick = { context.onShowEnergyDialog() }).pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
                             "ENERGY",
@@ -326,9 +324,7 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                     }
                     Column(
                         modifier =
-                            Modifier.weight(1f).clickable {
-                                context.onShowFrictionDialog()
-                            }.pointerHoverIcon(PointerIcon.Hand),
+                            Modifier.weight(1f).mouseClickable(onClick = { context.onShowFrictionDialog() }).pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
                             "FRICTION",
@@ -356,7 +352,7 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowEstimateDialog() }
+                                .mouseClickable(onClick = { context.onShowEstimateDialog() })
                                 .pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
@@ -460,7 +456,7 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowMediaTypeDialog() }
+                                .mouseClickable(onClick = { context.onShowMediaTypeDialog() })
                                 .pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
@@ -479,7 +475,7 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowRatingDialog() }
+                                .mouseClickable(onClick = { context.onShowRatingDialog() })
                                 .pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
@@ -599,12 +595,10 @@ private fun renderNoteContextGraph(context: NoteDetailContext) {
                                 Icons.Default.Close,
                                 null,
                                 modifier =
-                                    Modifier.size(14.dp).clickable {
-                                        viewModel.detachTagFromNode(
+                                    Modifier.size(14.dp).mouseClickable(onClick = { viewModel.detachTagFromNode(
                                             noteId,
                                             tag.id,
-                                        )
-                                    }.pointerHoverIcon(PointerIcon.Hand),
+                                        ) }).pointerHoverIcon(PointerIcon.Hand),
                             )
                         },
                         colors =
@@ -821,7 +815,7 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .clickable { context.onShowAreaDialog() }
+                            .mouseClickable(onClick = { context.onShowAreaDialog() })
                             .pointerHoverIcon(PointerIcon.Hand),
                 ) {
                     Text(
@@ -840,7 +834,7 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .clickable { context.onShowProjectDialog() }
+                            .mouseClickable(onClick = { context.onShowProjectDialog() })
                             .pointerHoverIcon(PointerIcon.Hand),
                 ) {
                     Text(
@@ -911,7 +905,7 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowNoteTypeDialog() }
+                                .mouseClickable(onClick = { context.onShowNoteTypeDialog() })
                                 .pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(
@@ -930,7 +924,7 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowNoteStateDialog() }
+                                .mouseClickable(onClick = { context.onShowNoteStateDialog() })
                                 .pointerHoverIcon(PointerIcon.Hand),
                     ) {
                         Text(

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.screens.projects.detail
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -495,7 +495,7 @@ private fun renderProjectSidebar(context: ProjectDetailContext) {
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { context.onEditNode(node.id) }
+                                .mouseClickable(onClick = { context.onEditNode(node.id) })
                                 .pointerHoverIcon(PointerIcon.Hand),
                     )
                 }


### PR DESCRIPTION
This PR identifies and implements user experience improvements by migrating raw `.clickable` modifiers to the custom `mouseClickable` component across Compose Multiplatform UI elements. `mouseClickable` gracefully handles desktop hover cursors and explicit mouse button events properly, while following the existing pattern set in the codebase.

---
*PR created automatically by Jules for task [9826442273128317045](https://jules.google.com/task/9826442273128317045) started by @tajemniktv*

## Summary by Sourcery

Standardize UI click handling by replacing raw Compose `clickable` modifiers with the shared `mouseClickable` helper across dashboard, notes, areas, projects, calendar, finance, notifications, and related components.

Enhancements:
- Improve desktop interaction UX by using `mouseClickable` for note detail actions, metadata dialogs, and context graph tag detaching.
- Adopt `mouseClickable` for navigation and selection actions in dashboard modules, notes panels and workspace, decision options, task toggles, and finance/project sidebars.
- Update notification cards, calendar day selection, area sidebar items, track cards, and header menu to use `mouseClickable` for consistent pointer hover and mouse behavior across the app.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

