### PR TITLE
perf: optimize groupBy usage for size and counts

### DIFF
--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -127,14 +127,14 @@ fun calculateInsights(
 
     val completionsByArea =
         recentCompletions
-            .mapNotNull { item -> item.node.areaId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .mapNotNull { item -> item.node.areaId }
+            .groupingBy { it }
+            .eachCount()
     val completionsByProject =
         recentCompletions
-            .mapNotNull { item -> item.node.projectId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .mapNotNull { item -> item.node.projectId }
+            .groupingBy { it }
+            .eachCount()
 
     val inboxGrowth = recentNodes.count { it.node.inboxState }
     val archivedCount =
@@ -175,23 +175,23 @@ fun calculateInsights(
     // Correlating track entries with activity
     val dailyCompletions =
         recentCompletions
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.completedAt ?: 0)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyCaptures =
         recentNodes
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.createdAt)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyFocus =
         recentSessions
@@ -1736,9 +1736,9 @@ fun calculateCapacitySnapshot(
         ).coerceIn(0, 100)
     val fragmentationScore =
         (
-                activeTasks.groupBy { it.node.projectId }.size *
+                activeTasks.distinctBy { it.node.projectId }.size *
                         7 +
-                        activeTasks.groupBy { it.node.areaId }.size *
+                        activeTasks.distinctBy { it.node.areaId }.size *
                         4
         ).coerceIn(0, 100)
 
@@ -1762,7 +1762,7 @@ fun calculateCapacitySnapshot(
     val unrealisticWeekSignal =
         if (weeklyCreatedActive > weeklyDone * 2 + 5) "THIS WEEK IS UNREALISTIC // INTAKE OUTPACES EXECUTION" else null
     val tooManyActiveFrontsIndicator =
-        if (activeTasks.groupBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
+        if (activeTasks.distinctBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
     val attentionFragmentedIndicator =
         if (fragmentationScore >= 55) "ATTENTION IS TOO FRAGMENTED" else null
     val weeklyStructuralOverloadWarning =
@@ -1863,7 +1863,7 @@ fun calculateCapacitySnapshot(
                 val fallbackFrag =
                     nodes
                         .filter { it.node.status == "active" && it.node.createdAt <= bucketEnd }
-                        .groupBy { it.node.projectId }
+                        .distinctBy { it.node.projectId }
                         .size
                         .times(8)
                         .coerceIn(0, 100)

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -443,7 +443,7 @@ suspend fun buildDashboardUIState(
     val areaHealthMetrics = areaSnapshot.areas.associateBy { it.areaId }
 
     val loadScore = (activeTasks.size * 2) + (openLoops.size * 3) + (overdue.size * 5)
-    val fragmentation = activeTasks.groupBy { it.node.projectId }.size * 5
+    val fragmentation = activeTasks.distinctBy { it.node.projectId }.size * 5
     val capWarning =
         when
             {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
@@ -262,7 +262,7 @@ class CalendarManagerTest {
         assertTrue(events.isNotEmpty(), "Should have saved at least one event")
 
         // Group by external ID, every group should have size 1
-        val duplicates = events.groupBy { it.externalId }.filter { it.value.size > 1 }
+        val duplicates = events.groupingBy { it.externalId }.eachCount().filter { it.value > 1 }
         assertTrue(duplicates.isEmpty(), "Should deduplicate events to a single event per externalId")
     }
 


### PR DESCRIPTION
Optimized inefficient collection operations by substituting intermediate List allocations from `groupBy` logic:
- Exchanged `groupBy(...).mapValues { it.value.size }` with `groupingBy(...).eachCount()` to avoid unneeded Map instantiations in performance-critical calculations.
- Altered `groupBy(...).size` to `distinctBy(...).size` preventing collection wrapping inside memory nodes before evaluation.
- Applied changes to calculators, state assemblers, and matching logic inside tests.

---
*PR created automatically by Jules for task [12171983487721615830](https://jules.google.com/task/12171983487721615830) started by @tajemniktv*

## Summary by Sourcery

Optimize collection-based counting and distinct calculations used in main snapshot and dashboard capacity metrics, as well as event deduplication tests, to reduce intermediate allocations and improve performance.

Bug Fixes:
- Ensure calendar event deduplication test uses count-based grouping to detect duplicates by externalId rather than relying on grouped collections.

Enhancements:
- Replace groupBy + mapValues size patterns with groupingBy + eachCount in snapshot calculators to avoid unnecessary intermediate collections.
- Replace groupBy + size usage with distinctBy + size in capacity and fragmentation calculations to compute unique project/area counts more efficiently.
- Align dashboard fragmentation metric with distinct project-based counting consistent with capacity snapshot logic.

Tests:
- Update calendar manager duplication test to use groupingBy + eachCount for detecting multiple events per externalId.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

