### PR TITLE
docs: add missing KDocs to NodeMetadataEnvelope properties

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/NodeMetadata.kt
@@ -27,10 +27,15 @@ private val nodeMetadataJson =
 @Serializable
 data class NodeMetadataEnvelope(
     val schemaVersion: Int = 1,
+    /** Student domain metadata if the user has the Student pack enabled. */
     val student: StudentMetadata? = null,
+    /** Financial domain metadata if the user has the Finance pack enabled. */
     val finance: FinanceMetadata? = null,
+    /** People domain metadata if the user has the People pack enabled. */
     val people: PeopleMetadata? = null,
+    /** Creator domain metadata if the user has the Creator pack enabled. */
     val creator: CreatorMetadata? = null,
+    /** Area domain associations for aggregation and filtering. */
     val area: AreaMetadata? = null,
 )
 


### PR DESCRIPTION
This PR adds missing KDocs to the domain-specific metadata properties (e.g. `student`, `finance`, `people`, `creator`, `area`) inside the `NodeMetadataEnvelope` data class. This improves the maintainability and readability of the codebase by explicitly explaining when and why each pack metadata property is used, reducing ambiguity.

---
*PR created automatically by Jules for task [16841706345229123057](https://jules.google.com/task/16841706345229123057) started by @tajemniktv*

## Summary by Sourcery

Documentation:
- Add KDoc descriptions for student, finance, people, creator, and area metadata properties in NodeMetadataEnvelope.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

