### PR TITLE
test: Add edge case tests for DomainLensQueries and FilterHelper

### DIFF
--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesDomainMatcherEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/domain/lens/DomainLensQueriesDomainMatcherEdgeTest.kt
@@ -1,0 +1,59 @@
+package com.tajemniktv.tajsos.domain.lens
+
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DomainLensQueriesDomainMatcherEdgeTest {
+
+    private fun createNode(
+        title: String = "",
+        content: String = "",
+        maintenanceType: String? = null,
+        noteType: String? = null
+    ): NodeWithPin {
+        return NodeWithPin(
+            node = NodeEntity(
+                id = 1L,
+                title = title,
+                content = content,
+                type = "task",
+                status = "active",
+                maintenanceType = maintenanceType,
+                noteType = noteType,
+            ),
+            pin = null,
+            tags = emptyList()
+        )
+    }
+
+    @Test
+    fun healthMatcher_emptyTitleAndContent() {
+        val node = createNode(title = "", content = "")
+        val result = DomainLensQueries.healthActionItems(listOf(node))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun financeMatcher_emptyTitleAndContent() {
+        val node = createNode(title = "", content = "")
+        val result = DomainLensQueries.financeActionItems(listOf(node))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun healthMatcher_blankTitleAndContent() {
+        val node = createNode(title = "   ", content = "\n\t")
+        val result = DomainLensQueries.healthActionItems(listOf(node))
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun financeMatcher_blankTitleAndContent() {
+        val node = createNode(title = "   ", content = "\n\t")
+        val result = DomainLensQueries.financeActionItems(listOf(node))
+        assertTrue(result.isEmpty())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/ui/FilterHelperMatchesQueryEdgeTest.kt
@@ -1,46 +1,109 @@
 package com.tajemniktv.tajsos.ui
 
+import com.tajemniktv.tajsos.data.NodeEntity
+import com.tajemniktv.tajsos.data.NodeWithPin
+import com.tajemniktv.tajsos.data.TagEntity
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class FilterHelperMatchesQueryEdgeTest {
 
+    private fun createNodeWithPin(
+        title: String = "",
+        content: String = "",
+        tags: List<String> = emptyList()
+    ): NodeWithPin {
+        return NodeWithPin(
+            node = NodeEntity(
+                id = 1L,
+                title = title,
+                content = content,
+                type = "task"
+            ),
+            pin = null,
+            tags = tags.mapIndexed { index, name ->
+                TagEntity(id = index.toLong(), name = name, normalizedName = name.lowercase())
+            }
+        )
+    }
+
     @Test
-    fun testMatchesQuery_blankQuery() {
-        val node = buildTestNode(1, "title", "content", tags = listOf("tag1"))
+    fun matchesQuery_blank_queries_return_false() {
+        val node = createNodeWithPin(title = "test", content = "test", tags = listOf("test"))
+
         assertFalse(FilterHelper.matchesQuery(node, ""))
+        assertFalse(FilterHelper.matchesQuery(node, " "))
         assertFalse(FilterHelper.matchesQuery(node, "   "))
+        assertFalse(FilterHelper.matchesQuery(node, "\t\n"))
     }
 
     @Test
-    fun testMatchesQuery_hashtagSearch() {
-        val node1 = buildTestNode(1, "title", "content", tags = listOf("tag1"))
-        val node2 = buildTestNode(2, "title", "content", tags = listOf("other"))
+    fun matchesQuery_hashtag_blank_after_hash_returns_false() {
+        val node = createNodeWithPin(tags = listOf("tag"))
 
-        assertTrue(FilterHelper.matchesQuery(node1, "#tag1"))
-        assertTrue(FilterHelper.matchesQuery(node1, "#TAG1")) // case insensitive
-        assertTrue(FilterHelper.matchesQuery(node1, "# tag1")) // space handled by substring(1).trim()
-        assertFalse(FilterHelper.matchesQuery(node2, "#tag1"))
+        assertFalse(FilterHelper.matchesQuery(node, "#"))
+        assertFalse(FilterHelper.matchesQuery(node, "#  "))
     }
 
     @Test
-    fun testMatchesQuery_hashtagSearch_empty() {
-        val node1 = buildTestNode(1, "title", "content", tags = listOf("tag1"))
-        assertFalse(FilterHelper.matchesQuery(node1, "#"))
-        assertFalse(FilterHelper.matchesQuery(node1, "#   "))
+    fun matchesQuery_hashtag_matches_tags_case_insensitive() {
+        val node = createNodeWithPin(tags = listOf("MyTag", "Another"))
+
+        assertTrue(FilterHelper.matchesQuery(node, "#mytag"))
+        assertTrue(FilterHelper.matchesQuery(node, "#MYTAG"))
+        assertTrue(FilterHelper.matchesQuery(node, "#  mytag  ")) // Trimming applies
+        assertTrue(FilterHelper.matchesQuery(node, "#tag")) // Partial match
+        assertFalse(FilterHelper.matchesQuery(node, "#notag"))
     }
 
     @Test
-    fun testMatchesQuery_normalSearch() {
-        val nodeTitle = buildTestNode(1, "my title", "content")
-        val nodeContent = buildTestNode(2, "other", "my content")
-        val nodeTag = buildTestNode(3, "other", "other", tags = listOf("my tag"))
-        val nodeNone = buildTestNode(4, "other", "other", tags = listOf("other"))
+    fun matchesQuery_hashtag_ignores_title_and_content() {
+        val node = createNodeWithPin(title = "keyword", content = "keyword", tags = listOf("other"))
 
-        assertTrue(FilterHelper.matchesQuery(nodeTitle, "title"))
-        assertTrue(FilterHelper.matchesQuery(nodeContent, "content"))
-        assertTrue(FilterHelper.matchesQuery(nodeTag, "tag"))
-        assertFalse(FilterHelper.matchesQuery(nodeNone, "title"))
+        // Even though "keyword" is in title and content, it's a tag search
+        assertFalse(FilterHelper.matchesQuery(node, "#keyword"))
+    }
+
+    @Test
+    fun matchesQuery_normal_query_matches_title_content_tags_case_insensitive() {
+        val node1 = createNodeWithPin(title = "FindMe")
+        val node2 = createNodeWithPin(content = "findMeHere")
+        val node3 = createNodeWithPin(tags = listOf("FindMeTag"))
+        val node4 = createNodeWithPin(title = "nope", content = "nope")
+
+        assertTrue(FilterHelper.matchesQuery(node1, "findme"))
+        assertTrue(FilterHelper.matchesQuery(node2, "FINDME"))
+        assertTrue(FilterHelper.matchesQuery(node3, "find"))
+        assertFalse(FilterHelper.matchesQuery(node4, "findme"))
+    }
+
+    @Test
+    fun relevanceScore_exact_matches() {
+        // Can't test relevanceScore directly as it's private, but can test indirectly via sorting
+        val exactTitle = createNodeWithPin(title = "Apple")
+        val startsTitle = createNodeWithPin(title = "Apple Pie")
+        val containsTitle = createNodeWithPin(title = "Big Apple")
+        val containsContent = createNodeWithPin(title = "Fruit", content = "An Apple")
+        val exactTag = createNodeWithPin(title = "Fruit", tags = listOf("Apple"))
+        val partialTag = createNodeWithPin(title = "Fruit", tags = listOf("AppleTree"))
+
+        val nodes = listOf(partialTag, containsContent, startsTitle, exactTag, containsTitle, exactTitle)
+
+        val sorted = FilterHelper.filterAndSortNodes(
+            nodes = nodes,
+            query = "apple",
+            type = null, status = null, projectId = null, areaId = null, linkedToId = null,
+            maxMins = null, energy = null, friction = null, locationContext = null,
+            energyContext = null, deviceContext = null, socialContext = null,
+            timeWindowContext = null, timeHorizon = null, relations = emptyList(),
+            sortMode = "relevance"
+        )
+
+        // Exact title (100+60+30=190) should be first
+        assertEquals(exactTitle, sorted[0])
+        // Starts title (60+30=90) should be second
+        assertEquals(startsTitle, sorted[1])
     }
 }


### PR DESCRIPTION
Added explicit test coverage for edge cases involving blank, empty, and edge input in `FilterHelper` logic and `DomainLensQueries`. Specifically covered hashtag boundary cases, content matching, and the implicit `DomainMatcher` fallbacks.

---
*PR created automatically by Jules for task [3660672768130749321](https://jules.google.com/task/3660672768130749321) started by @tajemniktv*

## Summary by Sourcery

Add edge-case regression tests for FilterHelper query handling and DomainLensQueries matchers.

Tests:
- Add tests for FilterHelper hashtag, blank query, and relevance-based sorting behaviors.
- Add tests for DomainLensQueries health and finance matchers when given empty or blank titles and contents.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

