### PR TITLE
test: add edge cases for matchesQuery and matchesItemFilter

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectModelsTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/data/LifeObjectModelsTest.kt
@@ -150,4 +150,10 @@ class LifeObjectModelsTest {
         assertFalse(taskWithLocation.isPlaceAnchor())
         assertEquals(ItemKind.TASK, taskWithLocation.itemKindOrNull())
     }
+
+    @Test
+    fun matchesItemFilter_nullInput_returnsTrue() {
+        val taskNode = NodeEntity(type = "task", title = "Task")
+        assertTrue(taskNode.matchesItemFilter(null))
+    }
 }

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
@@ -43,4 +43,11 @@ class FilterHelperMatchesQueryEdgeTest {
         assertTrue(FilterHelper.matchesQuery(nodeTag, "tag"))
         assertFalse(FilterHelper.matchesQuery(nodeNone, "title"))
     }
+
+    @Test
+    fun testMatchesQuery_normalSearch_withTags() {
+        val node1 = buildTestNode(1, "title", "content", tags = listOf("my special tag"))
+        assertTrue(FilterHelper.matchesQuery(node1, "special"))
+        assertFalse(FilterHelper.matchesQuery(node1, "other"))
+    }
 }


### PR DESCRIPTION
This PR adds edge-case tests for the `matchesQuery` and `matchesItemFilter` methods. Specifically, it tests matching behaviour against node tags when no hashtag is explicitly requested, and it verifies that `matchesItemFilter` safely handles null filter inputs, returning true as expected.

---
*PR created automatically by Jules for task [14928224448772611133](https://jules.google.com/task/14928224448772611133) started by @tajemniktv*

## Summary by Sourcery

Add edge-case tests for query and item filter behavior.

Tests:
- Add tests for matchesQuery to cover normal search behavior with tagged nodes.
- Add tests for matchesItemFilter to ensure null filter inputs are treated as matching.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

