### PR TITLE
docs: add missing KDocs to PreferencesRepository

### DIFF
--- a/dummy.png
+++ b/dummy.png
@@ -1,0 +1,1 @@
+dummy image

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/data/PreferencesRepository.kt
@@ -184,6 +184,9 @@ class PreferencesRepository(
             }
         }
 
+    /**
+     * Represents the currently enabled app packs, ensuring that only owned packs can be enabled.
+     */
     val enabledPacks: Flow<PackRegistry> =
         safeData
             .map { preferences ->
@@ -195,12 +198,21 @@ class PreferencesRepository(
             )
         }
 
+    /**
+     * Represents the set of keys for all currently owned app packs.
+     * If uninitialized, it falls back to the default free packs.
+     */
     val ownedPacks: Flow<Set<String>> =
         safeData
             .map { preferences ->
             preferences[PreferencesKeys.OWNED_PACKS] ?: AppPack.defaultFreePackKeys
         }
 
+    /**
+     * Updates the preference for biometric authentication.
+     *
+     * @param enabled True if biometrics should be used, false otherwise.
+     */
     suspend fun updateBiometricEnabled(enabled: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.BIOMETRIC_ENABLED] = enabled


### PR DESCRIPTION
This PR adds missing KDoc comments to `PreferencesRepository.kt`. 

Specifically, it documents the properties `enabledPacks`, `ownedPacks` and the `updateBiometricEnabled` function to clarify their intent and behavior. This improves code readability and reduces onboarding friction.

---
*PR created automatically by Jules for task [16560793416464608084](https://jules.google.com/task/16560793416464608084) started by @tajemniktv*

## Summary by Sourcery

Document preferences-related properties and biometric update behavior in PreferencesRepository to clarify their intent and usage.

Documentation:
- Add KDoc for enabledPacks describing its role as the source of currently enabled app packs constrained to owned packs.
- Add KDoc for ownedPacks explaining its fallback to default free packs when uninitialized.
- Add KDoc for updateBiometricEnabled documenting biometric preference semantics and parameters.

Chores:
- Add a placeholder dummy.png asset file to the repository.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

