### PR TITLE
fix(reliability): Replace unsafe non-null assertion with safe call in App.kt

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/App.kt
@@ -238,8 +238,8 @@ fun App(
                                 val currentRoute = currentDestination?.route
                                 val canPop = navController.previousBackStackEntry != null
                                 if (!canPop) return@mouseButtons
-                                if (isForwardNavigable(currentRoute)) {
-                                    mouseForwardRoutes.addLast(currentRoute!!)
+                                if (currentRoute != null && isForwardNavigable(currentRoute)) {
+                                    mouseForwardRoutes.addLast(currentRoute)
                                 }
                                 navController.popBackStack()
                             },


### PR DESCRIPTION
This PR addresses a reliability issue in `App.kt`. Specifically, it replaces the unsafe non-null assertion (`!!`) on `currentRoute` with a safe check and adds a `currentRoute != null` verification before attempting to navigate. This prevents a potential `NullPointerException` (NPE) that could crash the application if `currentDestination?.route` happens to be null.

---
*PR created automatically by Jules for task [2460947054945472930](https://jules.google.com/task/2460947054945472930) started by @tajemniktv*

## Summary by Sourcery

Bug Fixes:
- Prevent a possible NullPointerException by replacing a non-null assertion on the current route with a null-safe check before adding it to the forward navigation stack.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

