### PR TITLE
fix(ui): standardize on custom mouseClickable modifier for interactive elements

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/TrackCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/cards/TrackCards.kt
@@ -4,7 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.components.cards
 
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -35,6 +35,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.track_dosage_confirmed
 import tajsos.composeapp.generated.resources.track_medication_synk
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 @Composable
 fun MedicationSyncCard(
@@ -88,8 +89,8 @@ fun MedicationSyncCard(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { onToggleMed(med.id) }
-                                .pointerHoverIcon(PointerIcon.Hand)
+                                .mouseClickable(onClick = { onToggleMed(med.id) })
+
                                 .padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/layout/DashHeader.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.components.layout
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -37,6 +37,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import org.jetbrains.compose.resources.stringResource
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.common_system_online
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 /**
  * Renders the dashboard header with a left menu badge and status block and a right-side system indicator with a settings button.
@@ -60,7 +61,7 @@ fun DashHeader(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.clickable { onMenuClick() }.pointerHoverIcon(PointerIcon.Hand),
+            modifier = Modifier.mouseClickable(onClick = { onMenuClick() }),
         ) {
             Box(
                 modifier =

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/DecisionDetailContent.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.components.nodes
 
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -98,6 +98,7 @@ import tajsos.composeapp.generated.resources.identity_clear
 import kotlin.time.Clock
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 /**
  * Renders a detailed UI for viewing and editing a single decision node.
@@ -426,8 +427,8 @@ fun DecisionDetailContent(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { selectedOptionId = option.id }
-                                    .pointerHoverIcon(PointerIcon.Hand),
+                                    .mouseClickable(onClick = { selectedOptionId = option.id })
+                                    ,
                         ) {
                             RadioButton(
                                 selected = selectedOptionId == option.id,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/nodes/TaskBrief.kt
@@ -6,7 +6,7 @@ package com.tajemniktv.tajsos.ui.components.nodes
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import com.tajemniktv.tajsos.ui.theme.TajsOSTheme
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 /**
  * Renders a clickable task row with a circular completion indicator and title.
@@ -73,7 +74,7 @@ fun TaskBrief(
                             1.dp,
                             if (isDone) TajsOSTheme.Primary else TajsOSTheme.GhostBorder,
                             CircleShape,
-                        ).clickable { onToggle() }.pointerHoverIcon(PointerIcon.Hand),
+                        ).mouseClickable(onClick = { onToggle() }),
                 contentAlignment = Alignment.Center,
             ) {
                 if (isDone) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/components/notifications/NotificationComponents.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.components.notifications
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -48,6 +48,7 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import tajsos.composeapp.generated.resources.Res
 import tajsos.composeapp.generated.resources.no_active_system_alerts
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 /**
  * Premium "system-monitor" notification card with futuristic aesthetics.
@@ -71,8 +72,8 @@ fun TajsNotificationCard(
             modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(TajsOSTheme.RadiusMd))
-                .clickable { notification.onClick() }
-                .pointerHoverIcon(PointerIcon.Hand),
+                .mouseClickable(onClick = { notification.onClick() })
+                ,
         color = TajsOSTheme.SurfaceLow,
         shape = RoundedCornerShape(TajsOSTheme.RadiusMd),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/areas/detail/AreaDetailBlocks.kt
@@ -4,7 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.areas.detail
 
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -83,6 +83,7 @@ import tajsos.composeapp.generated.resources.type_note
 import tajsos.composeapp.generated.resources.type_record
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 object AreaDetailBlocks {
     private val renderers: Map<String, AreaDetailBlockRenderer> =
@@ -416,8 +417,8 @@ private fun renderAreaSidebar(context: AreaDetailContext) {
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clickable { context.onEditNode(node.id) }
-                            .pointerHoverIcon(PointerIcon.Hand),
+                            .mouseClickable(onClick = { context.onEditNode(node.id) })
+                            ,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/calendar/CalendarScreen.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.screens.calendar
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -64,6 +64,7 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 /**
  * Central calendar entry point that collects system state and coordinates layout.
@@ -261,8 +262,8 @@ fun MonthView(
                                         } else {
                                             TajsOSTheme.CalendarIdleDay
                                         },
-                                    ).clickable { onDateSelected(date) }
-                                        .pointerHoverIcon(PointerIcon.Hand),
+                                    ).mouseClickable(onClick = { onDateSelected(date) })
+                                        ,
                             contentAlignment = Alignment.Center,
                         ) {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/dashboard/DashboardScreen.kt
@@ -7,7 +7,7 @@ package com.tajemniktv.tajsos.ui.screens.dashboard
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -80,6 +80,7 @@ import tajsos.composeapp.generated.resources.screen_today
 import kotlin.time.Clock
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 /**
  * Central dashboard entry point that collects system state and coordinates layout.
@@ -444,8 +445,8 @@ private fun RenderDashboardBlock(
                     Row(
                         modifier =
                             Modifier
-                                .clickable { context.onNewEntry() }
-                                .pointerHoverIcon(PointerIcon.Hand)
+                                .mouseClickable(onClick = { context.onNewEntry() })
+
                                 .background(TajsOSTheme.Primary, RoundedCornerShape(TajsOSTheme.RadiusXs))
                                 .padding(horizontal = 12.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -607,8 +608,8 @@ private fun DashboardOperationsOverview(
                                 1.dp,
                                 TajsOSTheme.Border,
                                 RoundedCornerShape(TajsOSTheme.RadiusMd),
-                            ).clickable { onNavigate(module.screen.route) }
-                                .pointerHoverIcon(PointerIcon.Hand)
+                            ).mouseClickable(onClick = { onNavigate(module.screen.route) })
+
                               .padding(TajsOSTheme.SpacingMd),
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/finance/FinanceDashboardBlocks.kt
@@ -7,7 +7,7 @@
 package com.tajemniktv.tajsos.ui.screens.finance
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -62,6 +62,7 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 /**
  * Renders the finance dashboard header shell with high-level status chips and dataset volume context.
@@ -216,8 +217,8 @@ internal fun renderFinanceActivityBlock(context: FinanceDashboardContext) {
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .clickable { context.onEditNode(item.node.id) }
-                            .pointerHoverIcon(PointerIcon.Hand)
+                            .mouseClickable(onClick = { context.onEditNode(item.node.id) })
+
                             .padding(vertical = 4.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesContextPanel.kt
@@ -4,7 +4,7 @@
 
 package com.tajemniktv.tajsos.ui.screens.notes
 
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -47,6 +47,7 @@ import tajsos.composeapp.generated.resources.note_select_inspect_context
 import kotlin.time.Instant
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 /**
  * Collapsible right rail with note metadata, graph context, and history sections.
@@ -138,8 +139,8 @@ fun NotesContextPanel(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onOpenNode(task.id) }
-                                        .pointerHoverIcon(PointerIcon.Hand)
+                                        .mouseClickable(onClick = { onOpenNode(task.id) })
+
                                         .padding(vertical = 2.dp),
                             )
                         }
@@ -163,8 +164,8 @@ fun NotesContextPanel(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable { onOpenNode(note.id) }
-                                        .pointerHoverIcon(PointerIcon.Hand)
+                                        .mouseClickable(onClick = { onOpenNode(note.id) })
+
                                         .padding(vertical = 2.dp),
                             )
                         }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/NotesWorkspaceDetail.kt
@@ -7,7 +7,7 @@ package com.tajemniktv.tajsos.ui.screens.notes
 import com.tajemniktv.tajsos.ui.components.TactileOutlinedTextField
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -91,6 +91,7 @@ import tajsos.composeapp.generated.resources.view_all
 import kotlin.time.Instant
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 /**
  * Notes-first desktop workspace with separated reading/editing modes and contextual side panels.
@@ -247,8 +248,8 @@ fun NotesWorkspaceDetail(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .clickable { onNavigateToNode(item.id) }
-                                    .pointerHoverIcon(PointerIcon.Hand),
+                                    .mouseClickable(onClick = { onNavigateToNode(item.id) })
+                                    ,
                             shape = RoundedCornerShape(TajsOSTheme.RadiusSm),
                             color =
                                 if (item.id ==
@@ -422,8 +423,8 @@ fun NotesWorkspaceDetail(
                             "• ${linkedNode.title}",
                             modifier =
                                 Modifier
-                                    .clickable { onNavigateToNode(linkedNode.id) }
-                                    .pointerHoverIcon(PointerIcon.Hand),
+                                    .mouseClickable(onClick = { onNavigateToNode(linkedNode.id) })
+                                    ,
                             color = TajsOSTheme.Text,
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/notes/detail/NoteDetailBlocks.kt
@@ -7,7 +7,7 @@ package com.tajemniktv.tajsos.ui.screens.notes.detail
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -98,6 +98,7 @@ import tajsos.composeapp.generated.resources.note_detail_linked_context
 import tajsos.composeapp.generated.resources.note_detail_new_node
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 object NoteDetailBlocks {
     private val renderers: Map<String, NoteDetailBlockRenderer> =
@@ -296,9 +297,9 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                 ) {
                     Column(
                         modifier =
-                            Modifier.weight(1f).clickable {
+                            Modifier.weight(1f).mouseClickable(onClick = {
                                 context.onShowEnergyDialog()
-                            }.pointerHoverIcon(PointerIcon.Hand),
+                            }),
                     ) {
                         Text(
                             "ENERGY",
@@ -326,9 +327,9 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                     }
                     Column(
                         modifier =
-                            Modifier.weight(1f).clickable {
+                            Modifier.weight(1f).mouseClickable(onClick = {
                                 context.onShowFrictionDialog()
-                            }.pointerHoverIcon(PointerIcon.Hand),
+                            }),
                     ) {
                         Text(
                             "FRICTION",
@@ -356,8 +357,8 @@ private fun renderNoteTaskMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowEstimateDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onShowEstimateDialog() })
+                                ,
                     ) {
                         Text(
                             "ESTIMATE",
@@ -460,8 +461,8 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowMediaTypeDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onShowMediaTypeDialog() })
+                                ,
                     ) {
                         Text(
                             "MEDIA TYPE",
@@ -479,8 +480,8 @@ private fun renderNoteResourceMetadata(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowRatingDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onShowRatingDialog() })
+                                ,
                     ) {
                         Text(
                             "RATING",
@@ -599,12 +600,12 @@ private fun renderNoteContextGraph(context: NoteDetailContext) {
                                 Icons.Default.Close,
                                 null,
                                 modifier =
-                                    Modifier.size(14.dp).clickable {
+                                    Modifier.size(14.dp).mouseClickable(onClick = {
                                         viewModel.detachTagFromNode(
                                             noteId,
                                             tag.id,
                                         )
-                                    }.pointerHoverIcon(PointerIcon.Hand),
+                                    }),
                             )
                         },
                         colors =
@@ -821,8 +822,8 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .clickable { context.onShowAreaDialog() }
-                            .pointerHoverIcon(PointerIcon.Hand),
+                            .mouseClickable(onClick = { context.onShowAreaDialog() })
+                            ,
                 ) {
                     Text(
                         "AREA",
@@ -840,8 +841,8 @@ private fun renderNoteOrganization(context: NoteDetailContext) {
                     modifier =
                         Modifier
                             .weight(1f)
-                            .clickable { context.onShowProjectDialog() }
-                            .pointerHoverIcon(PointerIcon.Hand),
+                            .mouseClickable(onClick = { context.onShowProjectDialog() })
+                            ,
                 ) {
                     Text(
                         "PROJECT",
@@ -911,8 +912,8 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowNoteTypeDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onShowNoteTypeDialog() })
+                                ,
                     ) {
                         Text(
                             "NOTE TYPE",
@@ -930,8 +931,8 @@ private fun renderNoteKnowledgeConfig(context: NoteDetailContext) {
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .clickable { context.onShowNoteStateDialog() }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onShowNoteStateDialog() })
+                                ,
                     ) {
                         Text(
                             "STATE",

--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/screens/projects/detail/ProjectDetailBlocks.kt
@@ -5,7 +5,7 @@
 package com.tajemniktv.tajsos.ui.screens.projects.detail
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -99,6 +99,7 @@ import tajsos.composeapp.generated.resources.type_record
 import kotlin.math.roundToInt
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import com.tajemniktv.tajsos.ui.components.common.mouseClickable
 
 object ProjectDetailBlockRegistry {
     private val renderers: Map<String, ProjectDetailBlockRenderer> =
@@ -495,8 +496,8 @@ private fun renderProjectSidebar(context: ProjectDetailContext) {
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { context.onEditNode(node.id) }
-                                .pointerHoverIcon(PointerIcon.Hand),
+                                .mouseClickable(onClick = { context.onEditNode(node.id) })
+                                ,
                     )
                 }
             }


### PR DESCRIPTION
Replaced standard `.clickable` modifiers with the custom `Modifier.mouseClickable()` across various Compose UI components.

The `mouseClickable` modifier provides extended interactions, particularly on desktop, by seamlessly enabling pointer hover icons (hand cursor on hover) and cleanly handling non-primary mouse button clicks if needed.

Files updated:
* `DecisionDetailContent.kt`
* `TaskBrief.kt`
* `NotificationComponents.kt`
* `TrackCards.kt`
* `DashHeader.kt`
* `CalendarScreen.kt`
* `DashboardScreen.kt`
* `AreaDetailBlocks.kt`
* `FinanceDashboardBlocks.kt`
* `NotesContextPanel.kt`
* `NotesWorkspaceDetail.kt`
* `NoteDetailBlocks.kt`
* `ProjectDetailBlocks.kt`

---
*PR created automatically by Jules for task [7446418366837558213](https://jules.google.com/task/7446418366837558213) started by @tajemniktv*

## Summary by Sourcery

Enhancements:
- Replace direct clickable + pointerHoverIcon usages with the shared mouseClickable modifier across multiple screens and components for consistent interaction patterns and cursor behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

