### PR TITLE
perf: optimize collection memory usage

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/Screen.kt
@@ -709,7 +709,7 @@ sealed class Screen(
 
             // Try base route match, ensuring we don't accidentally match sub-screens that share a base
             // unless they are explicitly the root screen.
-            return rootScreens.find { it.route.split("/").first() == currentRouteBase }
+            return rootScreens.find { it.route.substringBefore("/") == currentRouteBase }
         }
 
         /**

--- a/dummy.png
+++ b/dummy.png
@@ -1,0 +1,1 @@
+dummy image

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainSnapshotCalculators.kt
@@ -127,14 +127,14 @@ fun calculateInsights(
 
     val completionsByArea =
         recentCompletions
-            .mapNotNull { item -> item.node.areaId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .mapNotNull { item -> item.node.areaId }
+            .groupingBy { it }
+            .eachCount()
     val completionsByProject =
         recentCompletions
-            .mapNotNull { item -> item.node.projectId?.let { it to item } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { it.value.size }
+            .mapNotNull { item -> item.node.projectId }
+            .groupingBy { it }
+            .eachCount()
 
     val inboxGrowth = recentNodes.count { it.node.inboxState }
     val archivedCount =
@@ -175,23 +175,23 @@ fun calculateInsights(
     // Correlating track entries with activity
     val dailyCompletions =
         recentCompletions
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.completedAt ?: 0)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyCaptures =
         recentNodes
-            .groupBy {
+            .groupingBy {
                 Instant
                     .fromEpochMilliseconds(it.node.createdAt)
                     .toLocalDateTime(sysZone)
                     .date
                     .toString()
-            }.mapValues { it.value.size }
+            }.eachCount()
 
     val dailyFocus =
         recentSessions
@@ -1736,9 +1736,9 @@ fun calculateCapacitySnapshot(
         ).coerceIn(0, 100)
     val fragmentationScore =
         (
-                activeTasks.groupBy { it.node.projectId }.size *
+                activeTasks.distinctBy { it.node.projectId }.size *
                         7 +
-                        activeTasks.groupBy { it.node.areaId }.size *
+                        activeTasks.distinctBy { it.node.areaId }.size *
                         4
         ).coerceIn(0, 100)
 
@@ -1762,7 +1762,7 @@ fun calculateCapacitySnapshot(
     val unrealisticWeekSignal =
         if (weeklyCreatedActive > weeklyDone * 2 + 5) "THIS WEEK IS UNREALISTIC // INTAKE OUTPACES EXECUTION" else null
     val tooManyActiveFrontsIndicator =
-        if (activeTasks.groupBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
+        if (activeTasks.distinctBy { it.node.areaId }.size >= 6) "TOO MANY ACTIVE FRONTS" else null
     val attentionFragmentedIndicator =
         if (fragmentationScore >= 55) "ATTENTION IS TOO FRAGMENTED" else null
     val weeklyStructuralOverloadWarning =
@@ -1863,7 +1863,7 @@ fun calculateCapacitySnapshot(
                 val fallbackFrag =
                     nodes
                         .filter { it.node.status == "active" && it.node.createdAt <= bucketEnd }
-                        .groupBy { it.node.projectId }
+                        .distinctBy { it.node.projectId }
                         .size
                         .times(8)
                         .coerceIn(0, 100)

--- a/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
+++ b/shared/src/commonMain/kotlin/com/tajemniktv/tajsos/ui/main/calculators/MainStateAssemblers.kt
@@ -443,7 +443,7 @@ suspend fun buildDashboardUIState(
     val areaHealthMetrics = areaSnapshot.areas.associateBy { it.areaId }
 
     val loadScore = (activeTasks.size * 2) + (openLoops.size * 3) + (overdue.size * 5)
-    val fragmentation = activeTasks.groupBy { it.node.projectId }.size * 5
+    val fragmentation = activeTasks.distinctBy { it.node.projectId }.size * 5
     val capWarning =
         when
             {

--- a/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/tajemniktv/tajsos/calendar/CalendarManagerTest.kt
@@ -262,7 +262,7 @@ class CalendarManagerTest {
         assertTrue(events.isNotEmpty(), "Should have saved at least one event")
 
         // Group by external ID, every group should have size 1
-        val duplicates = events.groupBy { it.externalId }.filter { it.value.size > 1 }
+        val duplicates = events.groupingBy { it.externalId }.eachCount().filter { it.value > 1 }
         assertTrue(duplicates.isEmpty(), "Should deduplicate events to a single event per externalId")
     }
 


### PR DESCRIPTION
Replaces several inefficient collection operations with their optimized counterparts. Specifically:
- `groupBy { ... }.size` -> `distinctBy { ... }.size`
- `groupBy({ ... }, { ... }).mapValues { it.value.size }` -> `mapNotNull { ... }.groupingBy { it }.eachCount()`
- `groupBy { ... }.filter { it.value.size > 1 }` -> `groupingBy { ... }.eachCount().filter { it.value > 1 }`
- `split("/").first()` -> `substringBefore("/")`

These changes reduce unnecessary memory allocations (like `LinkedHashMap`, `ArrayList`, and `Pair` objects) without changing functionality.

---
*PR created automatically by Jules for task [363467717185429625](https://jules.google.com/task/363467717185429625) started by @tajemniktv*

## Summary by Sourcery

Optimize collection-based calculations and route parsing to reduce memory usage without changing behavior.

Enhancements:
- Replace groupBy-based counting with groupingBy().eachCount() in insight and calendar calculations to avoid unnecessary intermediate collections.
- Use distinctBy() instead of groupBy().size when only unique key counts are needed in capacity and dashboard metrics.
- Switch route parsing from split("/").first() to substringBefore("/") for more efficient base route extraction.

Tests:
- Adjust calendar deduplication test to assert on counts using groupingBy().eachCount() instead of groupBy() size checks.

Chores:
- Add a dummy.png placeholder asset file to the repository.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tajemniktv/TajsOS/pull/940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

